### PR TITLE
Fix pants image cropping and footer shop links

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -346,7 +346,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>

--- a/all.html
+++ b/all.html
@@ -405,7 +405,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>

--- a/americandenim.html
+++ b/americandenim.html
@@ -145,9 +145,9 @@
             max-width: 400px;
         }
         .image-slider img {
-            width: 400px;
-            height: 400px;
-            object-fit: cover;
+            width: 100%;
+            height: auto;
+            object-fit: contain;
             display: block;
             margin: 0 auto;
         }
@@ -197,7 +197,7 @@
 <div class="product-item" data-product="american-denim" data-price="120" data-selected-color="black">
     <div class="image-slider" data-images="blackjeans.png,bluejeans.png">
         <button class="prev">&#10094;</button>
-        <img id="product-image" src="blackjeans.png" alt="American Denim" width="400" height="400">
+        <img id="product-image" src="blackjeans.png" alt="American Denim">
         <button class="next">&#10095;</button>
     </div>
     <h1>American Denim</h1>

--- a/bags.html
+++ b/bags.html
@@ -346,7 +346,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>

--- a/category_template.html
+++ b/category_template.html
@@ -346,7 +346,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>

--- a/gym.html
+++ b/gym.html
@@ -346,7 +346,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>

--- a/hats.html
+++ b/hats.html
@@ -355,7 +355,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>

--- a/jackets.html
+++ b/jackets.html
@@ -346,7 +346,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>

--- a/joggers.html
+++ b/joggers.html
@@ -29,7 +29,7 @@
         .desktop-nav ul li a:hover, .desktop-nav ul li a:focus, .desktop-nav ul li a:active { border:2px solid red; color:red; background-color:white; }
         .product-item { margin-top:20px; display:flex; flex-direction:column; align-items:center; text-align:center; }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; margin:0 auto; }
-        .image-slider img { width:400px; height:400px; object-fit:cover; }
+        .image-slider img { width:100%; height:auto; object-fit:contain; }
         .image-slider button { position:absolute; top:50%; transform:translateY(-50%); background:transparent; border:none; font-size:2rem; cursor:pointer; color:red; }
         .image-slider .prev { left:0; }
         .image-slider .next { right:0; }
@@ -57,7 +57,7 @@
 <div class="product-item" data-product="joggers" data-price="140" data-selected-color="black">
     <div class="image-slider" data-images="blackjoggers.png,whitejoggers.png">
         <button class="prev">&#10094;</button>
-        <img src="blackjoggers.png" alt="Joggers" width="400" height="400">
+        <img src="blackjoggers.png" alt="Joggers">
         <button class="next">&#10095;</button>
     </div>
     <h1>Joggers</h1>

--- a/new.html
+++ b/new.html
@@ -405,7 +405,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>

--- a/pants.html
+++ b/pants.html
@@ -375,7 +375,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>

--- a/product.js
+++ b/product.js
@@ -9,9 +9,9 @@ function initSliders() {
     let index = 0;
     const img = slider.querySelector('img');
     if (img) {
-      img.style.width = '400px';
-      img.style.height = '400px';
-      img.style.objectFit = 'cover';
+      img.style.width = '100%';
+      img.style.height = 'auto';
+      img.style.objectFit = 'contain';
     }
     const prev = slider.querySelector('.prev');
     const next = slider.querySelector('.next');
@@ -83,7 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
@@ -122,7 +122,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .footer-links a:hover, .footer-links a:focus, .footer-links a:active { color:red; border:2px solid red; background:white; }
     .full-site-link { text-align:center; margin-top:20px; }
     .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; margin:0 auto; }
-    .image-slider img { margin:0 auto; width:400px; height:400px; object-fit:cover; }
+    .image-slider img { margin:0 auto; width:100%; height:auto; object-fit:contain; }
     .image-slider button { position:absolute; top:50%; transform:translateY(-50%); background:transparent; border:none; font-size:2rem; cursor:pointer; color:red; }
     .image-slider button:hover, .image-slider button:focus, .image-slider button:active { background:white; border:2px solid red; }
     .image-slider .prev { left:0; }

--- a/shirts.html
+++ b/shirts.html
@@ -355,7 +355,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>

--- a/shoes.html
+++ b/shoes.html
@@ -346,7 +346,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>

--- a/shop.html
+++ b/shop.html
@@ -417,7 +417,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>

--- a/shorts.html
+++ b/shorts.html
@@ -46,7 +46,7 @@
         .desktop-nav ul li a:hover, .desktop-nav ul li a:focus, .desktop-nav ul li a:active { border:2px solid red; color:red; background-color:white; }
         .product-item { margin-top:20px; display:flex; flex-direction:column; align-items:center; text-align:center; }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; margin:0 auto; }
-        .image-slider img { width:400px; height:400px; object-fit:cover; }
+        .image-slider img { width:100%; height:auto; object-fit:contain; }
         .image-slider button { position:absolute; top:50%; transform:translateY(-50%); background:transparent; border:none; font-size:2rem; cursor:pointer; color:red; }
         .image-slider .prev { left:0; }
         .image-slider .next { right:0; }

--- a/skate.html
+++ b/skate.html
@@ -346,7 +346,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -355,7 +355,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -355,7 +355,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -346,7 +346,7 @@
     <br>
     <div class="footer-links">
         <div class="footer-line extra-padding">
-            <a href="#">shop</a>
+            <a href="shop.html">shop</a>
             <a href="#">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>


### PR DESCRIPTION
## Summary
- ensure product sliders scale images without cropping
- point footer "shop" links to shop.html and maintain highlight styling

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689c79871fe08321a7350f9f5f0b2608