### PR TITLE
Align category headers and fix coming-soon layout

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -61,13 +61,18 @@
             font-weight: 600;
         }
 
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 60px;
+        }
+
         .coming-soon {
             display: flex;
             justify-content: center;
             align-items: center;
             text-align: center;
             font-size: 2rem;
-            margin-top: 0vh;
+            margin-top: 20px;
             flex-grow: 2;
         }
 
@@ -199,6 +204,7 @@
     <div class="time" id="current-time"></div>
 </div>
 
+<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/all.html
+++ b/all.html
@@ -61,6 +61,11 @@
             font-weight: 600;
         }
 
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 60px;
+        }
+
         /* Mobile Navigation */
         .mobile-nav {
             display: block;
@@ -189,6 +194,7 @@
     <div class="time" id="current-time"></div>
 </div>
 
+<div class="header-line"></div>
 <div class="product-grid">
 <div class="product-item">
     <img src="blackhat.png" alt="Black Hat">

--- a/bags.html
+++ b/bags.html
@@ -61,13 +61,18 @@
             font-weight: 600;
         }
 
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 60px;
+        }
+
         .coming-soon {
             display: flex;
             justify-content: center;
             align-items: center;
             text-align: center;
             font-size: 2rem;
-            margin-top: 0vh;
+            margin-top: 20px;
             flex-grow: 2;
         }
 
@@ -199,6 +204,7 @@
     <div class="time" id="current-time"></div>
 </div>
 
+<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/category_template.html
+++ b/category_template.html
@@ -61,6 +61,11 @@
             font-weight: 600;
         }
 
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 60px;
+        }
+
         /* Mobile Navigation */
         .mobile-nav {
             display: block;
@@ -189,6 +194,7 @@
     <div class="time" id="current-time"></div>
 </div>
 
+<div class="header-line"></div>
 <div class="product-grid">
     {{ITEMS}}
 </div>

--- a/gym.html
+++ b/gym.html
@@ -61,13 +61,18 @@
             font-weight: 600;
         }
 
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 60px;
+        }
+
         .coming-soon {
             display: flex;
             justify-content: center;
             align-items: center;
             text-align: center;
             font-size: 2rem;
-            margin-top: 0vh;
+            margin-top: 20px;
             flex-grow: 2;
         }
 
@@ -199,6 +204,7 @@
     <div class="time" id="current-time"></div>
 </div>
 
+<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/hats.html
+++ b/hats.html
@@ -61,6 +61,11 @@
             font-weight: 600;
         }
 
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 60px;
+        }
+
         /* Mobile Navigation */
         .mobile-nav {
             display: block;
@@ -189,6 +194,7 @@
     <div class="time" id="current-time"></div>
 </div>
 
+<div class="header-line"></div>
 <div class="product-grid">
 <div class="product-item">
     <img src="blackhat.png" alt="Black Hat">

--- a/jackets.html
+++ b/jackets.html
@@ -61,13 +61,18 @@
             font-weight: 600;
         }
 
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 60px;
+        }
+
         .coming-soon {
             display: flex;
             justify-content: center;
             align-items: center;
             text-align: center;
             font-size: 2rem;
-            margin-top: 0vh;
+            margin-top: 20px;
             flex-grow: 2;
         }
 
@@ -199,6 +204,7 @@
     <div class="time" id="current-time"></div>
 </div>
 
+<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/new.html
+++ b/new.html
@@ -61,6 +61,11 @@
             font-weight: 600;
         }
 
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 60px;
+        }
+
         /* Mobile Navigation */
         .mobile-nav {
             display: block;
@@ -189,6 +194,7 @@
     <div class="time" id="current-time"></div>
 </div>
 
+<div class="header-line"></div>
 <div class="product-grid">
 <div class="product-item">
     <img src="blackhat.png" alt="Black Hat">

--- a/pants.html
+++ b/pants.html
@@ -61,6 +61,11 @@
             font-weight: 600;
         }
 
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 60px;
+        }
+
         /* Mobile Navigation */
         .mobile-nav {
             display: block;
@@ -189,6 +194,7 @@
     <div class="time" id="current-time"></div>
 </div>
 
+<div class="header-line"></div>
 <div class="product-grid">
 <div class="product-item">
     <img src="blackjeans.png" alt="Black Jeans">

--- a/shirts.html
+++ b/shirts.html
@@ -61,13 +61,18 @@
             font-weight: 600;
         }
 
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 60px;
+        }
+
         .coming-soon {
             display: flex;
             justify-content: center;
             align-items: center;
             text-align: center;
             font-size: 2rem;
-            margin-top: 0vh;
+            margin-top: 20px;
             flex-grow: 2;
         }
 
@@ -199,6 +204,7 @@
     <div class="time" id="current-time"></div>
 </div>
 
+<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/shoes.html
+++ b/shoes.html
@@ -61,13 +61,18 @@
             font-weight: 600;
         }
 
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 60px;
+        }
+
         .coming-soon {
             display: flex;
             justify-content: center;
             align-items: center;
             text-align: center;
             font-size: 2rem;
-            margin-top: 0vh;
+            margin-top: 20px;
             flex-grow: 2;
         }
 
@@ -199,6 +204,7 @@
     <div class="time" id="current-time"></div>
 </div>
 
+<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/shop.html
+++ b/shop.html
@@ -73,7 +73,7 @@
         .mobile-nav {
             display: block;
             width: 100%;
-            margin-top: 40px; /* Ensure spacing between time and the first nav link */
+            margin-top: 20px; /* Ensure spacing between time and the first nav link */
         }
 
         nav.mobile-nav ul {

--- a/skate.html
+++ b/skate.html
@@ -61,13 +61,18 @@
             font-weight: 600;
         }
 
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 60px;
+        }
+
         .coming-soon {
             display: flex;
             justify-content: center;
             align-items: center;
             text-align: center;
             font-size: 2rem;
-            margin-top: 0vh;
+            margin-top: 20px;
             flex-grow: 2;
         }
 
@@ -199,6 +204,7 @@
     <div class="time" id="current-time"></div>
 </div>
 
+<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -61,6 +61,11 @@
             font-weight: 600;
         }
 
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 60px;
+        }
+
         /* Mobile Navigation */
         .mobile-nav {
             display: block;
@@ -189,6 +194,7 @@
     <div class="time" id="current-time"></div>
 </div>
 
+<div class="header-line"></div>
 <div class="product-grid">
 <div class="product-item">
     <img src="blackhoodie.png" alt="Black Hoodie">

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -61,6 +61,11 @@
             font-weight: 600;
         }
 
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 60px;
+        }
+
         /* Mobile Navigation */
         .mobile-nav {
             display: block;
@@ -189,6 +194,7 @@
     <div class="time" id="current-time"></div>
 </div>
 
+<div class="header-line"></div>
 <div class="product-grid">
 <div class="product-item">
     <img src="blackshirt.png" alt="Black Shirt">

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -61,13 +61,18 @@
             font-weight: 600;
         }
 
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 60px;
+        }
+
         .coming-soon {
             display: flex;
             justify-content: center;
             align-items: center;
             text-align: center;
             font-size: 2rem;
-            margin-top: 0vh;
+            margin-top: 20px;
             flex-grow: 2;
         }
 
@@ -199,6 +204,7 @@
     <div class="time" id="current-time"></div>
 </div>
 
+<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">


### PR DESCRIPTION
## Summary
- Move top category line on the shop page closer to the header
- Add consistent header divider across category pages and position "Coming Soon" beneath it

## Testing
- `python -m py_compile generate_category_pages.py`
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b80202dbc8321bd4007269ec6d071