### PR TITLE
Align headers for new, all, and product pages

### DIFF
--- a/all.html
+++ b/all.html
@@ -66,13 +66,6 @@
             width: 100%;
         }
 
-        .cart-counter {
-            margin-top: 5px;
-            font-size: 0.7rem;
-            text-align: center;
-            font-weight: 600;
-        }
-
         /* Mobile Navigation */
         .mobile-nav {
             display: block;
@@ -222,7 +215,7 @@
             top: auto;
             left: auto;
             transform: none;
-            margin-top: -90px;
+            margin-top: 10px;
             font-weight: 600;
             font-size: 0.7rem;
             text-align: center;
@@ -264,12 +257,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
+</header>
 <div class="header-line"></div>
-<div class="cart-counter">
-        <span class="cart-icon">🛒</span><span id="cart-count">0</span>
-    
-</div>
 <div class="product-grid">
     <div class="product-item" data-product="hoodie" data-price="220" data-selected-color="black">
         <img src="blackhoodie.png" alt="Hoodie">

--- a/blackhat2.html
+++ b/blackhat2.html
@@ -11,7 +11,7 @@ body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;backgro
 .logo-container{position:static;width:20vw;height:20vh;margin-top:0;}
 .logo-overlay{position:absolute;top:0;left:0;width:100%;height:100%;cursor:pointer;z-index:10;}
 iframe{width:100%;height:100%;border:none;}
-.time{font-size:0.7rem;text-align:center;margin-top:-90px;font-weight:600;}
+.time{font-size:0.7rem;text-align:center;margin-top:10px;font-weight:600;position:static;}
 .header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
 .cart-counter{margin-top:5px;font-size:0.7rem;text-align:center;font-weight:600;}
 .product-item{margin-top:20px;display:flex;flex-direction:column;align-items:center;}

--- a/blackjeans.html
+++ b/blackjeans.html
@@ -8,10 +8,10 @@
 <style>
 body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;background-color:#f7f7f7;color:#000;height:100%;display:flex;flex-direction:column;}
 .header-container{width:100%;padding:10px;background-color:#f7f7f7;display:flex;flex-direction:column;align-items:center;}
-.logo-container{position:absolute;top:0;left:50%;transform:translateX(-50%);width:20vw;height:20vh;margin-top:-40px;}
+.logo-container{position:static;width:20vw;height:20vh;margin-top:0;}
 .logo-overlay{position:absolute;top:0;left:0;width:100%;height:100%;cursor:pointer;z-index:10;}
 iframe{width:100%;height:100%;border:none;}
-.time{font-size:0.7rem;text-align:center;margin-top:-90px;font-weight:600;}
+.time{font-size:0.7rem;text-align:center;margin-top:10px;font-weight:600;position:static;}
 .header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
 .product-item{margin-top:20px;display:flex;flex-direction:column;align-items:center;}
 .product-item img{width:80%;max-width:400px;}

--- a/bluejeans.html
+++ b/bluejeans.html
@@ -8,10 +8,10 @@
 <style>
 body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;background-color:#f7f7f7;color:#000;height:100%;display:flex;flex-direction:column;}
 .header-container{width:100%;padding:10px;background-color:#f7f7f7;display:flex;flex-direction:column;align-items:center;}
-.logo-container{position:absolute;top:0;left:50%;transform:translateX(-50%);width:20vw;height:20vh;margin-top:-40px;}
+.logo-container{position:static;width:20vw;height:20vh;margin-top:0;}
 .logo-overlay{position:absolute;top:0;left:0;width:100%;height:100%;cursor:pointer;z-index:10;}
 iframe{width:100%;height:100%;border:none;}
-.time{font-size:0.7rem;text-align:center;margin-top:-90px;font-weight:600;}
+.time{font-size:0.7rem;text-align:center;margin-top:10px;font-weight:600;position:static;}
 .header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
 .product-item{margin-top:20px;display:flex;flex-direction:column;align-items:center;}
 .product-item img{width:80%;max-width:400px;}

--- a/hat.html
+++ b/hat.html
@@ -48,8 +48,9 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -90px;
+            margin-top: 10px;
             font-weight: 600;
+            position: static;
         }
         .header-line {
             border-top: 1px solid #000;

--- a/hoodie.html
+++ b/hoodie.html
@@ -12,7 +12,7 @@
         .logo-container { position:static; width:20vw; height:20vh; margin-top:0; }
         .logo-overlay { position:absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
         iframe { width:100%; height:100%; border:none; }
-        .time { font-size:0.7rem; text-align:center; margin-top:-90px; font-weight:600; }
+        .time { font-size:0.7rem; text-align:center; margin-top:10px; font-weight:600; position:static; }
         .header-line { border-top:1px solid #000; margin-top:10px; width:100%; }
         .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
         .product-item { margin-top:20px; display:flex; flex-direction:column; align-items:center; }

--- a/new.html
+++ b/new.html
@@ -66,13 +66,6 @@
             width: 100%;
         }
 
-        .cart-counter {
-            margin-top: 5px;
-            font-size: 0.7rem;
-            text-align: center;
-            font-weight: 600;
-        }
-
         /* Mobile Navigation */
         .mobile-nav {
             display: block;
@@ -222,7 +215,10 @@
             top: auto;
             left: auto;
             transform: none;
-            margin-top: -90px;
+            margin-top: 10px;
+            font-weight: 600;
+            font-size: 0.7rem;
+            text-align: center;
         }
         .header-line {
             margin-top: 10px;
@@ -263,10 +259,6 @@
     <div class="time" id="current-time"></div>
     </header>
 <div class="header-line"></div>
-<div class="cart-counter">
-        <span class="cart-icon">🛒</span><span id="cart-count">0</span>
-    
-</div>
 <div class="product-grid">
     <div class="product-item" data-product="hoodie" data-price="220" data-selected-color="black">
         <img src="blackhoodie.png" alt="Hoodie">

--- a/shirt.html
+++ b/shirt.html
@@ -48,8 +48,9 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -90px;
+            margin-top: 10px;
             font-weight: 600;
+            position: static;
         }
         .header-line {
             border-top: 1px solid #000;

--- a/whitehat2.html
+++ b/whitehat2.html
@@ -11,7 +11,7 @@ body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;backgro
 .logo-container{position:static;width:20vw;height:20vh;margin-top:0;}
 .logo-overlay{position:absolute;top:0;left:0;width:100%;height:100%;cursor:pointer;z-index:10;}
 iframe{width:100%;height:100%;border:none;}
-.time{font-size:0.7rem;text-align:center;margin-top:-90px;font-weight:600;}
+.time{font-size:0.7rem;text-align:center;margin-top:10px;font-weight:600;position:static;}
 .header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
 .cart-counter{margin-top:5px;font-size:0.7rem;text-align:center;font-weight:600;}
 .product-item{margin-top:20px;display:flex;flex-direction:column;align-items:center;}


### PR DESCRIPTION
## Summary
- Standardize header layout on `new.html` and `all.html` by positioning the time label below the logo and removing the stray cart counter.
- Bring individual product pages (hat, shirt, hoodie, jean and hat variants) into the same header structure used on category pages.

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689bb360fbb0832195179b8bd25ee2dc