### PR TITLE
Align header line and add simple cart with color choices

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -22,6 +22,9 @@
             width: 100%;
             padding: 10px;
             background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
                 .logo-container {
@@ -63,7 +66,8 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top: 60px;
+            margin-top: 10px;
+            width: 100%;
         }
 
         .coming-soon {
@@ -202,9 +206,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/all.html
+++ b/all.html
@@ -22,6 +22,9 @@
             width: 100%;
             padding: 10px;
             background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
                 .logo-container {
@@ -63,7 +66,8 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top: 60px;
+            margin-top: 10px;
+            width: 100%;
         }
 
         /* Mobile Navigation */
@@ -192,9 +196,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 <div class="product-grid">
 <div class="product-item">
     <img src="blackhat.png" alt="Black Hat">

--- a/bags.html
+++ b/bags.html
@@ -22,6 +22,9 @@
             width: 100%;
             padding: 10px;
             background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
                 .logo-container {
@@ -63,7 +66,8 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top: 60px;
+            margin-top: 10px;
+            width: 100%;
         }
 
         .coming-soon {
@@ -202,9 +206,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/blackhat2.html
+++ b/blackhat2.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Black Hat 2 - MaybeNot Shop</title>
+<link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+<style>
+body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;background-color:#f7f7f7;color:#000;height:100%;display:flex;flex-direction:column;}
+.header-container{width:100%;padding:10px;background-color:#f7f7f7;display:flex;flex-direction:column;align-items:center;}
+.logo-container{position:absolute;top:0;left:50%;transform:translateX(-50%);width:20vw;height:20vh;margin-top:-40px;}
+.logo-overlay{position:absolute;top:0;left:0;width:100%;height:100%;cursor:pointer;z-index:10;}
+iframe{width:100%;height:100%;border:none;}
+.time{font-size:0.7rem;text-align:center;position:absolute;left:50%;transform:translateX(-50%);top:12vh;font-weight:600;}
+.header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
+.product-item{margin-top:160px;display:flex;flex-direction:column;align-items:center;}
+.product-item img{width:80%;max-width:400px;}
+.product-item button{margin-top:5px;font-family:'Courier New',Courier,monospace;cursor:pointer;}
+</style>
+</head>
+<body>
+<div class="header-container">
+<div class="logo-container"><iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe><div class="logo-overlay"></div></div>
+<div class="time" id="current-time"></div><div class="header-line"></div></div>
+<div class="product-item" data-product="blackhat2" data-price="120">
+<img src="blackhat2.png" alt="Black Hat 2">
+<h1>Black Hat 2</h1>
+<p>$120</p>
+<button onclick="addToCart(this)">Add to Cart</button>
+<button onclick="checkout(this)">Checkout</button>
+</div>
+<script src="cart.js"></script>
+<script>
+function updateChicagoTime(){const options={timeZone:'America/Chicago',hour:'2-digit',minute:'2-digit',year:'numeric',month:'2-digit',day:'2-digit'};const currentTime=new Intl.DateTimeFormat('en-US',options).format(new Date()).replace(","," ");document.getElementById('current-time').textContent=currentTime+" CHICAGO";}
+setInterval(updateChicagoTime,1000);
+const logoOverlay=document.querySelector('.logo-overlay');
+if(logoOverlay){let pressTimer;let moved=false;const restoreOverlay=()=>{logoOverlay.style.display='block';};const cancel=()=>{clearTimeout(pressTimer);document.removeEventListener('mousemove',moveHandler);document.removeEventListener('touchmove',moveHandler);document.removeEventListener('mouseup',cancel);document.removeEventListener('touchend',cancel);document.removeEventListener('touchcancel',cancel);logoOverlay.style.display='none';setTimeout(restoreOverlay,1000);};const moveHandler=()=>{moved=true;cancel();};const startPress=()=>{moved=false;document.addEventListener('mousemove',moveHandler);document.addEventListener('touchmove',moveHandler);document.addEventListener('mouseup',cancel);document.addEventListener('touchend',cancel);document.addEventListener('touchcancel',cancel);pressTimer=setTimeout(()=>{if(!moved){window.location.href='index.html';}cancel();},600);};logoOverlay.addEventListener('mousedown',startPress);logoOverlay.addEventListener('touchstart',startPress);}
+</script>
+</body>
+</html>

--- a/blackjeans.html
+++ b/blackjeans.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Black Jeans - MaybeNot Shop</title>
+<link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+<style>
+body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;background-color:#f7f7f7;color:#000;height:100%;display:flex;flex-direction:column;}
+.header-container{width:100%;padding:10px;background-color:#f7f7f7;display:flex;flex-direction:column;align-items:center;}
+.logo-container{position:absolute;top:0;left:50%;transform:translateX(-50%);width:20vw;height:20vh;margin-top:-40px;}
+.logo-overlay{position:absolute;top:0;left:0;width:100%;height:100%;cursor:pointer;z-index:10;}
+iframe{width:100%;height:100%;border:none;}
+.time{font-size:0.7rem;text-align:center;position:absolute;left:50%;transform:translateX(-50%);top:12vh;font-weight:600;}
+.header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
+.product-item{margin-top:160px;display:flex;flex-direction:column;align-items:center;}
+.product-item img{width:80%;max-width:400px;}
+.product-item button{margin-top:5px;font-family:'Courier New',Courier,monospace;cursor:pointer;}
+</style>
+</head>
+<body>
+<div class="header-container">
+<div class="logo-container"><iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe><div class="logo-overlay"></div></div>
+<div class="time" id="current-time"></div><div class="header-line"></div></div>
+<div class="product-item" data-product="blackjeans" data-price="100">
+<img src="blackjeans.png" alt="Black Jeans">
+<h1>Black Jeans</h1>
+<p>$100</p>
+<button onclick="addToCart(this)">Add to Cart</button>
+<button onclick="checkout(this)">Checkout</button>
+</div>
+<script src="cart.js"></script>
+<script>
+function updateChicagoTime(){const options={timeZone:'America/Chicago',hour:'2-digit',minute:'2-digit',year:'numeric',month:'2-digit',day:'2-digit'};const currentTime=new Intl.DateTimeFormat('en-US',options).format(new Date()).replace(","," ");document.getElementById('current-time').textContent=currentTime+" CHICAGO";}
+setInterval(updateChicagoTime,1000);
+const logoOverlay=document.querySelector('.logo-overlay');
+if(logoOverlay){let pressTimer;let moved=false;const restoreOverlay=()=>{logoOverlay.style.display='block';};const cancel=()=>{clearTimeout(pressTimer);document.removeEventListener('mousemove',moveHandler);document.removeEventListener('touchmove',moveHandler);document.removeEventListener('mouseup',cancel);document.removeEventListener('touchend',cancel);document.removeEventListener('touchcancel',cancel);logoOverlay.style.display='none';setTimeout(restoreOverlay,1000);};const moveHandler=()=>{moved=true;cancel();};const startPress=()=>{moved=false;document.addEventListener('mousemove',moveHandler);document.addEventListener('touchmove',moveHandler);document.addEventListener('mouseup',cancel);document.addEventListener('touchend',cancel);document.addEventListener('touchcancel',cancel);pressTimer=setTimeout(()=>{if(!moved){window.location.href='index.html';}cancel();},600);};logoOverlay.addEventListener('mousedown',startPress);logoOverlay.addEventListener('touchstart',startPress);}
+</script>
+</body>
+</html>

--- a/bluejeans.html
+++ b/bluejeans.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Blue Jeans - MaybeNot Shop</title>
+<link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+<style>
+body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;background-color:#f7f7f7;color:#000;height:100%;display:flex;flex-direction:column;}
+.header-container{width:100%;padding:10px;background-color:#f7f7f7;display:flex;flex-direction:column;align-items:center;}
+.logo-container{position:absolute;top:0;left:50%;transform:translateX(-50%);width:20vw;height:20vh;margin-top:-40px;}
+.logo-overlay{position:absolute;top:0;left:0;width:100%;height:100%;cursor:pointer;z-index:10;}
+iframe{width:100%;height:100%;border:none;}
+.time{font-size:0.7rem;text-align:center;position:absolute;left:50%;transform:translateX(-50%);top:12vh;font-weight:600;}
+.header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
+.product-item{margin-top:160px;display:flex;flex-direction:column;align-items:center;}
+.product-item img{width:80%;max-width:400px;}
+.product-item button{margin-top:5px;font-family:'Courier New',Courier,monospace;cursor:pointer;}
+</style>
+</head>
+<body>
+<div class="header-container">
+<div class="logo-container"><iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe><div class="logo-overlay"></div></div>
+<div class="time" id="current-time"></div><div class="header-line"></div></div>
+<div class="product-item" data-product="bluejeans" data-price="120">
+<img src="bluejeans.png" alt="Blue Jeans">
+<h1>Blue Jeans</h1>
+<p>$120</p>
+<button onclick="addToCart(this)">Add to Cart</button>
+<button onclick="checkout(this)">Checkout</button>
+</div>
+<script src="cart.js"></script>
+<script>
+function updateChicagoTime(){const options={timeZone:'America/Chicago',hour:'2-digit',minute:'2-digit',year:'numeric',month:'2-digit',day:'2-digit'};const currentTime=new Intl.DateTimeFormat('en-US',options).format(new Date()).replace(","," ");document.getElementById('current-time').textContent=currentTime+" CHICAGO";}
+setInterval(updateChicagoTime,1000);
+const logoOverlay=document.querySelector('.logo-overlay');
+if(logoOverlay){let pressTimer;let moved=false;const restoreOverlay=()=>{logoOverlay.style.display='block';};const cancel=()=>{clearTimeout(pressTimer);document.removeEventListener('mousemove',moveHandler);document.removeEventListener('touchmove',moveHandler);document.removeEventListener('mouseup',cancel);document.removeEventListener('touchend',cancel);document.removeEventListener('touchcancel',cancel);logoOverlay.style.display='none';setTimeout(restoreOverlay,1000);};const moveHandler=()=>{moved=true;cancel();};const startPress=()=>{moved=false;document.addEventListener('mousemove',moveHandler);document.addEventListener('touchmove',moveHandler);document.addEventListener('mouseup',cancel);document.addEventListener('touchend',cancel);document.addEventListener('touchcancel',cancel);pressTimer=setTimeout(()=>{if(!moved){window.location.href='index.html';}cancel();},600);};logoOverlay.addEventListener('mousedown',startPress);logoOverlay.addEventListener('touchstart',startPress);}
+</script>
+</body>
+</html>

--- a/cart.js
+++ b/cart.js
@@ -1,0 +1,34 @@
+let cart = [];
+
+function initCart() {
+    cart = JSON.parse(localStorage.getItem('cart') || '[]');
+}
+
+function addToCart(button) {
+    const item = button.closest('.product-item');
+    const product = {
+        name: item.dataset.product,
+        color: item.dataset.selectedColor || '',
+        price: item.dataset.price
+    };
+    cart.push(product);
+    localStorage.setItem('cart', JSON.stringify(cart));
+    // TODO: sync with store server for inventory management
+    alert('Added to cart');
+}
+
+function checkout(button) {
+    alert('Checkout flow not implemented. Integrate with third-party payment.');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    initCart();
+    document.querySelectorAll('.color-option').forEach(opt => {
+        opt.addEventListener('click', () => {
+            const item = opt.closest('.product-item');
+            const img = item.querySelector('img');
+            img.src = opt.dataset.image;
+            item.dataset.selectedColor = opt.dataset.color;
+        });
+    });
+});

--- a/category_template.html
+++ b/category_template.html
@@ -22,6 +22,9 @@
             width: 100%;
             padding: 10px;
             background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
                 .logo-container {
@@ -63,7 +66,8 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top: 60px;
+            margin-top: 10px;
+            width: 100%;
         }
 
         /* Mobile Navigation */
@@ -192,9 +196,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 <div class="product-grid">
     {{ITEMS}}
 </div>

--- a/gym.html
+++ b/gym.html
@@ -22,6 +22,9 @@
             width: 100%;
             padding: 10px;
             background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
                 .logo-container {
@@ -63,7 +66,8 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top: 60px;
+            margin-top: 10px;
+            width: 100%;
         }
 
         .coming-soon {
@@ -202,9 +206,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/hat.html
+++ b/hat.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Hat product page">
+    <title>Hat - MaybeNot Shop</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+    <style>
+        body, html {
+            margin: 0;
+            padding: 0;
+            font-family: 'Courier New', Courier, monospace;
+            background-color: #f7f7f7;
+            color: #000;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+        }
+        .header-container {
+            width: 100%;
+            padding: 10px;
+            background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .logo-container {
+            position: absolute;
+            top: 0;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 20vw;
+            height: 20vh;
+            margin-top: -40px;
+        }
+        .logo-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            cursor: pointer;
+            z-index: 10;
+        }
+        iframe {
+            width: 100%;
+            height: 100%;
+            border: none;
+        }
+        .time {
+            font-size: 0.7rem;
+            text-align: center;
+            position: absolute;
+            left: 50%;
+            transform: translateX(-50%);
+            top: 12vh;
+            font-weight: 600;
+        }
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 10px;
+            width: 100%;
+        }
+        .product-item {
+            margin-top: 160px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .product-item img {
+            width: 80%;
+            max-width: 400px;
+        }
+        .color-options {
+            display: flex;
+            gap: 5px;
+            margin: 5px 0;
+        }
+        .color-option {
+            width: 15px;
+            height: 15px;
+            cursor: pointer;
+            display: inline-block;
+        }
+        .product-item button {
+            margin-top: 5px;
+            font-family: 'Courier New', Courier, monospace;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+<div class="header-container">
+    <div class="logo-container">
+        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <div class="logo-overlay"></div>
+    </div>
+    <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
+</div>
+<div class="product-item" data-product="hat" data-price="100" data-selected-color="black">
+    <img src="blackhat.png" alt="Hat">
+    <h1>Hat</h1>
+    <p>$100</p>
+    <div class="color-options">
+        <span class="color-option" data-color="black" data-image="blackhat.png" style="background:#000;"></span>
+        <span class="color-option" data-color="white" data-image="whitehat.png" style="background:#fff;border:1px solid #000;"></span>
+    </div>
+    <button onclick="addToCart(this)">Add to Cart</button>
+    <button onclick="checkout(this)">Checkout</button>
+</div>
+<script src="cart.js"></script>
+<script>
+    function updateChicagoTime() {
+        const options = {
+            timeZone: 'America/Chicago',
+            hour: '2-digit',
+            minute: '2-digit',
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+        };
+        const currentTime = new Intl.DateTimeFormat('en-US', options).format(new Date()).replace(",", "");
+        document.getElementById('current-time').textContent = currentTime + " CHICAGO";
+    }
+    setInterval(updateChicagoTime, 1000);
+    const logoOverlay = document.querySelector(".logo-overlay");
+    if (logoOverlay) {
+        let pressTimer;
+        let moved = false;
+        const restoreOverlay = () => {
+            logoOverlay.style.display = "block";
+        };
+        const cancel = () => {
+            clearTimeout(pressTimer);
+            document.removeEventListener("mousemove", moveHandler);
+            document.removeEventListener("touchmove", moveHandler);
+            document.removeEventListener("mouseup", cancel);
+            document.removeEventListener("touchend", cancel);
+            document.removeEventListener("touchcancel", cancel);
+            logoOverlay.style.display = "none";
+            setTimeout(restoreOverlay, 1000);
+        };
+        const moveHandler = () => {
+            moved = true;
+            cancel();
+        };
+        const startPress = () => {
+            moved = false;
+            document.addEventListener("mousemove", moveHandler);
+            document.addEventListener("touchmove", moveHandler);
+            document.addEventListener("mouseup", cancel);
+            document.addEventListener("touchend", cancel);
+            document.addEventListener("touchcancel", cancel);
+            pressTimer = setTimeout(() => {
+                if (!moved) {
+                    window.location.href = "index.html";
+                }
+                cancel();
+            }, 600);
+        };
+        logoOverlay.addEventListener("mousedown", startPress);
+        logoOverlay.addEventListener("touchstart", startPress);
+    }
+</script>
+</body>
+</html>

--- a/hats.html
+++ b/hats.html
@@ -22,6 +22,9 @@
             width: 100%;
             padding: 10px;
             background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
                 .logo-container {
@@ -63,7 +66,8 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top: 60px;
+            margin-top: 10px;
+            width: 100%;
         }
 
         /* Mobile Navigation */
@@ -121,6 +125,25 @@
         .product-item img {
             width: 100%;
             display: block;
+        }
+
+        .color-options {
+            display: flex;
+            gap: 5px;
+            margin: 5px 0;
+        }
+
+        .color-option {
+            width: 15px;
+            height: 15px;
+            cursor: pointer;
+            display: inline-block;
+        }
+
+        .product-info button {
+            margin-top: 5px;
+            font-family: 'Courier New', Courier, monospace;
+            cursor: pointer;
         }
 
         .product-info {
@@ -192,39 +215,40 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 <div class="product-grid">
-<div class="product-item">
-    <img src="blackhat.png" alt="Black Hat">
+<div class="product-item" data-product="hat" data-price="100" data-selected-color="black">
+    <a href="hat.html"><img src="blackhat.png" alt="Hat"></a>
     <div class="product-info">
-        <p>Black Hat</p>
+        <p>Hat</p>
         <p>$100</p>
+        <div class="color-options">
+            <span class="color-option" data-color="black" data-image="blackhat.png" style="background:#000;"></span>
+            <span class="color-option" data-color="white" data-image="whitehat.png" style="background:#fff;border:1px solid #000;"></span>
+        </div>
+        <button onclick="addToCart(this)">Add to Cart</button>
+        <button onclick="checkout(this)">Checkout</button>
     </div>
 </div>
 
-<div class="product-item">
-    <img src="blackhat2.png" alt="Black Hat 2">
+<div class="product-item" data-product="blackhat2" data-price="120">
+    <a href="blackhat2.html"><img src="blackhat2.png" alt="Black Hat 2"></a>
     <div class="product-info">
         <p>Black Hat 2</p>
         <p>$120</p>
+        <button onclick="addToCart(this)">Add to Cart</button>
+        <button onclick="checkout(this)">Checkout</button>
     </div>
 </div>
 
-<div class="product-item">
-    <img src="whitehat.png" alt="White Hat">
-    <div class="product-info">
-        <p>White Hat</p>
-        <p>$140</p>
-    </div>
-</div>
-
-<div class="product-item">
-    <img src="whitehat2.png" alt="White Hat 2">
+<div class="product-item" data-product="whitehat2" data-price="160">
+    <a href="whitehat2.html"><img src="whitehat2.png" alt="White Hat 2"></a>
     <div class="product-info">
         <p>White Hat 2</p>
         <p>$160</p>
+        <button onclick="addToCart(this)">Add to Cart</button>
+        <button onclick="checkout(this)">Checkout</button>
     </div>
 </div>
 </div>
@@ -281,6 +305,7 @@
     </div>
 </footer>
 
+<script src="cart.js"></script>
 <script>
     function updateChicagoTime() {
         const options = {

--- a/hoodie.html
+++ b/hoodie.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Hoodie product page">
+    <title>Hoodie - MaybeNot Shop</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+    <style>
+        body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; height:100%; display:flex; flex-direction:column; }
+        .header-container { width:100%; padding:10px; background-color:#f7f7f7; display:flex; flex-direction:column; align-items:center; }
+        .logo-container { position:absolute; top:0; left:50%; transform:translateX(-50%); width:20vw; height:20vh; margin-top:-40px; }
+        .logo-overlay { position:absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
+        iframe { width:100%; height:100%; border:none; }
+        .time { font-size:0.7rem; text-align:center; position:absolute; left:50%; transform:translateX(-50%); top:12vh; font-weight:600; }
+        .header-line { border-top:1px solid #000; margin-top:10px; width:100%; }
+        .product-item { margin-top:160px; display:flex; flex-direction:column; align-items:center; }
+        .product-item img { width:80%; max-width:400px; }
+        .color-options { display:flex; gap:5px; margin:5px 0; }
+        .color-option { width:15px; height:15px; cursor:pointer; display:inline-block; }
+        .product-item button { margin-top:5px; font-family:'Courier New', Courier, monospace; cursor:pointer; }
+    </style>
+</head>
+<body>
+<div class="header-container">
+    <div class="logo-container">
+        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <div class="logo-overlay"></div>
+    </div>
+    <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
+</div>
+<div class="product-item" data-product="hoodie" data-price="100" data-selected-color="black">
+    <img src="blackhoodie.png" alt="Hoodie">
+    <h1>Hoodie</h1>
+    <p>$100</p>
+    <div class="color-options">
+        <span class="color-option" data-color="black" data-image="blackhoodie.png" style="background:#000;"></span>
+        <span class="color-option" data-color="white" data-image="whitehoodie.png" style="background:#fff;border:1px solid #000;"></span>
+    </div>
+    <button onclick="addToCart(this)">Add to Cart</button>
+    <button onclick="checkout(this)">Checkout</button>
+</div>
+<script src="cart.js"></script>
+<script>
+    function updateChicagoTime(){const options={timeZone:'America/Chicago',hour:'2-digit',minute:'2-digit',year:'numeric',month:'2-digit',day:'2-digit'};const currentTime=new Intl.DateTimeFormat('en-US',options).format(new Date()).replace(","," ");document.getElementById('current-time').textContent=currentTime+" CHICAGO";}
+    setInterval(updateChicagoTime,1000);
+    const logoOverlay=document.querySelector('.logo-overlay');
+    if(logoOverlay){let pressTimer;let moved=false;const restoreOverlay=()=>{logoOverlay.style.display='block';};const cancel=()=>{clearTimeout(pressTimer);document.removeEventListener('mousemove',moveHandler);document.removeEventListener('touchmove',moveHandler);document.removeEventListener('mouseup',cancel);document.removeEventListener('touchend',cancel);document.removeEventListener('touchcancel',cancel);logoOverlay.style.display='none';setTimeout(restoreOverlay,1000);};const moveHandler=()=>{moved=true;cancel();};const startPress=()=>{moved=false;document.addEventListener('mousemove',moveHandler);document.addEventListener('touchmove',moveHandler);document.addEventListener('mouseup',cancel);document.addEventListener('touchend',cancel);document.addEventListener('touchcancel',cancel);pressTimer=setTimeout(()=>{if(!moved){window.location.href='index.html';}cancel();},600);};logoOverlay.addEventListener('mousedown',startPress);logoOverlay.addEventListener('touchstart',startPress);}
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -231,7 +231,6 @@
     </div>
 
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
 
     <!-- Desktop Nav -->
     <nav class="desktop-nav">

--- a/jackets.html
+++ b/jackets.html
@@ -22,6 +22,9 @@
             width: 100%;
             padding: 10px;
             background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
                 .logo-container {
@@ -63,7 +66,8 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top: 60px;
+            margin-top: 10px;
+            width: 100%;
         }
 
         .coming-soon {
@@ -202,9 +206,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/joggers.html
+++ b/joggers.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Joggers product page">
+    <title>Joggers - MaybeNot Shop</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+    <style>
+        body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; height:100%; display:flex; flex-direction:column; }
+        .header-container { width:100%; padding:10px; background-color:#f7f7f7; display:flex; flex-direction:column; align-items:center; }
+        .logo-container { position:absolute; top:0; left:50%; transform:translateX(-50%); width:20vw; height:20vh; margin-top:-40px; }
+        .logo-overlay { position:absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
+        iframe { width:100%; height:100%; border:none; }
+        .time { font-size:0.7rem; text-align:center; position:absolute; left:50%; transform:translateX(-50%); top:12vh; font-weight:600; }
+        .header-line { border-top:1px solid #000; margin-top:10px; width:100%; }
+        .product-item { margin-top:160px; display:flex; flex-direction:column; align-items:center; }
+        .product-item img { width:80%; max-width:400px; }
+        .color-options { display:flex; gap:5px; margin:5px 0; }
+        .color-option { width:15px; height:15px; cursor:pointer; display:inline-block; }
+        .product-item button { margin-top:5px; font-family:'Courier New', Courier, monospace; cursor:pointer; }
+    </style>
+</head>
+<body>
+<div class="header-container">
+    <div class="logo-container">
+        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <div class="logo-overlay"></div>
+    </div>
+    <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
+</div>
+<div class="product-item" data-product="joggers" data-price="140" data-selected-color="black">
+    <img src="blackjoggers.png" alt="Joggers">
+    <h1>Joggers</h1>
+    <p>$140</p>
+    <div class="color-options">
+        <span class="color-option" data-color="black" data-image="blackjoggers.png" style="background:#000;"></span>
+        <span class="color-option" data-color="white" data-image="whitejoggers.png" style="background:#fff;border:1px solid #000;"></span>
+    </div>
+    <button onclick="addToCart(this)">Add to Cart</button>
+    <button onclick="checkout(this)">Checkout</button>
+</div>
+<script src="cart.js"></script>
+<script>
+    function updateChicagoTime() { const options={timeZone:'America/Chicago',hour:'2-digit',minute:'2-digit',year:'numeric',month:'2-digit',day:'2-digit'}; const currentTime=new Intl.DateTimeFormat('en-US',options).format(new Date()).replace(","," "); document.getElementById('current-time').textContent=currentTime+" CHICAGO"; }
+    setInterval(updateChicagoTime,1000);
+    const logoOverlay=document.querySelector('.logo-overlay');
+    if(logoOverlay){let pressTimer;let moved=false;const restoreOverlay=()=>{logoOverlay.style.display='block';};const cancel=()=>{clearTimeout(pressTimer);document.removeEventListener('mousemove',moveHandler);document.removeEventListener('touchmove',moveHandler);document.removeEventListener('mouseup',cancel);document.removeEventListener('touchend',cancel);document.removeEventListener('touchcancel',cancel);logoOverlay.style.display='none';setTimeout(restoreOverlay,1000);};const moveHandler=()=>{moved=true;cancel();};const startPress=()=>{moved=false;document.addEventListener('mousemove',moveHandler);document.addEventListener('touchmove',moveHandler);document.addEventListener('mouseup',cancel);document.addEventListener('touchend',cancel);document.addEventListener('touchcancel',cancel);pressTimer=setTimeout(()=>{if(!moved){window.location.href='index.html';}cancel();},600);};logoOverlay.addEventListener('mousedown',startPress);logoOverlay.addEventListener('touchstart',startPress);}
+</script>
+</body>
+</html>

--- a/new.html
+++ b/new.html
@@ -22,6 +22,9 @@
             width: 100%;
             padding: 10px;
             background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
                 .logo-container {
@@ -63,7 +66,8 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top: 60px;
+            margin-top: 10px;
+            width: 100%;
         }
 
         /* Mobile Navigation */
@@ -192,9 +196,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 <div class="product-grid">
 <div class="product-item">
     <img src="blackhat.png" alt="Black Hat">

--- a/pants.html
+++ b/pants.html
@@ -22,6 +22,9 @@
             width: 100%;
             padding: 10px;
             background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
                 .logo-container {
@@ -63,7 +66,8 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top: 60px;
+            margin-top: 10px;
+            width: 100%;
         }
 
         /* Mobile Navigation */
@@ -121,6 +125,25 @@
         .product-item img {
             width: 100%;
             display: block;
+        }
+
+        .color-options {
+            display: flex;
+            gap: 5px;
+            margin: 5px 0;
+        }
+
+        .color-option {
+            width: 15px;
+            height: 15px;
+            cursor: pointer;
+            display: inline-block;
+        }
+
+        .product-info button {
+            margin-top: 5px;
+            font-family: 'Courier New', Courier, monospace;
+            cursor: pointer;
         }
 
         .product-info {
@@ -192,55 +215,54 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 <div class="product-grid">
-<div class="product-item">
-    <img src="blackjeans.png" alt="Black Jeans">
+<div class="product-item" data-product="blackjeans" data-price="100">
+    <a href="blackjeans.html"><img src="blackjeans.png" alt="Black Jeans"></a>
     <div class="product-info">
         <p>Black Jeans</p>
         <p>$100</p>
+        <button onclick="addToCart(this)">Add to Cart</button>
+        <button onclick="checkout(this)">Checkout</button>
     </div>
 </div>
 
-<div class="product-item">
-    <img src="bluejeans.png" alt="Blue Jeans">
+<div class="product-item" data-product="bluejeans" data-price="120">
+    <a href="bluejeans.html"><img src="bluejeans.png" alt="Blue Jeans"></a>
     <div class="product-info">
         <p>Blue Jeans</p>
         <p>$120</p>
+        <button onclick="addToCart(this)">Add to Cart</button>
+        <button onclick="checkout(this)">Checkout</button>
     </div>
 </div>
 
-<div class="product-item">
-    <img src="blackjoggers.png" alt="Black Joggers">
+<div class="product-item" data-product="joggers" data-price="140" data-selected-color="black">
+    <a href="joggers.html"><img src="blackjoggers.png" alt="Joggers"></a>
     <div class="product-info">
-        <p>Black Joggers</p>
+        <p>Joggers</p>
         <p>$140</p>
+        <div class="color-options">
+            <span class="color-option" data-color="black" data-image="blackjoggers.png" style="background:#000;"></span>
+            <span class="color-option" data-color="white" data-image="whitejoggers.png" style="background:#fff;border:1px solid #000;"></span>
+        </div>
+        <button onclick="addToCart(this)">Add to Cart</button>
+        <button onclick="checkout(this)">Checkout</button>
     </div>
 </div>
 
-<div class="product-item">
-    <img src="whitejoggers.png" alt="White Joggers">
+<div class="product-item" data-product="shorts" data-price="180" data-selected-color="black">
+    <a href="shorts.html"><img src="blackshorts.png" alt="Shorts"></a>
     <div class="product-info">
-        <p>White Joggers</p>
-        <p>$160</p>
-    </div>
-</div>
-
-<div class="product-item">
-    <img src="blackshorts.png" alt="Black Shorts">
-    <div class="product-info">
-        <p>Black Shorts</p>
+        <p>Shorts</p>
         <p>$180</p>
-    </div>
-</div>
-
-<div class="product-item">
-    <img src="whiteshorts.png" alt="White Shorts">
-    <div class="product-info">
-        <p>White Shorts</p>
-        <p>$200</p>
+        <div class="color-options">
+            <span class="color-option" data-color="black" data-image="blackshorts.png" style="background:#000;"></span>
+            <span class="color-option" data-color="white" data-image="whiteshorts.png" style="background:#fff;border:1px solid #000;"></span>
+        </div>
+        <button onclick="addToCart(this)">Add to Cart</button>
+        <button onclick="checkout(this)">Checkout</button>
     </div>
 </div>
 </div>
@@ -297,6 +319,7 @@
     </div>
 </footer>
 
+<script src="cart.js"></script>
 <script>
     function updateChicagoTime() {
         const options = {

--- a/shirt.html
+++ b/shirt.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Shirt product page">
+    <title>Shirt - MaybeNot Shop</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+    <style>
+        body, html {
+            margin: 0;
+            padding: 0;
+            font-family: 'Courier New', Courier, monospace;
+            background-color: #f7f7f7;
+            color: #000;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+        }
+        .header-container {
+            width: 100%;
+            padding: 10px;
+            background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .logo-container {
+            position: absolute;
+            top: 0;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 20vw;
+            height: 20vh;
+            margin-top: -40px;
+        }
+        .logo-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            cursor: pointer;
+            z-index: 10;
+        }
+        iframe {
+            width: 100%;
+            height: 100%;
+            border: none;
+        }
+        .time {
+            font-size: 0.7rem;
+            text-align: center;
+            position: absolute;
+            left: 50%;
+            transform: translateX(-50%);
+            top: 12vh;
+            font-weight: 600;
+        }
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 10px;
+            width: 100%;
+        }
+        .product-item {
+            margin-top: 160px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .product-item img {
+            width: 80%;
+            max-width: 400px;
+        }
+        .color-options {
+            display: flex;
+            gap: 5px;
+            margin: 5px 0;
+        }
+        .color-option {
+            width: 15px;
+            height: 15px;
+            cursor: pointer;
+            display: inline-block;
+        }
+        .product-item button {
+            margin-top: 5px;
+            font-family: 'Courier New', Courier, monospace;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+<div class="header-container">
+    <div class="logo-container">
+        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <div class="logo-overlay"></div>
+    </div>
+    <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
+</div>
+<div class="product-item" data-product="shirt" data-price="100" data-selected-color="black">
+    <img src="blackshirt.png" alt="Shirt">
+    <h1>Shirt</h1>
+    <p>$100</p>
+    <div class="color-options">
+        <span class="color-option" data-color="black" data-image="blackshirt.png" style="background:#000;"></span>
+        <span class="color-option" data-color="white" data-image="whiteshirt.png" style="background:#fff;border:1px solid #000;"></span>
+    </div>
+    <button onclick="addToCart(this)">Add to Cart</button>
+    <button onclick="checkout(this)">Checkout</button>
+</div>
+<script src="cart.js"></script>
+<script>
+    function updateChicagoTime() {
+        const options = {
+            timeZone: 'America/Chicago',
+            hour: '2-digit',
+            minute: '2-digit',
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+        };
+        const currentTime = new Intl.DateTimeFormat('en-US', options).format(new Date()).replace(",", "");
+        document.getElementById('current-time').textContent = currentTime + " CHICAGO";
+    }
+    setInterval(updateChicagoTime, 1000);
+    const logoOverlay = document.querySelector(".logo-overlay");
+    if (logoOverlay) {
+        let pressTimer;
+        let moved = false;
+        const restoreOverlay = () => {
+            logoOverlay.style.display = "block";
+        };
+        const cancel = () => {
+            clearTimeout(pressTimer);
+            document.removeEventListener("mousemove", moveHandler);
+            document.removeEventListener("touchmove", moveHandler);
+            document.removeEventListener("mouseup", cancel);
+            document.removeEventListener("touchend", cancel);
+            document.removeEventListener("touchcancel", cancel);
+            logoOverlay.style.display = "none";
+            setTimeout(restoreOverlay, 1000);
+        };
+        const moveHandler = () => {
+            moved = true;
+            cancel();
+        };
+        const startPress = () => {
+            moved = false;
+            document.addEventListener("mousemove", moveHandler);
+            document.addEventListener("touchmove", moveHandler);
+            document.addEventListener("mouseup", cancel);
+            document.addEventListener("touchend", cancel);
+            document.addEventListener("touchcancel", cancel);
+            pressTimer = setTimeout(() => {
+                if (!moved) {
+                    window.location.href = "index.html";
+                }
+                cancel();
+            }, 600);
+        };
+        logoOverlay.addEventListener("mousedown", startPress);
+        logoOverlay.addEventListener("touchstart", startPress);
+    }
+</script>
+</body>
+</html>

--- a/shirts.html
+++ b/shirts.html
@@ -22,6 +22,9 @@
             width: 100%;
             padding: 10px;
             background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
                 .logo-container {
@@ -63,7 +66,8 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top: 60px;
+            margin-top: 10px;
+            width: 100%;
         }
 
         .coming-soon {
@@ -202,9 +206,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/shoes.html
+++ b/shoes.html
@@ -22,6 +22,9 @@
             width: 100%;
             padding: 10px;
             background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
                 .logo-container {
@@ -63,7 +66,8 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top: 60px;
+            margin-top: 10px;
+            width: 100%;
         }
 
         .coming-soon {
@@ -202,9 +206,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/shop.html
+++ b/shop.html
@@ -29,7 +29,10 @@
         .header-container {
             width: 100%;
             padding: 10px;
-            background-color: #f7f7f7; /* Off-white background color for mobile header */
+            background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center; /* Off-white background color for mobile header */
         }
 
         .logo-container {
@@ -71,8 +74,8 @@
 
         .header-line {
             border-top: 1px solid #000;
+            margin-top: 10px;
             width: 100%;
-            margin-top: 60px;
         }
 
         /* Mobile Navigation */
@@ -300,9 +303,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
@@ -377,6 +379,7 @@
     </div>
 </footer>
 
+<script src="cart.js"></script>
 <script>
     // Function to get Chicago time without the comma and without seconds
     function updateChicagoTime() {

--- a/shorts.html
+++ b/shorts.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Shorts product page">
+    <title>Shorts - MaybeNot Shop</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+    <style>
+        body, html {
+            margin: 0;
+            padding: 0;
+            font-family: 'Courier New', Courier, monospace;
+            background-color: #f7f7f7;
+            color: #000;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+        }
+        .header-container {
+            width: 100%;
+            padding: 10px;
+            background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .logo-container { position: absolute; top: 0; left: 50%; transform: translateX(-50%); width: 20vw; height: 20vh; margin-top: -40px; }
+        .logo-overlay { position: absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
+        iframe { width:100%; height:100%; border:none; }
+        .time { font-size:0.7rem; text-align:center; position:absolute; left:50%; transform:translateX(-50%); top:12vh; font-weight:600; }
+        .header-line { border-top:1px solid #000; margin-top:10px; width:100%; }
+        .product-item { margin-top:160px; display:flex; flex-direction:column; align-items:center; }
+        .product-item img { width:80%; max-width:400px; }
+        .color-options { display:flex; gap:5px; margin:5px 0; }
+        .color-option { width:15px; height:15px; cursor:pointer; display:inline-block; }
+        .product-item button { margin-top:5px; font-family:'Courier New', Courier, monospace; cursor:pointer; }
+    </style>
+</head>
+<body>
+<div class="header-container">
+    <div class="logo-container">
+        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <div class="logo-overlay"></div>
+    </div>
+    <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
+</div>
+<div class="product-item" data-product="shorts" data-price="180" data-selected-color="black">
+    <img src="blackshorts.png" alt="Shorts">
+    <h1>Shorts</h1>
+    <p>$180</p>
+    <div class="color-options">
+        <span class="color-option" data-color="black" data-image="blackshorts.png" style="background:#000;"></span>
+        <span class="color-option" data-color="white" data-image="whiteshorts.png" style="background:#fff;border:1px solid #000;"></span>
+    </div>
+    <button onclick="addToCart(this)">Add to Cart</button>
+    <button onclick="checkout(this)">Checkout</button>
+</div>
+<script src="cart.js"></script>
+<script>
+    function updateChicagoTime() {
+        const options = { timeZone: 'America/Chicago', hour:'2-digit', minute:'2-digit', year:'numeric', month:'2-digit', day:'2-digit' };
+        const currentTime = new Intl.DateTimeFormat('en-US', options).format(new Date()).replace(",", "");
+        document.getElementById('current-time').textContent = currentTime + " CHICAGO";
+    }
+    setInterval(updateChicagoTime, 1000);
+    const logoOverlay = document.querySelector('.logo-overlay');
+    if (logoOverlay) {
+        let pressTimer; let moved=false;
+        const restoreOverlay=()=>{logoOverlay.style.display='block';};
+        const cancel=()=>{clearTimeout(pressTimer);document.removeEventListener('mousemove',moveHandler);document.removeEventListener('touchmove',moveHandler);document.removeEventListener('mouseup',cancel);document.removeEventListener('touchend',cancel);document.removeEventListener('touchcancel',cancel);logoOverlay.style.display='none';setTimeout(restoreOverlay,1000);};
+        const moveHandler=()=>{moved=true;cancel();};
+        const startPress=()=>{moved=false;document.addEventListener('mousemove',moveHandler);document.addEventListener('touchmove',moveHandler);document.addEventListener('mouseup',cancel);document.addEventListener('touchend',cancel);document.addEventListener('touchcancel',cancel);pressTimer=setTimeout(()=>{if(!moved){window.location.href='index.html';}cancel();},600);};
+        logoOverlay.addEventListener('mousedown',startPress);
+        logoOverlay.addEventListener('touchstart',startPress);
+    }
+</script>
+</body>
+</html>

--- a/skate.html
+++ b/skate.html
@@ -22,6 +22,9 @@
             width: 100%;
             padding: 10px;
             background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
                 .logo-container {
@@ -63,7 +66,8 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top: 60px;
+            margin-top: 10px;
+            width: 100%;
         }
 
         .coming-soon {
@@ -202,9 +206,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -22,6 +22,9 @@
             width: 100%;
             padding: 10px;
             background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
                 .logo-container {
@@ -63,7 +66,8 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top: 60px;
+            margin-top: 10px;
+            width: 100%;
         }
 
         /* Mobile Navigation */
@@ -121,6 +125,25 @@
         .product-item img {
             width: 100%;
             display: block;
+        }
+
+        .color-options {
+            display: flex;
+            gap: 5px;
+            margin: 5px 0;
+        }
+
+        .color-option {
+            width: 15px;
+            height: 15px;
+            cursor: pointer;
+            display: inline-block;
+        }
+
+        .product-info button {
+            margin-top: 5px;
+            font-family: 'Courier New', Courier, monospace;
+            cursor: pointer;
         }
 
         .product-info {
@@ -192,23 +215,20 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 <div class="product-grid">
-<div class="product-item">
-    <img src="blackhoodie.png" alt="Black Hoodie">
+<div class="product-item" data-product="hoodie" data-price="100" data-selected-color="black">
+    <a href="hoodie.html"><img src="blackhoodie.png" alt="Hoodie"></a>
     <div class="product-info">
-        <p>Black Hoodie</p>
+        <p>Hoodie</p>
         <p>$100</p>
-    </div>
-</div>
-
-<div class="product-item">
-    <img src="whitehoodie.png" alt="White Hoodie">
-    <div class="product-info">
-        <p>White Hoodie</p>
-        <p>$120</p>
+        <div class="color-options">
+            <span class="color-option" data-color="black" data-image="blackhoodie.png" style="background:#000;"></span>
+            <span class="color-option" data-color="white" data-image="whitehoodie.png" style="background:#fff;border:1px solid #000;"></span>
+        </div>
+        <button onclick="addToCart(this)">Add to Cart</button>
+        <button onclick="checkout(this)">Checkout</button>
     </div>
 </div>
 </div>
@@ -265,6 +285,7 @@
     </div>
 </footer>
 
+<script src="cart.js"></script>
 <script>
     function updateChicagoTime() {
         const options = {

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -22,6 +22,9 @@
             width: 100%;
             padding: 10px;
             background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
                 .logo-container {
@@ -63,7 +66,8 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top: 60px;
+            margin-top: 10px;
+            width: 100%;
         }
 
         /* Mobile Navigation */
@@ -121,6 +125,25 @@
         .product-item img {
             width: 100%;
             display: block;
+        }
+
+        .color-options {
+            display: flex;
+            gap: 5px;
+            margin: 5px 0;
+        }
+
+        .color-option {
+            width: 15px;
+            height: 15px;
+            cursor: pointer;
+            display: inline-block;
+        }
+
+        .product-info button {
+            margin-top: 5px;
+            font-family: 'Courier New', Courier, monospace;
+            cursor: pointer;
         }
 
         .product-info {
@@ -192,23 +215,20 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 <div class="product-grid">
-<div class="product-item">
-    <img src="blackshirt.png" alt="Black Shirt">
+<div class="product-item" data-product="shirt" data-price="100" data-selected-color="black">
+    <a href="shirt.html"><img src="blackshirt.png" alt="Shirt"></a>
     <div class="product-info">
-        <p>Black Shirt</p>
+        <p>Shirt</p>
         <p>$100</p>
-    </div>
-</div>
-
-<div class="product-item">
-    <img src="whiteshirt.png" alt="White Shirt">
-    <div class="product-info">
-        <p>White Shirt</p>
-        <p>$120</p>
+        <div class="color-options">
+            <span class="color-option" data-color="black" data-image="blackshirt.png" style="background:#000;"></span>
+            <span class="color-option" data-color="white" data-image="whiteshirt.png" style="background:#fff;border:1px solid #000;"></span>
+        </div>
+        <button onclick="addToCart(this)">Add to Cart</button>
+        <button onclick="checkout(this)">Checkout</button>
     </div>
 </div>
 </div>
@@ -265,6 +285,7 @@
     </div>
 </footer>
 
+<script src="cart.js"></script>
 <script>
     function updateChicagoTime() {
         const options = {

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -22,6 +22,9 @@
             width: 100%;
             padding: 10px;
             background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
         }
 
                 .logo-container {
@@ -63,7 +66,8 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top: 60px;
+            margin-top: 10px;
+            width: 100%;
         }
 
         .coming-soon {
@@ -202,9 +206,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
 </div>
-
-<div class="header-line"></div>
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/whitehat2.html
+++ b/whitehat2.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>White Hat 2 - MaybeNot Shop</title>
+<link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+<style>
+body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;background-color:#f7f7f7;color:#000;height:100%;display:flex;flex-direction:column;}
+.header-container{width:100%;padding:10px;background-color:#f7f7f7;display:flex;flex-direction:column;align-items:center;}
+.logo-container{position:absolute;top:0;left:50%;transform:translateX(-50%);width:20vw;height:20vh;margin-top:-40px;}
+.logo-overlay{position:absolute;top:0;left:0;width:100%;height:100%;cursor:pointer;z-index:10;}
+iframe{width:100%;height:100%;border:none;}
+.time{font-size:0.7rem;text-align:center;position:absolute;left:50%;transform:translateX(-50%);top:12vh;font-weight:600;}
+.header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
+.product-item{margin-top:160px;display:flex;flex-direction:column;align-items:center;}
+.product-item img{width:80%;max-width:400px;}
+.product-item button{margin-top:5px;font-family:'Courier New',Courier,monospace;cursor:pointer;}
+</style>
+</head>
+<body>
+<div class="header-container">
+<div class="logo-container"><iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe><div class="logo-overlay"></div></div>
+<div class="time" id="current-time"></div><div class="header-line"></div></div>
+<div class="product-item" data-product="whitehat2" data-price="160">
+<img src="whitehat2.png" alt="White Hat 2">
+<h1>White Hat 2</h1>
+<p>$160</p>
+<button onclick="addToCart(this)">Add to Cart</button>
+<button onclick="checkout(this)">Checkout</button>
+</div>
+<script src="cart.js"></script>
+<script>
+function updateChicagoTime(){const options={timeZone:'America/Chicago',hour:'2-digit',minute:'2-digit',year:'numeric',month:'2-digit',day:'2-digit'};const currentTime=new Intl.DateTimeFormat('en-US',options).format(new Date()).replace(","," ");document.getElementById('current-time').textContent=currentTime+" CHICAGO";}
+setInterval(updateChicagoTime,1000);
+const logoOverlay=document.querySelector('.logo-overlay');
+if(logoOverlay){let pressTimer;let moved=false;const restoreOverlay=()=>{logoOverlay.style.display='block';};const cancel=()=>{clearTimeout(pressTimer);document.removeEventListener('mousemove',moveHandler);document.removeEventListener('touchmove',moveHandler);document.removeEventListener('mouseup',cancel);document.removeEventListener('touchend',cancel);document.removeEventListener('touchcancel',cancel);logoOverlay.style.display='none';setTimeout(restoreOverlay,1000);};const moveHandler=()=>{moved=true;cancel();};const startPress=()=>{moved=false;document.addEventListener('mousemove',moveHandler);document.addEventListener('touchmove',moveHandler);document.addEventListener('mouseup',cancel);document.addEventListener('touchend',cancel);document.addEventListener('touchcancel',cancel);pressTimer=setTimeout(()=>{if(!moved){window.location.href='index.html';}cancel();},600);};logoOverlay.addEventListener('mousedown',startPress);logoOverlay.addEventListener('touchstart',startPress);}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Place header separators under the clock on all category pages and remove it from the landing page
- Combine color variants into single products with selectable swatches and link to detail pages
- Introduce a basic localStorage cart with placeholder checkout

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689b87ac51b88321a51c4b9775bf5ceb