### PR TITLE
feat: add long-press logo home redirect

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -279,6 +279,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/all.html
+++ b/all.html
@@ -279,6 +279,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/bags.html
+++ b/bags.html
@@ -279,6 +279,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/category_template.html
+++ b/category_template.html
@@ -256,6 +256,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/gym.html
+++ b/gym.html
@@ -279,6 +279,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/hats.html
+++ b/hats.html
@@ -279,6 +279,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -280,6 +280,23 @@
             document.getElementById('cookie-banner').style.display = 'none';
         }
     };
+
+    // Redirect to the home page when the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/jackets.html
+++ b/jackets.html
@@ -279,6 +279,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/new.html
+++ b/new.html
@@ -279,6 +279,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/pants.html
+++ b/pants.html
@@ -279,6 +279,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/shirts.html
+++ b/shirts.html
@@ -279,6 +279,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/shoes.html
+++ b/shoes.html
@@ -279,6 +279,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/shop.html
+++ b/shop.html
@@ -329,6 +329,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/skate.html
+++ b/skate.html
@@ -279,6 +279,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/soon.html
+++ b/soon.html
@@ -316,6 +316,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -279,6 +279,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -279,6 +279,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -279,6 +279,23 @@
             fullSiteLink.style.display = 'none';
         }
     });
+
+    // Redirect to home page if the logo is held down
+    const logoFrame = document.getElementById('8b9281ad-097b-4408-88e2-ef824efa63eb');
+    if (logoFrame) {
+        let holdTimer;
+        const start = () => {
+            holdTimer = setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        };
+        const cancel = () => clearTimeout(holdTimer);
+
+        logoFrame.addEventListener('pointerdown', start);
+        logoFrame.addEventListener('pointerup', cancel);
+        logoFrame.addEventListener('pointerleave', cancel);
+        logoFrame.addEventListener('pointermove', cancel);
+    }
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- Redirect users to the homepage when the 3D logo iframe is held down
- Apply long-press redirect across home, shop, soon, and all category pages

## Testing
- `python3 generate_category_pages.py`
- `python3 -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689b55c7322883218f52f3f19d9e052f