### PR TITLE
Tighten product layouts and update button styling

### DIFF
--- a/blackhat2.html
+++ b/blackhat2.html
@@ -12,8 +12,8 @@ body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;backgro
 .logo-overlay{position:absolute;top:0;left:0;width:100%;height:100%;cursor:pointer;z-index:10;}
 iframe{width:100%;height:100%;border:none;}
 .time{font-size:0.7rem;text-align:center;position:absolute;left:50%;transform:translateX(-50%);top:12vh;font-weight:600;}
-.header-line{border-top:1px solid #000;margin-top:200px;width:100%;}
-.cart-counter{margin-top:50px;font-size:0.7rem;text-align:center;font-weight:600;}
+.header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
+.cart-counter{margin-top:5px;font-size:0.7rem;text-align:center;font-weight:600;}
 .product-item{margin-top:20px;display:flex;flex-direction:column;align-items:center;}
 .product-item img{width:80%;max-width:400px;}
 px;font-family:'Courier New',Courier,monospace;cursor:pointer;}

--- a/blackjeans.html
+++ b/blackjeans.html
@@ -12,10 +12,11 @@ body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;backgro
 .logo-overlay{position:absolute;top:0;left:0;width:100%;height:100%;cursor:pointer;z-index:10;}
 iframe{width:100%;height:100%;border:none;}
 .time{font-size:0.7rem;text-align:center;position:absolute;left:50%;transform:translateX(-50%);top:12vh;font-weight:600;}
-.header-line{border-top:1px solid #000;margin-top:200px;width:100%;}
+.header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
 .product-item{margin-top:20px;display:flex;flex-direction:column;align-items:center;}
 .product-item img{width:80%;max-width:400px;}
-px;font-family:'Courier New',Courier,monospace;cursor:pointer;}
+.cart-counter{margin-top:5px;font-size:0.7rem;text-align:center;font-weight:600;}
+px;font-family:'Courier New',Courier,monospace;cursor:pointer;}
 .cart-counter{margin-top:50px;font-size:0.7rem;text-align:center;font-weight:600;}
 </style>
 </head>

--- a/bluejeans.html
+++ b/bluejeans.html
@@ -12,10 +12,11 @@ body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;backgro
 .logo-overlay{position:absolute;top:0;left:0;width:100%;height:100%;cursor:pointer;z-index:10;}
 iframe{width:100%;height:100%;border:none;}
 .time{font-size:0.7rem;text-align:center;position:absolute;left:50%;transform:translateX(-50%);top:12vh;font-weight:600;}
-.header-line{border-top:1px solid #000;margin-top:200px;width:100%;}
+.header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
 .product-item{margin-top:20px;display:flex;flex-direction:column;align-items:center;}
 .product-item img{width:80%;max-width:400px;}
-px;font-family:'Courier New',Courier,monospace;cursor:pointer;}
+.cart-counter{margin-top:5px;font-size:0.7rem;text-align:center;font-weight:600;}
+px;font-family:'Courier New',Courier,monospace;cursor:pointer;}
 .cart-counter{margin-top:50px;font-size:0.7rem;text-align:center;font-weight:600;}
 </style>
 </head>

--- a/hat.html
+++ b/hat.html
@@ -59,12 +59,12 @@
         }
         .header-line {
             border-top: 1px solid #000;
-            margin-top:200px;
+            margin-top:10px;
             width: 100%;
         }
 
         .cart-counter {
-            margin-top:50px;
+            margin-top:5px;
             font-size: 0.7rem;
             text-align: center;
             font-weight: 600;

--- a/hoodie.html
+++ b/hoodie.html
@@ -29,8 +29,8 @@
             top:12vh;
             font-weight:600;
         }
-        .header-line { border-top:1px solid #000; margin-top:200px; width:100%; }
-        .cart-counter { margin-top:50px; font-size:0.7rem; text-align:center; font-weight:600; }
+        .header-line { border-top:1px solid #000; margin-top:10px; width:100%; }
+        .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
         .product-item { margin-top:20px; display:flex; flex-direction:column; align-items:center; }
         .product-item img { width:80%; max-width:400px; }
         .color-options { display:flex; gap:5px; margin:5px 0; }

--- a/product.js
+++ b/product.js
@@ -39,6 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const header = document.querySelector('.header-container');
   if (header) {
     header.style.position = 'relative';
+    header.style.height = '20vh';
   }
 
   const logo = document.querySelector('.logo-container');
@@ -65,13 +66,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const headerLine = document.querySelector('.header-line');
   if (headerLine) {
     headerLine.style.borderTop = '1px solid #000';
-    headerLine.style.marginTop = '200px';
+    headerLine.style.marginTop = '10px';
     headerLine.style.width = '100%';
-  }
-
-  const cartCounter = document.querySelector('.cart-counter');
-  if (cartCounter) {
-    cartCounter.style.marginTop = '150px';
   }
 
   const productItem = document.querySelector('.product-item');
@@ -131,9 +127,11 @@ document.addEventListener('DOMContentLoaded', () => {
     .full-site-link { text-align:center; margin-top:20px; }
     .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:100%; }
     .image-slider img { margin:0 auto; }
-    .image-slider button { position:absolute; top:50%; transform:translateY(-50%); background:transparent; border:none; font-size:2rem; cursor:pointer; }
-    .image-slider .prev { left:10px; }
-    .image-slider .next { right:10px; }
+    .image-slider button { position:absolute; top:50%; transform:translateY(-50%); background:transparent; border:none; font-size:2rem; cursor:pointer; color:red; }
+    .image-slider .prev { left:10%; }
+    .image-slider .next { right:10%; }
+    .product-item button { background:#000; color:#fff; border:2px solid #000; font-family:'Courier New', Courier, monospace; cursor:pointer; margin-top:5px; }
+    .product-item button:hover, .product-item button:active { background:#fff; color:red; border-color:red; }
     .product-item h1, .product-item p, .product-details { text-align:center; }
   `;
   document.head.appendChild(style);

--- a/shirt.html
+++ b/shirt.html
@@ -59,12 +59,12 @@
         }
         .header-line {
             border-top: 1px solid #000;
-            margin-top:200px;
+            margin-top:10px;
             width: 100%;
         }
 
         .cart-counter {
-            margin-top:50px;
+            margin-top:5px;
             font-size: 0.7rem;
             text-align: center;
             font-weight: 600;

--- a/shop.html
+++ b/shop.html
@@ -68,12 +68,12 @@
 
         .header-line {
             border-top: 1px solid #000;
-            margin-top:200px;
+            margin-top:10px;
             width: 100%;
         }
 
         .cart-counter {
-            margin-top:50px;
+            margin-top:5px;
             font-size: 0.7rem;
             text-align: center;
             font-weight: 600;

--- a/whitehat2.html
+++ b/whitehat2.html
@@ -12,8 +12,8 @@ body,html{margin:0;padding:0;font-family:'Courier New',Courier,monospace;backgro
 .logo-overlay{position:absolute;top:0;left:0;width:100%;height:100%;cursor:pointer;z-index:10;}
 iframe{width:100%;height:100%;border:none;}
 .time{font-size:0.7rem;text-align:center;position:absolute;left:50%;transform:translateX(-50%);top:12vh;font-weight:600;}
-.header-line{border-top:1px solid #000;margin-top:200px;width:100%;}
-.cart-counter{margin-top:50px;font-size:0.7rem;text-align:center;font-weight:600;}
+.header-line{border-top:1px solid #000;margin-top:10px;width:100%;}
+.cart-counter{margin-top:5px;font-size:0.7rem;text-align:center;font-weight:600;}
 .product-item{margin-top:20px;display:flex;flex-direction:column;align-items:center;}
 .product-item img{width:80%;max-width:400px;}
 px;font-family:'Courier New',Courier,monospace;cursor:pointer;}


### PR DESCRIPTION
## Summary
- Move header rule and cart counter directly below the clock on product and shop pages
- Style image navigation arrows red and position them beside product edges
- Render Add to Cart and Checkout buttons black with white text, turning red on hover

## Testing
- `node --check product.js`
- `node --check cart.js`


------
https://chatgpt.com/codex/tasks/task_e_689bc7f509b08321a1be3335a7841d09