### PR TITLE
Remove external BAPE domain references

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -175,7 +175,7 @@
     <form id="checkout-form" style="display:none;">
         <h3>Sign up and know first!</h3>
         <input type="email" name="email" placeholder="Email" required>
-        <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from us.bape.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
+        <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from maybenot.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
         <button type="submit">Submit</button>
         <h3>Express checkout</h3>
         <div class="payment-icons">
@@ -193,11 +193,11 @@
         <h3>Order summary</h3>
         <p>Original price</p>
         <p class="original-price">$0.00</p>
-        <h2>us.bape.com Checkout</h2>
+        <h2>maybenot.com Checkout</h2>
         <form id="final-form">
             <h3>Sign up and know first!</h3>
             <input type="email" name="signup_email" placeholder="Enter an email" required>
-            <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from us.bape.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
+            <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from maybenot.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
             <button type="submit">Submit</button>
             <h3>Express checkout</h3>
             <div class="payment-icons">

--- a/cart.js
+++ b/cart.js
@@ -80,7 +80,7 @@ function createCartModal() {
             <form id="checkout-form" style="display:none;">
                 <h3>Sign up and know first!</h3>
                 <input type="email" name="email" placeholder="Email" required>
-                <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from us.bape.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
+                <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from maybenot.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
                 <button type="submit">Submit</button>
                 <h3>Express checkout</h3>
                 <div class="payment-icons">
@@ -98,11 +98,11 @@ function createCartModal() {
                 <h3>Order summary</h3>
                 <p>Original price</p>
                 <p class="original-price">$0.00</p>
-                <h2>us.bape.com Checkout</h2>
+                <h2>maybenot.com Checkout</h2>
                 <form id="final-form">
                     <h3>Sign up and know first!</h3>
                     <input type="email" name="signup_email" placeholder="Enter an email" required>
-                    <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from us.bape.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
+                    <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from maybenot.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
                     <button type="submit">Submit</button>
                     <h3>Express checkout</h3>
                     <div class="payment-icons">


### PR DESCRIPTION
## Summary
- replace leftover BAPE checkout references with our maybenot.com domain

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/MBNT/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689cb5ed8d788321af390e3460d1b4f0