### PR TITLE
Move category navigation to bottom

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -268,6 +268,10 @@
 
 </div>
 
+<div class="product-grid">
+    
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -307,10 +311,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-
-<div class="product-grid">
-    
-</div>
 
 <footer>
     <br>

--- a/all.html
+++ b/all.html
@@ -268,46 +268,6 @@
 
 </div>
 
-<!-- Desktop Nav -->
-<nav class="desktop-nav">
-    <ul>
-        <li><a href="new.html">new</a></li>
-        <li><a href="jackets.html">jackets</a></li>
-        <li><a href="shirts.html">shirts</a></li>
-        <li><a href="tops-sweaters.html">tops/sweaters</a></li>
-        <li><a href="sweatshirts.html">sweatshirts</a></li>
-        <li><a href="pants.html">pants</a></li>
-        <li><a href="t-shirts.html">t-shirts</a></li>
-        <li><a href="hats.html">hats</a></li>
-        <li><a href="bags.html">bags</a></li>
-        <li><a href="accessories.html">accessories</a></li>
-        <li><a href="shoes.html">shoes</a></li>
-        <li><a href="gym.html">gym</a></li>
-        <li><a href="skate.html">skate</a></li>
-        <li><a href="all.html">all</a></li>
-    </ul>
-</nav>
-
-<!-- Mobile Nav -->
-<nav class="mobile-nav">
-    <ul>
-        <li><a href="new.html">new</a></li>
-        <li><a href="jackets.html">jackets</a></li>
-        <li><a href="shirts.html">shirts</a></li>
-        <li><a href="tops-sweaters.html">tops/sweaters</a></li>
-        <li><a href="sweatshirts.html">sweatshirts</a></li>
-        <li><a href="pants.html">pants</a></li>
-        <li><a href="t-shirts.html">t-shirts</a></li>
-        <li><a href="hats.html">hats</a></li>
-        <li><a href="bags.html">bags</a></li>
-        <li><a href="accessories.html">accessories</a></li>
-        <li><a href="shoes.html">shoes</a></li>
-        <li><a href="gym.html">gym</a></li>
-        <li><a href="skate.html">skate</a></li>
-        <li><a href="all.html">all</a></li>
-    </ul>
-</nav>
-
 <div class="product-grid">
     
 <div class="product-item">
@@ -370,6 +330,46 @@
     </a>
 </div>
 </div>
+
+<!-- Desktop Nav -->
+<nav class="desktop-nav">
+    <ul>
+        <li><a href="new.html">new</a></li>
+        <li><a href="jackets.html">jackets</a></li>
+        <li><a href="shirts.html">shirts</a></li>
+        <li><a href="tops-sweaters.html">tops/sweaters</a></li>
+        <li><a href="sweatshirts.html">sweatshirts</a></li>
+        <li><a href="pants.html">pants</a></li>
+        <li><a href="t-shirts.html">t-shirts</a></li>
+        <li><a href="hats.html">hats</a></li>
+        <li><a href="bags.html">bags</a></li>
+        <li><a href="accessories.html">accessories</a></li>
+        <li><a href="shoes.html">shoes</a></li>
+        <li><a href="gym.html">gym</a></li>
+        <li><a href="skate.html">skate</a></li>
+        <li><a href="all.html">all</a></li>
+    </ul>
+</nav>
+
+<!-- Mobile Nav -->
+<nav class="mobile-nav">
+    <ul>
+        <li><a href="new.html">new</a></li>
+        <li><a href="jackets.html">jackets</a></li>
+        <li><a href="shirts.html">shirts</a></li>
+        <li><a href="tops-sweaters.html">tops/sweaters</a></li>
+        <li><a href="sweatshirts.html">sweatshirts</a></li>
+        <li><a href="pants.html">pants</a></li>
+        <li><a href="t-shirts.html">t-shirts</a></li>
+        <li><a href="hats.html">hats</a></li>
+        <li><a href="bags.html">bags</a></li>
+        <li><a href="accessories.html">accessories</a></li>
+        <li><a href="shoes.html">shoes</a></li>
+        <li><a href="gym.html">gym</a></li>
+        <li><a href="skate.html">skate</a></li>
+        <li><a href="all.html">all</a></li>
+    </ul>
+</nav>
 
 <footer>
     <br>

--- a/americandenim.html
+++ b/americandenim.html
@@ -37,12 +37,6 @@ nav.mobile-nav ul li a:hover,nav.mobile-nav ul li a:focus,nav.mobile-nav ul li a
 <div class="header-line"></div>
 <div class="cart-counter"><span class="cart-icon">🛒</span><span id="cart-count">0</span></div>
 
-<!-- Desktop Nav -->
-<nav class="desktop-nav"><ul><li><a href="new.html">new</a></li><li><a href="jackets.html">jackets</a></li><li><a href="shirts.html">shirts</a></li><li><a href="tops-sweaters.html">tops/sweaters</a></li><li><a href="sweatshirts.html">sweatshirts</a></li><li><a href="pants.html">pants</a></li><li><a href="t-shirts.html">t-shirts</a></li><li><a href="hats.html">hats</a></li><li><a href="bags.html">bags</a></li><li><a href="accessories.html">accessories</a></li><li><a href="shoes.html">shoes</a></li><li><a href="gym.html">gym</a></li><li><a href="skate.html">skate</a></li><li><a href="all.html">all</a></li></ul></nav>
-
-<!-- Mobile Nav -->
-<nav class="mobile-nav"><ul><li><a href="new.html">new</a></li><li><a href="jackets.html">jackets</a></li><li><a href="shirts.html">shirts</a></li><li><a href="tops-sweaters.html">tops/sweaters</a></li><li><a href="sweatshirts.html">sweatshirts</a></li><li><a href="pants.html">pants</a></li><li><a href="t-shirts.html">t-shirts</a></li><li><a href="hats.html">hats</a></li><li><a href="bags.html">bags</a></li><li><a href="accessories.html">accessories</a></li><li><a href="shoes.html">shoes</a></li><li><a href="gym.html">gym</a></li><li><a href="skate.html">skate</a></li><li><a href="all.html">all</a></li></ul></nav>
-
 <div class="product-item" data-product="american-denim" data-price="120" data-selected-color="black">
 <div class="image-slider" data-images="blackjeans.png,bluejeans.png">
 <button class="prev">&#10094;</button>
@@ -60,9 +54,15 @@ nav.mobile-nav ul li a:hover,nav.mobile-nav ul li a:focus,nav.mobile-nav ul li a
 <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
 <p>Only national shipping for now.</p>
 </div>
-<button onclick="addToCart(this)">Add to Cart</button>
-<button onclick="checkout(this)">Checkout</button>
+    <button onclick="addToCart(this)">Add to Cart</button>
+    <button onclick="checkout(this)">Checkout</button>
 </div>
+
+<!-- Desktop Nav -->
+<nav class="desktop-nav"><ul><li><a href="new.html">new</a></li><li><a href="jackets.html">jackets</a></li><li><a href="shirts.html">shirts</a></li><li><a href="tops-sweaters.html">tops/sweaters</a></li><li><a href="sweatshirts.html">sweatshirts</a></li><li><a href="pants.html">pants</a></li><li><a href="t-shirts.html">t-shirts</a></li><li><a href="hats.html">hats</a></li><li><a href="bags.html">bags</a></li><li><a href="accessories.html">accessories</a></li><li><a href="shoes.html">shoes</a></li><li><a href="gym.html">gym</a></li><li><a href="skate.html">skate</a></li><li><a href="all.html">all</a></li></ul></nav>
+
+<!-- Mobile Nav -->
+<nav class="mobile-nav"><ul><li><a href="new.html">new</a></li><li><a href="jackets.html">jackets</a></li><li><a href="shirts.html">shirts</a></li><li><a href="tops-sweaters.html">tops/sweaters</a></li><li><a href="sweatshirts.html">sweatshirts</a></li><li><a href="pants.html">pants</a></li><li><a href="t-shirts.html">t-shirts</a></li><li><a href="hats.html">hats</a></li><li><a href="bags.html">bags</a></li><li><a href="accessories.html">accessories</a></li><li><a href="shoes.html">shoes</a></li><li><a href="gym.html">gym</a></li><li><a href="skate.html">skate</a></li><li><a href="all.html">all</a></li></ul></nav>
 <footer><div class="footer-links"><a href="index.html">home</a></div></footer>
 <script src="cart.js"></script>
 <script src="product.js"></script>

--- a/bags.html
+++ b/bags.html
@@ -268,6 +268,10 @@
 
 </div>
 
+<div class="product-grid">
+    
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -307,10 +311,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-
-<div class="product-grid">
-    
-</div>
 
 <footer>
     <br>

--- a/category_template.html
+++ b/category_template.html
@@ -268,6 +268,10 @@
 
 </div>
 
+<div class="product-grid">
+    {{ITEMS}}
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -307,10 +311,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-
-<div class="product-grid">
-    {{ITEMS}}
-</div>
 
 <footer>
     <br>

--- a/gym.html
+++ b/gym.html
@@ -268,6 +268,10 @@
 
 </div>
 
+<div class="product-grid">
+    
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -307,10 +311,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-
-<div class="product-grid">
-    
-</div>
 
 <footer>
     <br>

--- a/hat.html
+++ b/hat.html
@@ -162,7 +162,42 @@
             cursor: pointer;
             display: inline-block;
         }
-
+        }
+    </style>
+</head>
+<body>
+<header class="header-container">
+    <div class="logo-container">
+        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <div class="logo-overlay"></div>
+    </div>
+    <div class="time" id="current-time"></div>
+    </header>
+<div class="header-line"></div>
+<div class="cart-counter">
+        <span class="cart-icon">🛒</span><span id="cart-count">0</span>
+    
+</div>
+<div class="product-item" data-product="hat" data-price="100" data-selected-color="black">
+    <div class="image-slider" data-images="blackhat.png,whitehat.png">
+        <button class="prev">&#10094;</button>
+        <img id="product-image" src="blackhat.png" alt="Hat">
+        <button class="next">&#10095;</button>
+    </div>
+    <h1>Hat</h1>
+    <p>$100</p>
+    <div class="color-options">
+        <span class="color-option" data-color="black" data-image="blackhat.png" style="background:#000;"></span>
+        <span class="color-option" data-color="white" data-image="whitehat.png" style="background:#fff;border:1px solid #000;"></span>
+    </div>
+    <div class="product-details">
+        <p>100% heavyweight cotton.</p>
+        <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
+        <p>Only national shipping for now.</p>
+    </div>
+    <button onclick="addToCart(this)">Add to Cart</button>
+    <button onclick="checkout(this)">Checkout</button>
+</div>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
@@ -203,45 +238,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-px;
-            font-family: 'Courier New', Courier, monospace;
-            cursor: pointer;
-        }
-    </style>
-</head>
-<body>
-<header class="header-container">
-    <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
-        <div class="logo-overlay"></div>
-    </div>
-    <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
-<div class="cart-counter">
-        <span class="cart-icon">🛒</span><span id="cart-count">0</span>
-    
-</div>
-<div class="product-item" data-product="hat" data-price="100" data-selected-color="black">
-    <div class="image-slider" data-images="blackhat.png,whitehat.png">
-        <button class="prev">&#10094;</button>
-        <img id="product-image" src="blackhat.png" alt="Hat">
-        <button class="next">&#10095;</button>
-    </div>
-    <h1>Hat</h1>
-    <p>$100</p>
-    <div class="color-options">
-        <span class="color-option" data-color="black" data-image="blackhat.png" style="background:#000;"></span>
-        <span class="color-option" data-color="white" data-image="whitehat.png" style="background:#fff;border:1px solid #000;"></span>
-    </div>
-    <div class="product-details">
-        <p>100% heavyweight cotton.</p>
-        <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
-        <p>Only national shipping for now.</p>
-    </div>
-    <button onclick="addToCart(this)">Add to Cart</button>
-    <button onclick="checkout(this)">Checkout</button>
-</div>
 <footer>
     <div class="footer-links">
         <a href="index.html">home</a>

--- a/hats.html
+++ b/hats.html
@@ -268,6 +268,19 @@
 
 </div>
 
+<div class="product-grid">
+    
+<div class="product-item">
+    <a href="hat.html">
+        <img src="blackhat.png" alt="Hat">
+        <div class="product-info">
+            <p>Hat</p>
+            <p>$100</p>
+        </div>
+    </a>
+</div>
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -307,19 +320,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-
-<div class="product-grid">
-    
-<div class="product-item">
-    <a href="hat.html">
-        <img src="blackhat.png" alt="Hat">
-        <div class="product-info">
-            <p>Hat</p>
-            <p>$100</p>
-        </div>
-    </a>
-</div>
-</div>
 
 <footer>
     <br>

--- a/hoodie.html
+++ b/hoodie.html
@@ -31,7 +31,41 @@
         .product-item img { width:80%; max-width:400px; }
         .color-options { display:flex; gap:5px; margin:5px 0; }
         .color-option { width:15px; height:15px; cursor:pointer; display:inline-block; }
-
+    </style>
+</head>
+<body>
+<header class="header-container">
+    <div class="logo-container">
+        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <div class="logo-overlay"></div>
+    </div>
+    <div class="time" id="current-time"></div>
+    </header>
+<div class="header-line"></div>
+<div class="cart-counter">
+        <span class="cart-icon">🛒</span><span id="cart-count">0</span>
+    
+</div>
+<div class="product-item" data-product="hoodie" data-price="100" data-selected-color="black">
+    <div class="image-slider" data-images="blackhoodie.png,whitehoodie.png">
+        <button class="prev">&#10094;</button>
+        <img id="product-image" src="blackhoodie.png" alt="Hoodie">
+        <button class="next">&#10095;</button>
+    </div>
+    <h1>Hoodie</h1>
+    <p>$100</p>
+    <div class="color-options">
+        <span class="color-option" data-color="black" data-image="blackhoodie.png" style="background:#000;"></span>
+        <span class="color-option" data-color="white" data-image="whitehoodie.png" style="background:#fff;border:1px solid #000;"></span>
+    </div>
+    <div class="product-details">
+        <p>100% heavyweight cotton.</p>
+        <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
+        <p>Only national shipping for now.</p>
+    </div>
+    <button onclick="addToCart(this)">Add to Cart</button>
+    <button onclick="checkout(this)">Checkout</button>
+</div>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
@@ -72,42 +106,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-px; font-family:'Courier New', Courier, monospace; cursor:pointer; }
-    </style>
-</head>
-<body>
-<header class="header-container">
-    <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
-        <div class="logo-overlay"></div>
-    </div>
-    <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
-<div class="cart-counter">
-        <span class="cart-icon">🛒</span><span id="cart-count">0</span>
-    
-</div>
-<div class="product-item" data-product="hoodie" data-price="100" data-selected-color="black">
-    <div class="image-slider" data-images="blackhoodie.png,whitehoodie.png">
-        <button class="prev">&#10094;</button>
-        <img id="product-image" src="blackhoodie.png" alt="Hoodie">
-        <button class="next">&#10095;</button>
-    </div>
-    <h1>Hoodie</h1>
-    <p>$100</p>
-    <div class="color-options">
-        <span class="color-option" data-color="black" data-image="blackhoodie.png" style="background:#000;"></span>
-        <span class="color-option" data-color="white" data-image="whitehoodie.png" style="background:#fff;border:1px solid #000;"></span>
-    </div>
-    <div class="product-details">
-        <p>100% heavyweight cotton.</p>
-        <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
-        <p>Only national shipping for now.</p>
-    </div>
-    <button onclick="addToCart(this)">Add to Cart</button>
-    <button onclick="checkout(this)">Checkout</button>
-</div>
 <footer>
     <div class="footer-links">
         <a href="index.html">home</a>

--- a/jackets.html
+++ b/jackets.html
@@ -268,6 +268,10 @@
 
 </div>
 
+<div class="product-grid">
+    
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -307,10 +311,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-
-<div class="product-grid">
-    
-</div>
 
 <footer>
     <br>

--- a/joggers.html
+++ b/joggers.html
@@ -54,6 +54,27 @@
     <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 </div>
 
+<div class="product-item" data-product="joggers" data-price="140" data-selected-color="black">
+    <div class="image-slider" data-images="blackjoggers.png,whitejoggers.png">
+        <button class="prev">&#10094;</button>
+        <img src="blackjoggers.png" alt="Joggers">
+        <button class="next">&#10095;</button>
+    </div>
+    <h1>Joggers</h1>
+    <p>$140</p>
+    <div class="color-options">
+        <span class="color-option" data-color="black" data-image="blackjoggers.png" style="background:#000;"></span>
+        <span class="color-option" data-color="white" data-image="whitejoggers.png" style="background:#fff;border:1px solid #000;"></span>
+    </div>
+    <div class="product-details">
+        <p>100% heavyweight cotton.</p>
+        <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
+        <p>Only national shipping for now.</p>
+    </div>
+    <button onclick="addToCart(this)">Add to Cart</button>
+    <button onclick="checkout(this)">Checkout</button>
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -93,27 +114,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-
-<div class="product-item" data-product="joggers" data-price="140" data-selected-color="black">
-    <div class="image-slider" data-images="blackjoggers.png,whitejoggers.png">
-        <button class="prev">&#10094;</button>
-        <img src="blackjoggers.png" alt="Joggers">
-        <button class="next">&#10095;</button>
-    </div>
-    <h1>Joggers</h1>
-    <p>$140</p>
-    <div class="color-options">
-        <span class="color-option" data-color="black" data-image="blackjoggers.png" style="background:#000;"></span>
-        <span class="color-option" data-color="white" data-image="whitejoggers.png" style="background:#fff;border:1px solid #000;"></span>
-    </div>
-    <div class="product-details">
-        <p>100% heavyweight cotton.</p>
-        <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
-        <p>Only national shipping for now.</p>
-    </div>
-    <button onclick="addToCart(this)">Add to Cart</button>
-    <button onclick="checkout(this)">Checkout</button>
-</div>
 <footer></footer>
 <script src="cart.js"></script>
 <script src="product.js"></script>

--- a/new.html
+++ b/new.html
@@ -268,46 +268,6 @@
 
 </div>
 
-<!-- Desktop Nav -->
-<nav class="desktop-nav">
-    <ul>
-        <li><a href="new.html">new</a></li>
-        <li><a href="jackets.html">jackets</a></li>
-        <li><a href="shirts.html">shirts</a></li>
-        <li><a href="tops-sweaters.html">tops/sweaters</a></li>
-        <li><a href="sweatshirts.html">sweatshirts</a></li>
-        <li><a href="pants.html">pants</a></li>
-        <li><a href="t-shirts.html">t-shirts</a></li>
-        <li><a href="hats.html">hats</a></li>
-        <li><a href="bags.html">bags</a></li>
-        <li><a href="accessories.html">accessories</a></li>
-        <li><a href="shoes.html">shoes</a></li>
-        <li><a href="gym.html">gym</a></li>
-        <li><a href="skate.html">skate</a></li>
-        <li><a href="all.html">all</a></li>
-    </ul>
-</nav>
-
-<!-- Mobile Nav -->
-<nav class="mobile-nav">
-    <ul>
-        <li><a href="new.html">new</a></li>
-        <li><a href="jackets.html">jackets</a></li>
-        <li><a href="shirts.html">shirts</a></li>
-        <li><a href="tops-sweaters.html">tops/sweaters</a></li>
-        <li><a href="sweatshirts.html">sweatshirts</a></li>
-        <li><a href="pants.html">pants</a></li>
-        <li><a href="t-shirts.html">t-shirts</a></li>
-        <li><a href="hats.html">hats</a></li>
-        <li><a href="bags.html">bags</a></li>
-        <li><a href="accessories.html">accessories</a></li>
-        <li><a href="shoes.html">shoes</a></li>
-        <li><a href="gym.html">gym</a></li>
-        <li><a href="skate.html">skate</a></li>
-        <li><a href="all.html">all</a></li>
-    </ul>
-</nav>
-
 <div class="product-grid">
     
 <div class="product-item">
@@ -370,6 +330,46 @@
     </a>
 </div>
 </div>
+
+<!-- Desktop Nav -->
+<nav class="desktop-nav">
+    <ul>
+        <li><a href="new.html">new</a></li>
+        <li><a href="jackets.html">jackets</a></li>
+        <li><a href="shirts.html">shirts</a></li>
+        <li><a href="tops-sweaters.html">tops/sweaters</a></li>
+        <li><a href="sweatshirts.html">sweatshirts</a></li>
+        <li><a href="pants.html">pants</a></li>
+        <li><a href="t-shirts.html">t-shirts</a></li>
+        <li><a href="hats.html">hats</a></li>
+        <li><a href="bags.html">bags</a></li>
+        <li><a href="accessories.html">accessories</a></li>
+        <li><a href="shoes.html">shoes</a></li>
+        <li><a href="gym.html">gym</a></li>
+        <li><a href="skate.html">skate</a></li>
+        <li><a href="all.html">all</a></li>
+    </ul>
+</nav>
+
+<!-- Mobile Nav -->
+<nav class="mobile-nav">
+    <ul>
+        <li><a href="new.html">new</a></li>
+        <li><a href="jackets.html">jackets</a></li>
+        <li><a href="shirts.html">shirts</a></li>
+        <li><a href="tops-sweaters.html">tops/sweaters</a></li>
+        <li><a href="sweatshirts.html">sweatshirts</a></li>
+        <li><a href="pants.html">pants</a></li>
+        <li><a href="t-shirts.html">t-shirts</a></li>
+        <li><a href="hats.html">hats</a></li>
+        <li><a href="bags.html">bags</a></li>
+        <li><a href="accessories.html">accessories</a></li>
+        <li><a href="shoes.html">shoes</a></li>
+        <li><a href="gym.html">gym</a></li>
+        <li><a href="skate.html">skate</a></li>
+        <li><a href="all.html">all</a></li>
+    </ul>
+</nav>
 
 <footer>
     <br>

--- a/pants.html
+++ b/pants.html
@@ -268,6 +268,39 @@
 
 </div>
 
+<div class="product-grid">
+    
+<div class="product-item">
+    <a href="joggers.html">
+        <img src="blackjoggers.png" alt="Joggers">
+        <div class="product-info">
+            <p>Joggers</p>
+            <p>$140</p>
+        </div>
+    </a>
+</div>
+    
+<div class="product-item">
+    <a href="shorts.html">
+        <img src="blackshorts.png" alt="Shorts">
+        <div class="product-info">
+            <p>Shorts</p>
+            <p>$180</p>
+        </div>
+    </a>
+</div>
+    
+<div class="product-item">
+    <a href="americandenim.html">
+        <img src="bluejeans.png" alt="American Denim">
+        <div class="product-info">
+            <p>American Denim</p>
+            <p>$120</p>
+        </div>
+    </a>
+</div>
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -307,39 +340,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-
-<div class="product-grid">
-    
-<div class="product-item">
-    <a href="joggers.html">
-        <img src="blackjoggers.png" alt="Joggers">
-        <div class="product-info">
-            <p>Joggers</p>
-            <p>$140</p>
-        </div>
-    </a>
-</div>
-    
-<div class="product-item">
-    <a href="shorts.html">
-        <img src="blackshorts.png" alt="Shorts">
-        <div class="product-info">
-            <p>Shorts</p>
-            <p>$180</p>
-        </div>
-    </a>
-</div>
-    
-<div class="product-item">
-    <a href="americandenim.html">
-        <img src="bluejeans.png" alt="American Denim">
-        <div class="product-info">
-            <p>American Denim</p>
-            <p>$120</p>
-        </div>
-    </a>
-</div>
-</div>
 
 <footer>
     <br>

--- a/shirt.html
+++ b/shirt.html
@@ -156,6 +156,44 @@
         }
 
 
+            display: inline-block;
+        }
+    </style>
+</head>
+<body>
+<header class="header-container">
+    <div class="logo-container">
+        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <div class="logo-overlay"></div>
+    </div>
+    <div class="time" id="current-time"></div>
+    </header>
+<div class="header-line"></div>
+<div class="cart-counter">
+        <span class="cart-icon">🛒</span><span id="cart-count">0</span>
+    
+</div>
+<div class="product-item" data-product="shirt" data-price="100" data-selected-color="black">
+    <div class="image-slider" data-images="blackshirt.png,whiteshirt.png">
+        <button class="prev">&#10094;</button>
+        <img id="product-image" src="blackshirt.png" alt="Shirt">
+        <button class="next">&#10095;</button>
+    </div>
+    <h1>Shirt</h1>
+    <p>$100</p>
+    <div class="color-options">
+        <span class="color-option" data-color="black" data-image="blackshirt.png" style="background:#000;"></span>
+        <span class="color-option" data-color="white" data-image="whiteshirt.png" style="background:#fff;border:1px solid #000;"></span>
+    </div>
+    <div class="product-details">
+        <p>100% heavyweight cotton.</p>
+        <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
+        <p>Only national shipping for now.</p>
+    </div>
+    <button onclick="addToCart(this)">Add to Cart</button>
+    <button onclick="checkout(this)">Checkout</button>
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -195,45 +233,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-px;
-            font-family: 'Courier New', Courier, monospace;
-            cursor: pointer;
-        }
-    </style>
-</head>
-<body>
-<header class="header-container">
-    <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
-        <div class="logo-overlay"></div>
-    </div>
-    <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
-<div class="cart-counter">
-        <span class="cart-icon">🛒</span><span id="cart-count">0</span>
-    
-</div>
-<div class="product-item" data-product="shirt" data-price="100" data-selected-color="black">
-    <div class="image-slider" data-images="blackshirt.png,whiteshirt.png">
-        <button class="prev">&#10094;</button>
-        <img id="product-image" src="blackshirt.png" alt="Shirt">
-        <button class="next">&#10095;</button>
-    </div>
-    <h1>Shirt</h1>
-    <p>$100</p>
-    <div class="color-options">
-        <span class="color-option" data-color="black" data-image="blackshirt.png" style="background:#000;"></span>
-        <span class="color-option" data-color="white" data-image="whiteshirt.png" style="background:#fff;border:1px solid #000;"></span>
-    </div>
-    <div class="product-details">
-        <p>100% heavyweight cotton.</p>
-        <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
-        <p>Only national shipping for now.</p>
-    </div>
-    <button onclick="addToCart(this)">Add to Cart</button>
-    <button onclick="checkout(this)">Checkout</button>
-</div>
 <footer>
     <div class="footer-links">
         <a href="index.html">home</a>

--- a/shirts.html
+++ b/shirts.html
@@ -268,6 +268,19 @@
 
 </div>
 
+<div class="product-grid">
+    
+<div class="product-item">
+    <a href="shirt.html">
+        <img src="blackshirt.png" alt="Shirt">
+        <div class="product-info">
+            <p>Shirt</p>
+            <p>$100</p>
+        </div>
+    </a>
+</div>
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -307,19 +320,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-
-<div class="product-grid">
-    
-<div class="product-item">
-    <a href="shirt.html">
-        <img src="blackshirt.png" alt="Shirt">
-        <div class="product-info">
-            <p>Shirt</p>
-            <p>$100</p>
-        </div>
-    </a>
-</div>
-</div>
 
 <footer>
     <br>

--- a/shoes.html
+++ b/shoes.html
@@ -268,6 +268,10 @@
 
 </div>
 
+<div class="product-grid">
+    
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -307,10 +311,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-
-<div class="product-grid">
-    
-</div>
 
 <footer>
     <br>

--- a/shorts.html
+++ b/shorts.html
@@ -71,6 +71,27 @@
     <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 </div>
 
+<div class="product-item" data-product="shorts" data-price="180" data-selected-color="black">
+    <div class="image-slider" data-images="blackshorts.png,whiteshorts.png">
+        <button class="prev">&#10094;</button>
+        <img src="blackshorts.png" alt="Shorts">
+        <button class="next">&#10095;</button>
+    </div>
+    <h1>Shorts</h1>
+    <p>$180</p>
+    <div class="color-options">
+        <span class="color-option" data-color="black" data-image="blackshorts.png" style="background:#000;"></span>
+        <span class="color-option" data-color="white" data-image="whiteshorts.png" style="background:#fff;border:1px solid #000;"></span>
+    </div>
+    <div class="product-details">
+        <p>100% heavyweight cotton.</p>
+        <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
+        <p>Only national shipping for now.</p>
+    </div>
+    <button onclick="addToCart(this)">Add to Cart</button>
+    <button onclick="checkout(this)">Checkout</button>
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -110,27 +131,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-
-<div class="product-item" data-product="shorts" data-price="180" data-selected-color="black">
-    <div class="image-slider" data-images="blackshorts.png,whiteshorts.png">
-        <button class="prev">&#10094;</button>
-        <img src="blackshorts.png" alt="Shorts">
-        <button class="next">&#10095;</button>
-    </div>
-    <h1>Shorts</h1>
-    <p>$180</p>
-    <div class="color-options">
-        <span class="color-option" data-color="black" data-image="blackshorts.png" style="background:#000;"></span>
-        <span class="color-option" data-color="white" data-image="whiteshorts.png" style="background:#fff;border:1px solid #000;"></span>
-    </div>
-    <div class="product-details">
-        <p>100% heavyweight cotton.</p>
-        <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
-        <p>Only national shipping for now.</p>
-    </div>
-    <button onclick="addToCart(this)">Add to Cart</button>
-    <button onclick="checkout(this)">Checkout</button>
-</div>
 <footer></footer>
 <script src="cart.js"></script>
 <script src="product.js"></script>

--- a/skate.html
+++ b/skate.html
@@ -268,6 +268,10 @@
 
 </div>
 
+<div class="product-grid">
+    
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -307,10 +311,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-
-<div class="product-grid">
-    
-</div>
 
 <footer>
     <br>

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -268,6 +268,19 @@
 
 </div>
 
+<div class="product-grid">
+    
+<div class="product-item">
+    <a href="hoodie.html">
+        <img src="blackhoodie.png" alt="Hoodie">
+        <div class="product-info">
+            <p>Hoodie</p>
+            <p>$100</p>
+        </div>
+    </a>
+</div>
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -307,19 +320,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-
-<div class="product-grid">
-    
-<div class="product-item">
-    <a href="hoodie.html">
-        <img src="blackhoodie.png" alt="Hoodie">
-        <div class="product-info">
-            <p>Hoodie</p>
-            <p>$100</p>
-        </div>
-    </a>
-</div>
-</div>
 
 <footer>
     <br>

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -268,6 +268,19 @@
 
 </div>
 
+<div class="product-grid">
+    
+<div class="product-item">
+    <a href="shirt.html">
+        <img src="blackshirt.png" alt="Shirt">
+        <div class="product-info">
+            <p>Shirt</p>
+            <p>$100</p>
+        </div>
+    </a>
+</div>
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -307,19 +320,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-
-<div class="product-grid">
-    
-<div class="product-item">
-    <a href="shirt.html">
-        <img src="blackshirt.png" alt="Shirt">
-        <div class="product-info">
-            <p>Shirt</p>
-            <p>$100</p>
-        </div>
-    </a>
-</div>
-</div>
 
 <footer>
     <br>

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -268,6 +268,10 @@
 
 </div>
 
+<div class="product-grid">
+    
+</div>
+
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>
@@ -307,10 +311,6 @@
         <li><a href="all.html">all</a></li>
     </ul>
 </nav>
-
-<div class="product-grid">
-    
-</div>
 
 <footer>
     <br>


### PR DESCRIPTION
## Summary
- Place category navigation below product listings on all category pages.
- Relocate navigation to bottom of individual product pages beneath purchase buttons.

## Testing
- `python generate_category_pages.py`

------
https://chatgpt.com/codex/tasks/task_e_689bdf6ff5388321ae67f0158f91caa2