### PR TITLE
Align product page headers and image sizing

### DIFF
--- a/americandenim.html
+++ b/americandenim.html
@@ -76,8 +76,11 @@
             max-width: 400px;
         }
         .image-slider img {
-            width: 100%;
+            width: 400px;
+            height: 400px;
+            object-fit: cover;
             display: block;
+            margin: 0 auto;
         }
         .image-slider .prev,
         .image-slider .next {
@@ -107,10 +110,6 @@
             cursor: pointer;
             display: inline-block;
         }
-        .product-categories {
-            font-size: 0.8rem;
-            margin-top: 5px;
-        }
     </style>
 </head>
 <body>
@@ -129,7 +128,7 @@
 <div class="product-item" data-product="american-denim" data-price="120" data-selected-color="black">
     <div class="image-slider" data-images="blackjeans.png,bluejeans.png">
         <button class="prev">&#10094;</button>
-        <img id="product-image" src="blackjeans.png" alt="American Denim">
+        <img id="product-image" src="blackjeans.png" alt="American Denim" width="400" height="400">
         <button class="next">&#10095;</button>
     </div>
     <h1>American Denim</h1>
@@ -143,7 +142,6 @@
         <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
         <p>Only national shipping for now.</p>
     </div>
-    <div class="product-categories">Categories: pants, new, all</div>
     <button onclick="addToCart(this)">Add to Cart</button>
     <button onclick="checkout(this)">Checkout</button>
 </div>

--- a/joggers.html
+++ b/joggers.html
@@ -57,7 +57,7 @@
 <div class="product-item" data-product="joggers" data-price="140" data-selected-color="black">
     <div class="image-slider" data-images="blackjoggers.png,whitejoggers.png">
         <button class="prev">&#10094;</button>
-        <img src="blackjoggers.png" alt="Joggers">
+        <img src="blackjoggers.png" alt="Joggers" width="400" height="400">
         <button class="next">&#10095;</button>
     </div>
     <h1>Joggers</h1>

--- a/product.js
+++ b/product.js
@@ -8,6 +8,11 @@ function initSliders() {
     if (images.length === 0) return;
     let index = 0;
     const img = slider.querySelector('img');
+    if (img) {
+      img.style.width = '400px';
+      img.style.height = '400px';
+      img.style.objectFit = 'cover';
+    }
     const prev = slider.querySelector('.prev');
     const next = slider.querySelector('.next');
 
@@ -72,6 +77,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const headerLine = document.querySelector('.header-line');
   const cartCounter = document.querySelector('.cart-counter');
+  if (header && headerLine) {
+    header.insertAdjacentElement('afterend', headerLine);
+  }
+  if (headerLine && cartCounter) {
+    headerLine.insertAdjacentElement('afterend', cartCounter);
+  }
   if (headerLine) {
     headerLine.style.borderTop = '1px solid #000';
     headerLine.style.marginTop = window.innerWidth <= 768 ? '40px' : '10px';


### PR DESCRIPTION
## Summary
- ensure headers on product pages mirror shop layout by ordering header line and cart counter consistently
- normalize product images to 400x400 to avoid size shifts between colors
- remove stray categories block from American denim page for consistent navigation styling

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689c6eb683848321a90695ce74959e6a