### PR TITLE
Fix cookie banner close button and logo overlay sensitivity

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,12 +137,13 @@
         .cookie-banner {
             position: fixed;
             top: 0;
+            left: 0;
             width: 100%;
             background: rgba(128, 128, 128, 0.8);
-            padding: 10px;
+            padding: 10px 40px 10px 10px;
             color: #000;
             font-size: 0.8rem;
-            z-index: 5;
+            z-index: 1000;
             text-align: center;
         }
 
@@ -153,9 +154,12 @@
         }
 
         .cookie-banner .cookie-close {
-            margin-left: 10px;
+            position: absolute;
+            top: 5px;
+            right: 10px;
             cursor: pointer;
             font-size: 1.2rem;
+            color: #fff;
         }
 
         /* Mobile Adjustments */
@@ -308,7 +312,7 @@
             document.removeEventListener("mouseup", cancel);
             document.removeEventListener("touchend", cancel);
             document.removeEventListener("touchcancel", cancel);
-            logoOverlay.style.pointerEvents = "auto";
+            logoOverlay.style.display = "none";
         };
 
         const moveHandler = () => {
@@ -318,7 +322,6 @@
 
         const startPress = () => {
             moved = false;
-            logoOverlay.style.pointerEvents = "none";
             document.addEventListener("mousemove", moveHandler);
             document.addEventListener("touchmove", moveHandler);
             document.addEventListener("mouseup", cancel);


### PR DESCRIPTION
## Summary
- Ensure cookie banner can always be dismissed and position the close icon at the top-right
- Hide logo overlay on interaction to prevent accidental redirects and allow model interaction

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689b64d42b7483219c2e32e20c98606a