### PR TITLE
Align clock under logo and fix cropped product images

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 

--- a/all.html
+++ b/all.html
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 
@@ -156,7 +156,6 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
-            height: 400px;
             display: flex;
             justify-content: center;
             align-items: center;
@@ -169,9 +168,8 @@
         }
 
         .product-item img {
-            max-width: 100%;
-            height: 100%;
-            width: auto;
+            width: 100%;
+            height: auto;
             object-fit: contain;
             display: block;
             margin: 0 auto;

--- a/americandenim.html
+++ b/americandenim.html
@@ -49,7 +49,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
         .header-line {

--- a/bags.html
+++ b/bags.html
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 

--- a/category_template.html
+++ b/category_template.html
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 

--- a/gym.html
+++ b/gym.html
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 

--- a/hat.html
+++ b/hat.html
@@ -49,7 +49,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
         .header-line {

--- a/hats.html
+++ b/hats.html
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 

--- a/hoodie.html
+++ b/hoodie.html
@@ -12,7 +12,7 @@
         .logo-container { position:static; width:20vw; height:20vh; margin-top:0; }
         .logo-overlay { position:absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
         iframe { width:100%; height:100%; border:none; }
-        .time { font-size:0.7rem; text-align:center; margin-top:10px; font-weight:600; }
+        .time { font-size:0.7rem; text-align:center; margin-top: 0; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
         .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
         /* Mobile Navigation */

--- a/jackets.html
+++ b/jackets.html
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 

--- a/joggers.html
+++ b/joggers.html
@@ -12,7 +12,7 @@
         .logo-container { position:static; width:20vw; height:20vh; margin-top:0; }
         .logo-overlay { position:absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
         iframe { width:100%; height:100%; border:none; }
-        .time { font-size:0.7rem; text-align:center; margin-top:10px; font-weight:600; }
+        .time { font-size:0.7rem; text-align:center; margin-top: 0; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
         .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
         /* Mobile Navigation */

--- a/new.html
+++ b/new.html
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 
@@ -156,7 +156,6 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
-            height: 400px;
             display: flex;
             justify-content: center;
             align-items: center;
@@ -169,9 +168,8 @@
         }
 
         .product-item img {
-            max-width: 100%;
-            height: 100%;
-            width: auto;
+            width: 100%;
+            height: auto;
             object-fit: contain;
             display: block;
             margin: 0 auto;

--- a/pants.html
+++ b/pants.html
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 

--- a/shirt.html
+++ b/shirt.html
@@ -49,7 +49,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
         .header-line {

--- a/shirts.html
+++ b/shirts.html
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 

--- a/shoes.html
+++ b/shoes.html
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 

--- a/shop.html
+++ b/shop.html
@@ -63,7 +63,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 
@@ -221,8 +221,6 @@
 
             .time {
                 display: block;
-                left: 50%;
-                transform: translateX(-50%);
             }
 
             footer .footer-links {
@@ -266,11 +264,8 @@
 
             .time {
                 text-align: center;
+            margin-top: 0;
                 margin: 0 auto;
-                left: 50%;
-                transform: translateX(-50%);
-                top: 15vh;
-                position: absolute;
             }
 
             footer {
@@ -319,14 +314,11 @@
             height: 20vh;
         }
         .time {
-            position: static;
-            top: auto;
-            left: auto;
-            transform: none;
             margin-top: 10px;
             font-weight: 600;
             font-size: 0.7rem;
             text-align: center;
+            margin-top: 0;
         }
         .header-line {
             margin-top: 10px;

--- a/shorts.html
+++ b/shorts.html
@@ -29,7 +29,7 @@
         .logo-container { position: static; width: 20vw; height: 20vh; margin-top: 0; }
         .logo-overlay { position: absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
         iframe { width:100%; height:100%; border:none; }
-        .time { font-size:0.7rem; text-align:center; margin-top:10px; font-weight:600; }
+        .time { font-size:0.7rem; text-align:center; margin-top: 0; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
         .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
         /* Mobile Navigation */

--- a/skate.html
+++ b/skate.html
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 

--- a/soon.html
+++ b/soon.html
@@ -62,10 +62,7 @@
                 .time {
             font-size: 0.7rem;
             text-align: center;
-            position: absolute;
-            left: 50%;
-            transform: translateX(-50%);
-            top: 12vh;
+            margin-top: 0;
             font-weight: 600;
         }
 
@@ -143,8 +140,6 @@
 
             .time {
                 display: block;
-                left: 50%;
-                transform: translateX(-50%);
             }
 
             .line-under-time {
@@ -197,10 +192,7 @@
                     .time {
             font-size: 0.7rem;
             text-align: center;
-            position: absolute;
-            left: 50%;
-            transform: translateX(-50%);
-            top: 12vh;
+            margin-top: 0;
             font-weight: 600;
         }
 
@@ -265,14 +257,11 @@
             height: 20vh;
         }
         .time {
-            position: static;
-            top: auto;
-            left: auto;
-            transform: none;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
             font-size: 0.7rem;
             text-align: center;
+            margin-top: 0;
         }
         .header-line {
             margin-top: 10px;

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 10px;
+            margin-top: 0;
             font-weight: 600;
         }
 


### PR DESCRIPTION
## Summary
- Position site clock directly under the logo across all pages except index
- Adjust product grids in new and all categories so joggers and denim images display fully

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689c80003e408321ac22894bb3c713da