### PR TITLE
Standardize category page headers and cart icon placement

### DIFF
--- a/all.html
+++ b/all.html
@@ -57,10 +57,6 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            position: absolute;
-            left: 50%;
-            transform: translateX(-50%);
-            top: 12vh;
             font-weight: 600;
         }
 
@@ -226,7 +222,7 @@
             top: auto;
             left: auto;
             transform: none;
-            margin-top: 10px;
+            margin-top: -90px;
             font-weight: 600;
             font-size: 0.7rem;
             text-align: center;
@@ -271,7 +267,7 @@
     </header>
 <div class="header-line"></div>
 <div class="cart-counter">
-        <span class="cart-icon">🛍️</span><span id="cart-count">0</span>
+        <span class="cart-icon">🛒</span><span id="cart-count">0</span>
     
 </div>
 <div class="product-grid">

--- a/cart.js
+++ b/cart.js
@@ -32,12 +32,12 @@ function updateCartCounter() {
 
 function ensureCartCounter() {
     if (!document.getElementById('cart-count')) {
-        const header = document.querySelector('.header-container');
-        if (header) {
+        const headerLine = document.querySelector('.header-line');
+        if (headerLine) {
             const counter = document.createElement('div');
             counter.className = 'cart-counter';
             counter.innerHTML = '<span class="cart-icon">🛒</span><span id="cart-count">0</span>';
-            header.appendChild(counter);
+            headerLine.insertAdjacentElement('afterend', counter);
             updateCartCounter();
         }
     }

--- a/new.html
+++ b/new.html
@@ -57,10 +57,6 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            position: absolute;
-            left: 50%;
-            transform: translateX(-50%);
-            top: 12vh;
             font-weight: 600;
         }
 
@@ -205,6 +201,55 @@
         .full-site-link {
             text-align: center;
             margin-top: 20px;
+        }
+        /* Header and overlay fixes */
+        .header-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .logo-container {
+            position: static;
+            top: auto;
+            left: auto;
+            transform: none;
+            margin-top: 0;
+            width: 20vw;
+            height: 20vh;
+        }
+        .time {
+            position: static;
+            top: auto;
+            left: auto;
+            transform: none;
+            margin-top: -90px;
+        }
+        .header-line {
+            margin-top: 10px;
+            width: 100%;
+            border-top: 1px solid #000;
+        }
+        .product-grid {
+            margin-top: 20px;
+        }
+        .mobile-nav {
+            margin-top: 20px;
+        }
+        .product-info {
+            pointer-events: none;
+        }
+        .product-info button {
+            pointer-events: auto;
+            margin-top: 5px;
+            font-family: 'Courier New', Courier, monospace;
+            cursor: pointer;
+            background: #fff;
+            color: #000;
+            border: 1px solid #000;
+        }
+        .product-info button:hover {
+            background: red;
+            color: #fff;
         }
     </style>
 </head>

--- a/shop.html
+++ b/shop.html
@@ -363,7 +363,7 @@
     </header>
 <div class="header-line"></div>
 <div class="cart-counter">
-        <span class="cart-icon">🛍️</span><span id="cart-count">0</span>
+        <span class="cart-icon">🛒</span><span id="cart-count">0</span>
     
 </div>
 


### PR DESCRIPTION
## Summary
- Ensure cart counter renders below the header line on every page
- Normalize "new" and "all" category styles to match other sections
- Replace shopping bag emoji with shopping cart icon across pages

## Testing
- `node --check cart.js`
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689bae61941c8321a5acb37472d10f02