### PR TITLE
Show coming soon for empty categories and normalize product image sizes

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            aspect-ratio: 1 / 1;
         }
 
         .product-item a {
@@ -166,8 +167,20 @@
 
         .product-item img {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
+        }
+
+        .coming-soon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-align: center;
         }
 
         @media (min-width: 768px) {
@@ -285,7 +298,7 @@
 </div>
 
 <div class="product-grid">
-    
+    <div class="coming-soon">Coming Soon..</div>
 </div>
 
 <!-- Desktop Nav -->

--- a/all.html
+++ b/all.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            aspect-ratio: 1 / 1;
         }
 
         .product-item a {
@@ -166,8 +167,20 @@
 
         .product-item img {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
+        }
+
+        .coming-soon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-align: center;
         }
 
         @media (min-width: 768px) {

--- a/bags.html
+++ b/bags.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            aspect-ratio: 1 / 1;
         }
 
         .product-item a {
@@ -166,8 +167,20 @@
 
         .product-item img {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
+        }
+
+        .coming-soon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-align: center;
         }
 
         @media (min-width: 768px) {
@@ -285,7 +298,7 @@
 </div>
 
 <div class="product-grid">
-    
+    <div class="coming-soon">Coming Soon..</div>
 </div>
 
 <!-- Desktop Nav -->

--- a/category_template.html
+++ b/category_template.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            aspect-ratio: 1 / 1;
         }
 
         .product-item a {
@@ -166,8 +167,20 @@
 
         .product-item img {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
+        }
+
+        .coming-soon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-align: center;
         }
 
         @media (min-width: 768px) {

--- a/generate_category_pages.py
+++ b/generate_category_pages.py
@@ -83,7 +83,11 @@ for slug, title in categories:
     for product in products:
         if slug in product["categories"]:
             items.append(item_template.format(**product))
-    page = template.replace("{{TITLE}}", title).replace("{{ITEMS}}", "\n    ".join(items))
+    if not items:
+        items_content = '<div class="coming-soon">Coming Soon..</div>'
+    else:
+        items_content = "\n    ".join(items)
+    page = template.replace("{{TITLE}}", title).replace("{{ITEMS}}", items_content)
     filename = f"{slug}.html"
     with open(filename, "w") as f:
         f.write(page)

--- a/gym.html
+++ b/gym.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            aspect-ratio: 1 / 1;
         }
 
         .product-item a {
@@ -166,8 +167,20 @@
 
         .product-item img {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
+        }
+
+        .coming-soon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-align: center;
         }
 
         @media (min-width: 768px) {
@@ -285,7 +298,7 @@
 </div>
 
 <div class="product-grid">
-    
+    <div class="coming-soon">Coming Soon..</div>
 </div>
 
 <!-- Desktop Nav -->

--- a/hats.html
+++ b/hats.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            aspect-ratio: 1 / 1;
         }
 
         .product-item a {
@@ -166,8 +167,20 @@
 
         .product-item img {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
+        }
+
+        .coming-soon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-align: center;
         }
 
         @media (min-width: 768px) {

--- a/jackets.html
+++ b/jackets.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            aspect-ratio: 1 / 1;
         }
 
         .product-item a {
@@ -166,8 +167,20 @@
 
         .product-item img {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
+        }
+
+        .coming-soon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-align: center;
         }
 
         @media (min-width: 768px) {
@@ -285,7 +298,7 @@
 </div>
 
 <div class="product-grid">
-    
+    <div class="coming-soon">Coming Soon..</div>
 </div>
 
 <!-- Desktop Nav -->

--- a/new.html
+++ b/new.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            aspect-ratio: 1 / 1;
         }
 
         .product-item a {
@@ -166,8 +167,20 @@
 
         .product-item img {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
+        }
+
+        .coming-soon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-align: center;
         }
 
         @media (min-width: 768px) {

--- a/pants.html
+++ b/pants.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            aspect-ratio: 1 / 1;
         }
 
         .product-item a {
@@ -166,8 +167,20 @@
 
         .product-item img {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
+        }
+
+        .coming-soon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-align: center;
         }
 
         @media (min-width: 768px) {

--- a/shirts.html
+++ b/shirts.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            aspect-ratio: 1 / 1;
         }
 
         .product-item a {
@@ -166,8 +167,20 @@
 
         .product-item img {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
+        }
+
+        .coming-soon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-align: center;
         }
 
         @media (min-width: 768px) {

--- a/shoes.html
+++ b/shoes.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            aspect-ratio: 1 / 1;
         }
 
         .product-item a {
@@ -166,8 +167,20 @@
 
         .product-item img {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
+        }
+
+        .coming-soon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-align: center;
         }
 
         @media (min-width: 768px) {
@@ -285,7 +298,7 @@
 </div>
 
 <div class="product-grid">
-    
+    <div class="coming-soon">Coming Soon..</div>
 </div>
 
 <!-- Desktop Nav -->

--- a/skate.html
+++ b/skate.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            aspect-ratio: 1 / 1;
         }
 
         .product-item a {
@@ -166,8 +167,20 @@
 
         .product-item img {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
+        }
+
+        .coming-soon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-align: center;
         }
 
         @media (min-width: 768px) {
@@ -285,7 +298,7 @@
 </div>
 
 <div class="product-grid">
-    
+    <div class="coming-soon">Coming Soon..</div>
 </div>
 
 <!-- Desktop Nav -->

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            aspect-ratio: 1 / 1;
         }
 
         .product-item a {
@@ -166,8 +167,20 @@
 
         .product-item img {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
+        }
+
+        .coming-soon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-align: center;
         }
 
         @media (min-width: 768px) {

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            aspect-ratio: 1 / 1;
         }
 
         .product-item a {
@@ -166,8 +167,20 @@
 
         .product-item img {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
+        }
+
+        .coming-soon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-align: center;
         }
 
         @media (min-width: 768px) {

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            aspect-ratio: 1 / 1;
         }
 
         .product-item a {
@@ -166,8 +167,20 @@
 
         .product-item img {
             width: 100%;
+            height: 100%;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
+        }
+
+        .coming-soon {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 200px;
+            font-size: 1.2rem;
+            font-weight: 600;
+            text-align: center;
         }
 
         @media (min-width: 768px) {
@@ -285,7 +298,7 @@
 </div>
 
 <div class="product-grid">
-    
+    <div class="coming-soon">Coming Soon..</div>
 </div>
 
 <!-- Desktop Nav -->


### PR DESCRIPTION
## Summary
- Display a centered "Coming Soon.." message on category pages without products
- Ensure product thumbnails render at a consistent size across categories

## Testing
- `python generate_category_pages.py`

------
https://chatgpt.com/codex/tasks/task_e_689c768951108321912cc01f0bb91a3c