### PR TITLE
Ensure product headers display below clock

### DIFF
--- a/product.js
+++ b/product.js
@@ -65,8 +65,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const headerLine = document.querySelector('.header-line');
   if (headerLine) {
     headerLine.style.borderTop = '1px solid #000';
-    headerLine.style.marginTop = '10px';
+    headerLine.style.marginTop = '200px';
     headerLine.style.width = '100%';
+  }
+
+  const cartCounter = document.querySelector('.cart-counter');
+  if (cartCounter) {
+    cartCounter.style.marginTop = '150px';
   }
 
   const productItem = document.querySelector('.product-item');


### PR DESCRIPTION
## Summary
- Keep product page header line and cart counter beneath the clock for clearer layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bc4cd1cd08321bdc0bd3f0f6eb1cf