### PR TITLE
Show logo in cart popup and reposition checkout title

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -193,12 +193,12 @@
     <div id="final-checkout" style="display:none;">
         <div class="checkout-header">
             <img src="xlogo.png" alt="Logo" class="checkout-logo">
+            <h2>maybenot.com Checkout</h2>
             <div class="time" id="modal-time"></div>
         </div>
         <h3>Order summary</h3>
         <p>Original price</p>
         <p class="original-price">$0.00</p>
-        <h2>maybenot.com Checkout</h2>
         <form id="final-form">
             <h3>Sign up and know first!</h3>
             <input type="email" name="signup_email" placeholder="Enter an email" required>

--- a/cart.js
+++ b/cart.js
@@ -54,6 +54,9 @@ function createCartModal() {
     modal.innerHTML = `
         <div class="cart-content">
             <button id="cart-close" class="close-btn">&times;</button>
+            <div class="checkout-header">
+                <img src="xlogo.png" alt="Logo" class="checkout-logo">
+            </div>
             <h2>Cart</h2>
             <div class="item-count"></div>
             <div class="cart-items"></div>
@@ -93,12 +96,12 @@ function createCartModal() {
             <div id="final-checkout" style="display:none;">
                 <div class="checkout-header">
                     <img src="xlogo.png" alt="Logo" class="checkout-logo">
+                    <h2>maybenot.com Checkout</h2>
                     <div class="time" id="modal-time"></div>
                 </div>
                 <h3>Order summary</h3>
                 <p>Original price</p>
                 <p class="original-price">$0.00</p>
-                <h2>maybenot.com Checkout</h2>
                 <form id="final-form">
                     <h3>Sign up and know first!</h3>
                     <input type="email" name="signup_email" placeholder="Enter an email" required>


### PR DESCRIPTION
## Summary
- Display site logo at top of cart popup for better branding.
- Move checkout page title inside header so it's at the top of the popup.
- Apply same checkout-header structure on cart page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cbc88532c8321a629c57be04118da