### PR TITLE
Add additional payment buttons and style PayPal

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -74,6 +74,9 @@
             justify-content: center;
             align-items: center;
         }
+        .pay-btn.paypal {
+            background: #ffc439;
+        }
         .payment-icons img {
             height: 24px;
         }
@@ -164,10 +167,12 @@
     <div class="express-checkout">
         <h3>Express checkout</h3>
         <div class="payment-icons">
-            <button class="pay-btn" data-method="Shop Pay"><img src="https://upload.wikimedia.org/wikipedia/commons/4/4c/Shop_Pay_logo.svg" alt="Shop Pay"></button>
-            <button class="pay-btn" data-method="Apple Pay"><img src="https://upload.wikimedia.org/wikipedia/commons/3/30/Apple_Pay_logo.svg" alt="Apple Pay"></button>
-            <button class="pay-btn" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
-            <button class="pay-btn" data-method="Google Pay"><img src="https://upload.wikimedia.org/wikipedia/commons/5/5b/Google_Pay_logo.svg" alt="Google Pay"></button>
+            <button class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
+            <button class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
+            <button class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
+            <button class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
+            <button class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna"></button>
+            <button class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
         </div>
     </div>
     <form id="checkout-form" style="display:none;">
@@ -177,10 +182,12 @@
         <button type="submit">Submit</button>
         <h3>Express checkout</h3>
         <div class="payment-icons">
-            <button class="pay-btn" data-method="Shop Pay"><img src="https://upload.wikimedia.org/wikipedia/commons/4/4c/Shop_Pay_logo.svg" alt="Shop Pay"></button>
-            <button class="pay-btn" data-method="Apple Pay"><img src="https://upload.wikimedia.org/wikipedia/commons/3/30/Apple_Pay_logo.svg" alt="Apple Pay"></button>
-            <button class="pay-btn" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
-            <button class="pay-btn" data-method="Google Pay"><img src="https://upload.wikimedia.org/wikipedia/commons/5/5b/Google_Pay_logo.svg" alt="Google Pay"></button>
+            <button class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
+            <button class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
+            <button class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
+            <button class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
+            <button class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna"></button>
+            <button class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
         </div>
     </form>
     <div id="final-checkout" style="display:none;">
@@ -198,10 +205,12 @@
             <button type="submit">Submit</button>
             <h3>Express checkout</h3>
             <div class="payment-icons">
-                <button class="pay-btn" data-method="Shop Pay"><img src="https://upload.wikimedia.org/wikipedia/commons/4/4c/Shop_Pay_logo.svg" alt="Shop Pay"></button>
-                <button class="pay-btn" data-method="Apple Pay"><img src="https://upload.wikimedia.org/wikipedia/commons/3/30/Apple_Pay_logo.svg" alt="Apple Pay"></button>
-                <button class="pay-btn" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
-                <button class="pay-btn" data-method="Google Pay"><img src="https://upload.wikimedia.org/wikipedia/commons/5/5b/Google_Pay_logo.svg" alt="Google Pay"></button>
+                <button class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
+                <button class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
+                <button class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
+                <button class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
+                <button class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna"></button>
+                <button class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
             </div>
             <div class="or">OR</div>
             <h3>Contact</h3>
@@ -227,6 +236,8 @@
             <h4>Apple Pay</h4>
             <h4>PayPal</h4>
             <h4>Shop Pay</h4>
+            <h4>Google Pay</h4>
+            <h4>Venmo</h4>
             <p>Pay in full or in installments</p>
             <h4>Klarna - Flexible payments</h4>
             <label><input type="checkbox" name="remember"> Save my information for a faster checkout with a Shop account</label>


### PR DESCRIPTION
## Summary
- replace remote payment icons with local images and add buttons for Klarna and Venmo
- highlight PayPal button with official gold background color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cd52c81d4832189bd9bbf42cabae2