### PR TITLE
Delay logo redirect until long press

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,9 +298,42 @@
 
         const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {
-        const goHome = () => { window.location.href = "index.html"; };
-        logoOverlay.addEventListener("mousedown", goHome);
-        logoOverlay.addEventListener("touchstart", goHome);
+        let pressTimer;
+        let moved = false;
+
+        const cancel = () => {
+            clearTimeout(pressTimer);
+            document.removeEventListener("mousemove", moveHandler);
+            document.removeEventListener("touchmove", moveHandler);
+            document.removeEventListener("mouseup", cancel);
+            document.removeEventListener("touchend", cancel);
+            document.removeEventListener("touchcancel", cancel);
+            logoOverlay.style.pointerEvents = "auto";
+        };
+
+        const moveHandler = () => {
+            moved = true;
+            cancel();
+        };
+
+        const startPress = () => {
+            moved = false;
+            logoOverlay.style.pointerEvents = "none";
+            document.addEventListener("mousemove", moveHandler);
+            document.addEventListener("touchmove", moveHandler);
+            document.addEventListener("mouseup", cancel);
+            document.addEventListener("touchend", cancel);
+            document.addEventListener("touchcancel", cancel);
+            pressTimer = setTimeout(() => {
+                if (!moved) {
+                    window.location.href = "index.html";
+                }
+                cancel();
+            }, 600);
+        };
+
+        logoOverlay.addEventListener("mousedown", startPress);
+        logoOverlay.addEventListener("touchstart", startPress);
     }
 </script>
 


### PR DESCRIPTION
## Summary
- Only redirect from the 3D logo after a 600ms stationary press
- Cancel redirect when movement is detected so the logo can be manipulated

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b5f139bbc8321a0d8e642a3c05b07