### PR TITLE
Align product page headers with category layout

### DIFF
--- a/blackhat2.html
+++ b/blackhat2.html
@@ -13,8 +13,8 @@ body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;backgro
 iframe{width:100%;height:100%;border:none;}
 .time{font-size:0.7rem;text-align:center;position:absolute;left:50%;transform:translateX(-50%);top:12vh;font-weight:600;}
 .header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
-.cart-counter{margin-top:70px;font-size:0.7rem;text-align:center;font-weight:600;}
-.product-item{margin-top:160px;display:flex;flex-direction:column;align-items:center;}
+.cart-counter{margin-top:160px;font-size:0.7rem;text-align:center;font-weight:600;}
+.product-item{margin-top:20px;display:flex;flex-direction:column;align-items:center;}
 .product-item img{width:80%;max-width:400px;}
 .product-item button{margin-top:5px;font-family:'Courier New',Courier,monospace;cursor:pointer;}
 </style>

--- a/blackjeans.html
+++ b/blackjeans.html
@@ -13,10 +13,10 @@ body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;backgro
 iframe{width:100%;height:100%;border:none;}
 .time{font-size:0.7rem;text-align:center;position:absolute;left:50%;transform:translateX(-50%);top:12vh;font-weight:600;}
 .header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
-.product-item{margin-top:160px;display:flex;flex-direction:column;align-items:center;}
+.product-item{margin-top:20px;display:flex;flex-direction:column;align-items:center;}
 .product-item img{width:80%;max-width:400px;}
 .product-item button{margin-top:5px;font-family:'Courier New',Courier,monospace;cursor:pointer;}
-.cart-counter{margin-top:70px;font-size:0.7rem;text-align:center;font-weight:600;}
+.cart-counter{margin-top:160px;font-size:0.7rem;text-align:center;font-weight:600;}
 </style>
 </head>
 <body>

--- a/bluejeans.html
+++ b/bluejeans.html
@@ -13,10 +13,10 @@ body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;backgro
 iframe{width:100%;height:100%;border:none;}
 .time{font-size:0.7rem;text-align:center;position:absolute;left:50%;transform:translateX(-50%);top:12vh;font-weight:600;}
 .header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
-.product-item{margin-top:160px;display:flex;flex-direction:column;align-items:center;}
+.product-item{margin-top:20px;display:flex;flex-direction:column;align-items:center;}
 .product-item img{width:80%;max-width:400px;}
 .product-item button{margin-top:5px;font-family:'Courier New',Courier,monospace;cursor:pointer;}
-.cart-counter{margin-top:70px;font-size:0.7rem;text-align:center;font-weight:600;}
+.cart-counter{margin-top:160px;font-size:0.7rem;text-align:center;font-weight:600;}
 </style>
 </head>
 <body>

--- a/hat.html
+++ b/hat.html
@@ -64,13 +64,13 @@
         }
 
         .cart-counter {
-            margin-top: 70px;
+            margin-top: 160px;
             font-size: 0.7rem;
             text-align: center;
             font-weight: 600;
         }
         .product-item {
-            margin-top: 160px;
+            margin-top: 20px;
             display: flex;
             flex-direction: column;
             align-items: center;

--- a/hoodie.html
+++ b/hoodie.html
@@ -30,8 +30,8 @@
             font-weight:600;
         }
         .header-line { border-top:1px solid #000; margin-top:10px; width:100%; }
-        .cart-counter { margin-top:70px; font-size:0.7rem; text-align:center; font-weight:600; }
-        .product-item { margin-top:160px; display:flex; flex-direction:column; align-items:center; }
+        .cart-counter { margin-top:160px; font-size:0.7rem; text-align:center; font-weight:600; }
+        .product-item { margin-top:20px; display:flex; flex-direction:column; align-items:center; }
         .product-item img { width:80%; max-width:400px; }
         .color-options { display:flex; gap:5px; margin:5px 0; }
         .color-option { width:15px; height:15px; cursor:pointer; display:inline-block; }

--- a/shirt.html
+++ b/shirt.html
@@ -64,13 +64,13 @@
         }
 
         .cart-counter {
-            margin-top: 70px;
+            margin-top: 160px;
             font-size: 0.7rem;
             text-align: center;
             font-weight: 600;
         }
         .product-item {
-            margin-top: 160px;
+            margin-top: 20px;
             display: flex;
             flex-direction: column;
             align-items: center;

--- a/whitehat2.html
+++ b/whitehat2.html
@@ -13,8 +13,8 @@ body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;backgro
 iframe{width:100%;height:100%;border:none;}
 .time{font-size:0.7rem;text-align:center;position:absolute;left:50%;transform:translateX(-50%);top:12vh;font-weight:600;}
 .header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
-.cart-counter{margin-top:70px;font-size:0.7rem;text-align:center;font-weight:600;}
-.product-item{margin-top:160px;display:flex;flex-direction:column;align-items:center;}
+.cart-counter{margin-top:160px;font-size:0.7rem;text-align:center;font-weight:600;}
+.product-item{margin-top:20px;display:flex;flex-direction:column;align-items:center;}
 .product-item img{width:80%;max-width:400px;}
 .product-item button{margin-top:5px;font-family:'Courier New',Courier,monospace;cursor:pointer;}
 </style>


### PR DESCRIPTION
## Summary
- Align individual product page headers with category pages by repositioning the cart counter and updating product spacing

## Testing
- `python -m py_compile generate_category_pages.py`
- `node --check product.js`
- `node --check cart.js`


------
https://chatgpt.com/codex/tasks/task_e_689bbe1019cc8321b5e647523473a05d