### PR TITLE
Populate category pages with product images

### DIFF
--- a/all.html
+++ b/all.html
@@ -189,28 +189,115 @@
 </div>
 
 <div class="product-grid">
-    
 <div class="product-item">
-    <img src="https://via.placeholder.com/400x400" alt="All Item 1">
+    <img src="blackhat.png" alt="Black Hat">
     <div class="product-info">
-        <p>All Item 1</p>
+        <p>Black Hat</p>
         <p>$100</p>
     </div>
 </div>
-    
+
 <div class="product-item">
-    <img src="https://via.placeholder.com/400x400" alt="All Item 2">
+    <img src="blackhat2.png" alt="Black Hat 2">
     <div class="product-info">
-        <p>All Item 2</p>
+        <p>Black Hat 2</p>
         <p>$120</p>
     </div>
 </div>
-    
+
 <div class="product-item">
-    <img src="https://via.placeholder.com/400x400" alt="All Item 3">
+    <img src="whitehat.png" alt="White Hat">
     <div class="product-info">
-        <p>All Item 3</p>
+        <p>White Hat</p>
         <p>$140</p>
+    </div>
+</div>
+
+<div class="product-item">
+    <img src="whitehat2.png" alt="White Hat 2">
+    <div class="product-info">
+        <p>White Hat 2</p>
+        <p>$160</p>
+    </div>
+</div>
+
+<div class="product-item">
+    <img src="blackshirt.png" alt="Black Shirt">
+    <div class="product-info">
+        <p>Black Shirt</p>
+        <p>$180</p>
+    </div>
+</div>
+
+<div class="product-item">
+    <img src="whiteshirt.png" alt="White Shirt">
+    <div class="product-info">
+        <p>White Shirt</p>
+        <p>$200</p>
+    </div>
+</div>
+
+<div class="product-item">
+    <img src="blackhoodie.png" alt="Black Hoodie">
+    <div class="product-info">
+        <p>Black Hoodie</p>
+        <p>$220</p>
+    </div>
+</div>
+
+<div class="product-item">
+    <img src="whitehoodie.png" alt="White Hoodie">
+    <div class="product-info">
+        <p>White Hoodie</p>
+        <p>$240</p>
+    </div>
+</div>
+
+<div class="product-item">
+    <img src="blackjeans.png" alt="Black Jeans">
+    <div class="product-info">
+        <p>Black Jeans</p>
+        <p>$260</p>
+    </div>
+</div>
+
+<div class="product-item">
+    <img src="bluejeans.png" alt="Blue Jeans">
+    <div class="product-info">
+        <p>Blue Jeans</p>
+        <p>$280</p>
+    </div>
+</div>
+
+<div class="product-item">
+    <img src="blackjoggers.png" alt="Black Joggers">
+    <div class="product-info">
+        <p>Black Joggers</p>
+        <p>$300</p>
+    </div>
+</div>
+
+<div class="product-item">
+    <img src="whitejoggers.png" alt="White Joggers">
+    <div class="product-info">
+        <p>White Joggers</p>
+        <p>$320</p>
+    </div>
+</div>
+
+<div class="product-item">
+    <img src="blackshorts.png" alt="Black Shorts">
+    <div class="product-info">
+        <p>Black Shorts</p>
+        <p>$340</p>
+    </div>
+</div>
+
+<div class="product-item">
+    <img src="whiteshorts.png" alt="White Shorts">
+    <div class="product-info">
+        <p>White Shorts</p>
+        <p>$360</p>
     </div>
 </div>
 </div>

--- a/hats.html
+++ b/hats.html
@@ -189,28 +189,35 @@
 </div>
 
 <div class="product-grid">
-    
 <div class="product-item">
-    <img src="https://via.placeholder.com/400x400" alt="Hats Item 1">
+    <img src="blackhat.png" alt="Black Hat">
     <div class="product-info">
-        <p>Hats Item 1</p>
+        <p>Black Hat</p>
         <p>$100</p>
     </div>
 </div>
-    
+
 <div class="product-item">
-    <img src="https://via.placeholder.com/400x400" alt="Hats Item 2">
+    <img src="blackhat2.png" alt="Black Hat 2">
     <div class="product-info">
-        <p>Hats Item 2</p>
+        <p>Black Hat 2</p>
         <p>$120</p>
     </div>
 </div>
-    
+
 <div class="product-item">
-    <img src="https://via.placeholder.com/400x400" alt="Hats Item 3">
+    <img src="whitehat.png" alt="White Hat">
     <div class="product-info">
-        <p>Hats Item 3</p>
+        <p>White Hat</p>
         <p>$140</p>
+    </div>
+</div>
+
+<div class="product-item">
+    <img src="whitehat2.png" alt="White Hat 2">
+    <div class="product-info">
+        <p>White Hat 2</p>
+        <p>$160</p>
     </div>
 </div>
 </div>

--- a/pants.html
+++ b/pants.html
@@ -189,28 +189,51 @@
 </div>
 
 <div class="product-grid">
-    
 <div class="product-item">
-    <img src="https://via.placeholder.com/400x400" alt="Pants Item 1">
+    <img src="blackjeans.png" alt="Black Jeans">
     <div class="product-info">
-        <p>Pants Item 1</p>
+        <p>Black Jeans</p>
         <p>$100</p>
     </div>
 </div>
-    
+
 <div class="product-item">
-    <img src="https://via.placeholder.com/400x400" alt="Pants Item 2">
+    <img src="bluejeans.png" alt="Blue Jeans">
     <div class="product-info">
-        <p>Pants Item 2</p>
+        <p>Blue Jeans</p>
         <p>$120</p>
     </div>
 </div>
-    
+
 <div class="product-item">
-    <img src="https://via.placeholder.com/400x400" alt="Pants Item 3">
+    <img src="blackjoggers.png" alt="Black Joggers">
     <div class="product-info">
-        <p>Pants Item 3</p>
+        <p>Black Joggers</p>
         <p>$140</p>
+    </div>
+</div>
+
+<div class="product-item">
+    <img src="whitejoggers.png" alt="White Joggers">
+    <div class="product-info">
+        <p>White Joggers</p>
+        <p>$160</p>
+    </div>
+</div>
+
+<div class="product-item">
+    <img src="blackshorts.png" alt="Black Shorts">
+    <div class="product-info">
+        <p>Black Shorts</p>
+        <p>$180</p>
+    </div>
+</div>
+
+<div class="product-item">
+    <img src="whiteshorts.png" alt="White Shorts">
+    <div class="product-info">
+        <p>White Shorts</p>
+        <p>$200</p>
     </div>
 </div>
 </div>

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -189,28 +189,19 @@
 </div>
 
 <div class="product-grid">
-    
 <div class="product-item">
-    <img src="https://via.placeholder.com/400x400" alt="Sweatshirts Item 1">
+    <img src="blackhoodie.png" alt="Black Hoodie">
     <div class="product-info">
-        <p>Sweatshirts Item 1</p>
+        <p>Black Hoodie</p>
         <p>$100</p>
     </div>
 </div>
-    
+
 <div class="product-item">
-    <img src="https://via.placeholder.com/400x400" alt="Sweatshirts Item 2">
+    <img src="whitehoodie.png" alt="White Hoodie">
     <div class="product-info">
-        <p>Sweatshirts Item 2</p>
+        <p>White Hoodie</p>
         <p>$120</p>
-    </div>
-</div>
-    
-<div class="product-item">
-    <img src="https://via.placeholder.com/400x400" alt="Sweatshirts Item 3">
-    <div class="product-info">
-        <p>Sweatshirts Item 3</p>
-        <p>$140</p>
     </div>
 </div>
 </div>

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -189,28 +189,19 @@
 </div>
 
 <div class="product-grid">
-    
 <div class="product-item">
-    <img src="https://via.placeholder.com/400x400" alt="T-Shirts Item 1">
+    <img src="blackshirt.png" alt="Black Shirt">
     <div class="product-info">
-        <p>T-Shirts Item 1</p>
+        <p>Black Shirt</p>
         <p>$100</p>
     </div>
 </div>
-    
+
 <div class="product-item">
-    <img src="https://via.placeholder.com/400x400" alt="T-Shirts Item 2">
+    <img src="whiteshirt.png" alt="White Shirt">
     <div class="product-info">
-        <p>T-Shirts Item 2</p>
+        <p>White Shirt</p>
         <p>$120</p>
-    </div>
-</div>
-    
-<div class="product-item">
-    <img src="https://via.placeholder.com/400x400" alt="T-Shirts Item 3">
-    <div class="product-info">
-        <p>T-Shirts Item 3</p>
-        <p>$140</p>
     </div>
 </div>
 </div>


### PR DESCRIPTION
## Summary
- Replace placeholder images with actual product photos on hats, t-shirts, sweatshirts, pants, and all pages
- Label each item based on its file name and garment type

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689b790ff480832184a1a7b2c7ad2c4b