### PR TITLE
Unify headers and cart counter across storefront

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -379,10 +379,12 @@
             }, 600);
         };
 
-        logoOverlay.addEventListener("mousedown", startPress);
+logoOverlay.addEventListener("mousedown", startPress);
         logoOverlay.addEventListener("touchstart", startPress);
     }
 </script>
+
+<script src="cart.js"></script>
 
 </body>
 </html>

--- a/all.html
+++ b/all.html
@@ -28,10 +28,13 @@
         }
 
         .logo-container {
-            position: static;
+            position: absolute;
+            top: 0;
+            left: 50%;
+            transform: translateX(-50%);
             width: 20vw;
             height: 20vh;
-            margin-top: 0;
+            margin-top: -40px;
         }
 
         .logo-overlay {
@@ -54,7 +57,10 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            position: absolute;
+            left: 50%;
+            transform: translateX(-50%);
+            top: 12vh;
             font-weight: 600;
         }
 

--- a/bags.html
+++ b/bags.html
@@ -384,5 +384,7 @@
     }
 </script>
 
+<script src="cart.js"></script>
+
 </body>
 </html>

--- a/cart.js
+++ b/cart.js
@@ -30,8 +30,29 @@ function updateCartCounter() {
     }
 }
 
+function ensureCartCounter() {
+    if (!document.getElementById('cart-count')) {
+        const header = document.querySelector('.header-container');
+        if (header) {
+            const counter = document.createElement('div');
+            counter.className = 'cart-counter';
+            counter.innerHTML = '<span class="cart-icon">🛒</span><span id="cart-count">0</span>';
+            header.appendChild(counter);
+            updateCartCounter();
+        }
+    }
+
+    if (!document.getElementById('cart-counter-style')) {
+        const style = document.createElement('style');
+        style.id = 'cart-counter-style';
+        style.textContent = '.cart-counter{margin-top:5px;font-size:0.7rem;text-align:center;font-weight:600;}';
+        document.head.appendChild(style);
+    }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     initCart();
+    ensureCartCounter();
     document.querySelectorAll('.color-option').forEach(opt => {
         opt.addEventListener('click', () => {
             const item = opt.closest('.product-item');

--- a/category_template.html
+++ b/category_template.html
@@ -373,5 +373,7 @@
     }
 </script>
 
+<script src="cart.js"></script>
+
 </body>
 </html>

--- a/gym.html
+++ b/gym.html
@@ -384,5 +384,7 @@
     }
 </script>
 
+<script src="cart.js"></script>
+
 </body>
 </html>

--- a/jackets.html
+++ b/jackets.html
@@ -384,5 +384,7 @@
     }
 </script>
 
+<script src="cart.js"></script>
+
 </body>
 </html>

--- a/new.html
+++ b/new.html
@@ -25,8 +25,6 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-            position: relative;
-            height: 160px;
         }
 
         .logo-container {
@@ -68,8 +66,7 @@
 
         .header-line {
             border-top: 1px solid #000;
-            position: absolute;
-            bottom: 0;
+            margin-top: 10px;
             width: 100%;
         }
 

--- a/product.js
+++ b/product.js
@@ -35,42 +35,38 @@ function initSliders() {
 document.addEventListener('DOMContentLoaded', () => {
   initSliders();
 
-  // Ensure header layout matches shop.html
-  document.body.style.height = 'auto';
-  document.body.style.display = 'block';
-
+  // Apply header style similar to pants.html
   const header = document.querySelector('.header-container');
   if (header) {
     header.style.position = 'relative';
-    header.style.height = 'auto';
   }
 
   const logo = document.querySelector('.logo-container');
   if (logo) {
-    logo.style.position = 'static';
-    logo.style.top = '';
-    logo.style.left = '';
-    logo.style.transform = '';
+    logo.style.position = 'absolute';
+    logo.style.top = '0';
+    logo.style.left = '50%';
+    logo.style.transform = 'translateX(-50%)';
     logo.style.width = '20vw';
     logo.style.height = '20vh';
-    logo.style.marginTop = '0';
+    logo.style.marginTop = '-40px';
   }
 
   const timeEl = document.querySelector('.time');
   if (timeEl) {
-    timeEl.style.position = 'static';
-    timeEl.style.left = '';
-    timeEl.style.transform = '';
-    timeEl.style.top = '';
-    timeEl.style.marginTop = '10px';
+    timeEl.style.position = 'absolute';
+    timeEl.style.left = '50%';
+    timeEl.style.transform = 'translateX(-50%)';
+    timeEl.style.top = '12vh';
+    timeEl.style.marginTop = '';
+    timeEl.style.fontWeight = '600';
   }
 
   const headerLine = document.querySelector('.header-line');
   if (headerLine) {
-    headerLine.style.position = 'static';
-    headerLine.style.bottom = '';
-    headerLine.style.width = '100%';
+    headerLine.style.borderTop = '1px solid #000';
     headerLine.style.marginTop = '10px';
+    headerLine.style.width = '100%';
   }
 
   const productItem = document.querySelector('.product-item');
@@ -79,6 +75,7 @@ document.addEventListener('DOMContentLoaded', () => {
     productItem.style.display = 'flex';
     productItem.style.flexDirection = 'column';
     productItem.style.alignItems = 'center';
+    productItem.style.textAlign = 'center';
   }
 
   // Inject footer similar to shop.html
@@ -127,10 +124,12 @@ document.addEventListener('DOMContentLoaded', () => {
     .footer-links a { color:#000; text-decoration:none; transition:all 0.3s ease; }
     .footer-links a:hover, .footer-links a:focus, .footer-links a:active { color:red; border:2px solid red; background:white; }
     .full-site-link { text-align:center; margin-top:20px; }
-    .image-slider { position:relative; display:flex; align-items:center; }
+    .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:100%; }
+    .image-slider img { margin:0 auto; }
     .image-slider button { position:absolute; top:50%; transform:translateY(-50%); background:transparent; border:none; font-size:2rem; cursor:pointer; }
     .image-slider .prev { left:10px; }
     .image-slider .next { right:10px; }
+    .product-item h1, .product-item p, .product-details { text-align:center; }
   `;
   document.head.appendChild(style);
 

--- a/shirts.html
+++ b/shirts.html
@@ -384,5 +384,7 @@
     }
 </script>
 
+<script src="cart.js"></script>
+
 </body>
 </html>

--- a/shoes.html
+++ b/shoes.html
@@ -384,5 +384,7 @@
     }
 </script>
 
+<script src="cart.js"></script>
+
 </body>
 </html>

--- a/skate.html
+++ b/skate.html
@@ -384,5 +384,7 @@
     }
 </script>
 
+<script src="cart.js"></script>
+
 </body>
 </html>

--- a/soon.html
+++ b/soon.html
@@ -431,5 +431,7 @@
     }
 </script>
 
+<script src="cart.js"></script>
+
 </body>
 </html>

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -384,5 +384,7 @@
     }
 </script>
 
+<script src="cart.js"></script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Use pants-style header on product pages and on `new` and `all` category pages
- Center product images and details, stacking info cleanly
- Auto-inject cart counter and load cart script on all category pages

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689ba37ec9188321a8faef3b3528af9a