### PR TITLE
Display checkout summary beneath email signup

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -191,18 +191,20 @@
         </div>
     </form>
     <div id="final-checkout" style="display:none;">
-        <div class="checkout-header">
-            <h2 class="checkout-domain">maybenot.com</h2>
-            <h2 class="checkout-title">Checkout</h2>
-        </div>
-        <h3>Order summary</h3>
-        <p>Original price</p>
-        <p class="original-price">$0.00</p>
         <form id="final-form">
             <h3>Sign up and know first!</h3>
             <input type="email" name="signup_email" placeholder="Enter an email" required>
             <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from maybenot.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
             <button type="submit">Submit</button>
+            <h2>Cart</h2>
+            <p>0 Item(s)</p>
+            <div class="checkout-header">
+                <h2 class="checkout-domain">maybenot.com</h2>
+                <h2 class="checkout-title">Checkout</h2>
+            </div>
+            <h3>Order summary</h3>
+            <p>Original price</p>
+            <p class="original-price">$0.00</p>
             <h3>Express checkout</h3>
             <div class="payment-icons">
                 <button class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>


### PR DESCRIPTION
## Summary
- Reordered final checkout so the email signup form appears first.
- Show cart and order summary details directly beneath the signup button.

## Testing
- `npx htmlhint cart.html` *(fails: 403 Forbidden retrieving htmlhint package)*

------
https://chatgpt.com/codex/tasks/task_e_689cd6d158448321b0ee51e6b29c465e