### PR TITLE
Fix header line placement for category and product pages

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -252,14 +252,15 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/all.html
+++ b/all.html
@@ -262,16 +262,17 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-    <div class="cart-counter">
+    </header>
+<div class="header-line"></div>
+<div class="cart-counter">
         <span class="cart-icon">🛍️</span><span id="cart-count">0</span>
-    </div>
+    
 </div>
 <div class="product-grid">
     <div class="product-item" data-product="hoodie" data-price="220" data-selected-color="black">

--- a/bags.html
+++ b/bags.html
@@ -252,14 +252,15 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/blackhat2.html
+++ b/blackhat2.html
@@ -20,9 +20,10 @@ iframe{width:100%;height:100%;border:none;}
 </style>
 </head>
 <body>
-<div class="header-container">
+<header class="header-container">
 <div class="logo-container"><iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe><div class="logo-overlay"></div></div>
-<div class="time" id="current-time"></div><div class="header-line"></div></div>
+<div class="time" id="current-time"></div></header>
+<div class="header-line"></div>
 <div class="cart-counter"><span class="cart-icon">🛒</span><span id="cart-count">0</span></div>
 <div class="product-item" data-product="hat2" data-price="120" data-selected-color="black">
 <div class="image-slider" data-images="blackhat2.png,whitehat2.png">

--- a/blackjeans.html
+++ b/blackjeans.html
@@ -19,10 +19,11 @@ iframe{width:100%;height:100%;border:none;}
 </style>
 </head>
 <body>
-<div class="header-container">
+<header class="header-container">
 <div class="logo-container"><iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe><div class="logo-overlay"></div></div>
-<div class="time" id="current-time"></div><div class="header-line"></div>
-<div class="cart-counter"><span class="cart-icon">🛒</span><span id="cart-count">0</span></div></div>
+<div class="time" id="current-time"></div></header>
+<div class="header-line"></div>
+<div class="cart-counter"><span class="cart-icon">🛒</span><span id="cart-count">0</span></div>
 <div class="product-item" data-product="blackjeans" data-price="100">
 <div class="image-slider" data-images="blackjeans.png">
 <button class="prev">&#10094;</button>

--- a/bluejeans.html
+++ b/bluejeans.html
@@ -19,10 +19,11 @@ iframe{width:100%;height:100%;border:none;}
 </style>
 </head>
 <body>
-<div class="header-container">
+<header class="header-container">
 <div class="logo-container"><iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe><div class="logo-overlay"></div></div>
-<div class="time" id="current-time"></div><div class="header-line"></div>
-<div class="cart-counter"><span class="cart-icon">🛒</span><span id="cart-count">0</span></div></div>
+<div class="time" id="current-time"></div></header>
+<div class="header-line"></div>
+<div class="cart-counter"><span class="cart-icon">🛒</span><span id="cart-count">0</span></div>
 <div class="product-item" data-product="bluejeans" data-price="120">
 <div class="image-slider" data-images="bluejeans.png">
 <button class="prev">&#10094;</button>

--- a/category_template.html
+++ b/category_template.html
@@ -239,14 +239,15 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 <div class="product-grid">
     {{ITEMS}}
 </div>

--- a/gym.html
+++ b/gym.html
@@ -252,14 +252,15 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/hat.html
+++ b/hat.html
@@ -92,16 +92,17 @@
     </style>
 </head>
 <body>
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-    <div class="cart-counter">
+    </header>
+<div class="header-line"></div>
+<div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
-    </div>
+    
 </div>
 <div class="product-item" data-product="hat" data-price="100" data-selected-color="black">
     <div class="image-slider" data-images="blackhat.png,whitehat.png">

--- a/hats.html
+++ b/hats.html
@@ -261,14 +261,15 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 <div class="product-grid">
 <div class="product-item" data-product="hat" data-price="100" data-selected-color="black">
     <a href="hat.html"><img src="blackhat.png" alt="Hat"></a>

--- a/hoodie.html
+++ b/hoodie.html
@@ -23,16 +23,17 @@
     </style>
 </head>
 <body>
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-    <div class="cart-counter">
+    </header>
+<div class="header-line"></div>
+<div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
-    </div>
+    
 </div>
 <div class="product-item" data-product="hoodie" data-price="100" data-selected-color="black">
     <div class="image-slider" data-images="blackhoodie.png,whitehoodie.png">

--- a/jackets.html
+++ b/jackets.html
@@ -252,14 +252,15 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/joggers.html
+++ b/joggers.html
@@ -22,14 +22,15 @@
     </style>
 </head>
 <body>
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 <div class="product-item" data-product="joggers" data-price="140" data-selected-color="black">
     <img src="blackjoggers.png" alt="Joggers">
     <h1>Joggers</h1>

--- a/new.html
+++ b/new.html
@@ -210,16 +210,17 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-    <div class="cart-counter">
+    </header>
+<div class="header-line"></div>
+<div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
-    </div>
+    
 </div>
 <div class="product-grid">
     <div class="product-item" data-product="hoodie" data-price="220" data-selected-color="black">

--- a/pants.html
+++ b/pants.html
@@ -261,14 +261,15 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 <div class="product-grid">
 <div class="product-item" data-product="blackjeans" data-price="100">
     <a href="blackjeans.html"><img src="blackjeans.png" alt="Black Jeans"></a>

--- a/shirt.html
+++ b/shirt.html
@@ -92,16 +92,17 @@
     </style>
 </head>
 <body>
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-    <div class="cart-counter">
+    </header>
+<div class="header-line"></div>
+<div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
-    </div>
+    
 </div>
 <div class="product-item" data-product="shirt" data-price="100" data-selected-color="black">
     <div class="image-slider" data-images="blackshirt.png,whiteshirt.png">

--- a/shirts.html
+++ b/shirts.html
@@ -252,14 +252,15 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/shoes.html
+++ b/shoes.html
@@ -252,14 +252,15 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/shop.html
+++ b/shop.html
@@ -354,16 +354,17 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-    <div class="cart-counter">
+    </header>
+<div class="header-line"></div>
+<div class="cart-counter">
         <span class="cart-icon">🛍️</span><span id="cart-count">0</span>
-    </div>
+    
 </div>
 
 <!-- Desktop Nav -->

--- a/shorts.html
+++ b/shorts.html
@@ -38,14 +38,15 @@
     </style>
 </head>
 <body>
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 <div class="product-item" data-product="shorts" data-price="180" data-selected-color="black">
     <img src="blackshorts.png" alt="Shorts">
     <h1>Shorts</h1>

--- a/skate.html
+++ b/skate.html
@@ -252,14 +252,15 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/soon.html
+++ b/soon.html
@@ -314,14 +314,15 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 
 <div class="coming-soon">coming soon..</div>
 

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -261,14 +261,15 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 <div class="product-grid">
 <div class="product-item" data-product="hoodie" data-price="100" data-selected-color="black">
     <a href="hoodie.html"><img src="blackhoodie.png" alt="Hoodie"></a>

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -261,14 +261,15 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 <div class="product-grid">
 <div class="product-item" data-product="shirt" data-price="100" data-selected-color="black">
     <a href="shirt.html"><img src="blackshirt.png" alt="Shirt"></a>

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -252,14 +252,15 @@
 </head>
 <body>
 
-<div class="header-container">
+<header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    <div class="header-line"></div>
-</div>
+    </header>
+<div class="header-line"></div>
+
 <div class="coming-soon">Coming Soon</div>
 
 <nav class="mobile-nav">

--- a/whitehat2.html
+++ b/whitehat2.html
@@ -20,9 +20,10 @@ iframe{width:100%;height:100%;border:none;}
 </style>
 </head>
 <body>
-<div class="header-container">
+<header class="header-container">
 <div class="logo-container"><iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe><div class="logo-overlay"></div></div>
-<div class="time" id="current-time"></div><div class="header-line"></div></div>
+<div class="time" id="current-time"></div></header>
+<div class="header-line"></div>
 <div class="cart-counter"><span class="cart-icon">🛒</span><span id="cart-count">0</span></div>
 <div class="product-item" data-product="hat2" data-price="160" data-selected-color="white">
 <div class="image-slider" data-images="whitehat2.png,blackhat2.png">


### PR DESCRIPTION
## Summary
- Replace header container divs with semantic `<header>` elements
- Ensure logo and clock are grouped inside header and add separator line beneath

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689ba91540ac8321acb37fbadead14d9