### PR TITLE
Fix product image sizes and align styling

### DIFF
--- a/all.html
+++ b/all.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            height: 400px;
             display: flex;
             justify-content: center;
             align-items: center;
@@ -168,8 +169,9 @@
         }
 
         .product-item img {
-            width: 100%;
-            height: auto;
+            max-width: 100%;
+            height: 100%;
+            width: auto;
             object-fit: contain;
             display: block;
             margin: 0 auto;

--- a/new.html
+++ b/new.html
@@ -156,6 +156,7 @@
             width: 100%;
             max-width: 400px;
             margin: 0 auto;
+            height: 400px;
             display: flex;
             justify-content: center;
             align-items: center;
@@ -168,8 +169,9 @@
         }
 
         .product-item img {
-            width: 100%;
-            height: auto;
+            max-width: 100%;
+            height: 100%;
+            width: auto;
             object-fit: contain;
             display: block;
             margin: 0 auto;

--- a/product.js
+++ b/product.js
@@ -126,8 +126,9 @@ document.addEventListener('DOMContentLoaded', () => {
       display:flex;
       justify-content:center;
       align-items:center;
-      width:400px;
-      height:400px;
+      width:80%;
+      max-width:400px;
+      aspect-ratio:1/1;
       margin:0 auto;
     }
     .image-slider img {


### PR DESCRIPTION
## Summary
- Make product image sliders responsive and bounded to 400px square to prevent overlap with header
- Regenerate category pages so product thumbnails use consistent 400px square containers

## Testing
- `python generate_category_pages.py`
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689c8aee58fc83219b4754298a6a0f1c