### PR TITLE
Simplify checkout to show only domain before signup

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -137,22 +137,6 @@
             text-align: left;
             flex: 1;
         }
-        .summary-header {
-            display: flex;
-            align-items: center;
-            cursor: pointer;
-            font-weight: bold;
-            justify-content: flex-start;
-        }
-        .summary-header .arrow {
-            margin-left: 5px;
-        }
-        .cart-header {
-            display: flex;
-            justify-content: space-between;
-            font-weight: bold;
-            margin: 5px 0;
-        }
         .pay-option[data-method="paypal"] img {
             width: 60px;
         }
@@ -199,13 +183,7 @@
             margin: 5px auto;
             padding: 8px;
         }
-        .checkout-header {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-        }
-        .checkout-domain,
-        .checkout-title {
+        .checkout-domain {
             margin-top: 5px;
         }
         .credit-card input {
@@ -265,29 +243,11 @@
     </form>
     <div id="final-checkout" style="display:none;">
         <form id="final-form">
-            <div class="summary-header" id="order-summary-toggle">Order summary <span class="arrow">&#9660;</span></div>
-            <div id="order-summary" style="display:none;">
-                <p class="original-price">Original price <span class="original-total">$0.00</span></p>
-                <h4>Shopping cart</h4>
-                <div class="cart-summary"></div>
-                <h4>Cost summary</h4>
-                <div class="cost-summary">
-                    <div><span>Subtotal</span><span class="subtotal">$0.00</span></div>
-                    <div><span>Shipping</span><span>Enter shipping address</span></div>
-                    <div><span>Total</span><span class="total">$0.00</span></div>
-                </div>
-                <p class="order-note">PLEASE NOTE: WE DO NOT PROCESS ORDERS ON SATURDAYS AND SUNDAYS, PLEASE ALLOW AN ADDITIONAL 2 - 3 BUSINESS DAYS FOR PROCESSING TIME WHEN PLACED ON THE WEEKEND. ALL SALES FINAL. NO EXCHANGES OR RETURNS. EXPECT ALL ORDERS TO BE SHIPPED WITH DELAYS DUE TO THE 4TH OF JULY HOLIDAY.</p>
-            </div>
+            <h2 class="checkout-domain">maybenot.com</h2>
             <h3>Sign up and know first!</h3>
             <input type="email" name="signup_email" placeholder="Enter an email" required>
             <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from maybenot.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
             <button type="submit">Submit</button>
-            <h2>Cart</h2>
-            <p class="item-count">0 Item(s)</p>
-            <div class="checkout-header">
-                <h2 class="checkout-domain">maybenot.com</h2>
-                <h2 class="checkout-title">Checkout</h2>
-            </div>
             <h3>Express checkout</h3>
             <div class="payment-icons">
                 <button class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>

--- a/cart.js
+++ b/cart.js
@@ -103,29 +103,11 @@ function createCartModal() {
             </form>
             <div id="final-checkout" style="display:none;">
                 <form id="final-form">
-                    <div class="summary-header" id="order-summary-toggle">Order summary <span class="arrow">&#9660;</span></div>
-                    <div id="order-summary" style="display:none;">
-                        <p class="original-price">Original price <span class="original-total">$0.00</span></p>
-                        <h4>Shopping cart</h4>
-                        <div class="cart-summary"></div>
-                        <h4>Cost summary</h4>
-                        <div class="cost-summary">
-                            <div><span>Subtotal</span><span class="subtotal">$0.00</span></div>
-                            <div><span>Shipping</span><span>Enter shipping address</span></div>
-                            <div><span>Total</span><span class="total">$0.00</span></div>
-                        </div>
-                        <p class="order-note">PLEASE NOTE: WE DO NOT PROCESS ORDERS ON SATURDAYS AND SUNDAYS, PLEASE ALLOW AN ADDITIONAL 2 - 3 BUSINESS DAYS FOR PROCESSING TIME WHEN PLACED ON THE WEEKEND. ALL SALES FINAL. NO EXCHANGES OR RETURNS. EXPECT ALL ORDERS TO BE SHIPPED WITH DELAYS DUE TO THE 4TH OF JULY HOLIDAY.</p>
-                    </div>
+                    <h2 class="checkout-domain">maybenot.com</h2>
                     <h3>Sign up and know first!</h3>
                     <input type="email" name="signup_email" placeholder="Enter an email" required>
                     <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from maybenot.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
                     <button type="submit">Submit</button>
-                    <h2>Cart</h2>
-                    <p class="item-count">0 Item(s)</p>
-                    <div class="checkout-header">
-                        <h2 class="checkout-domain">maybenot.com</h2>
-                        <h2 class="checkout-title">Checkout</h2>
-                    </div>
                     <h3>Express checkout</h3>
                     <div class="payment-icons">
                         <button class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
@@ -232,9 +214,6 @@ function createCartModal() {
             #cart-modal .cart-item{display:flex;align-items:center;justify-content:space-between;margin:5px 0;}
             #cart-modal .cart-item img{width:50px;height:50px;object-fit:cover;margin-right:10px;}
             #cart-modal .cart-item .cart-item-info{text-align:left;flex:1;}
-            #final-checkout .summary-header{display:flex;align-items:center;cursor:pointer;font-weight:bold;justify-content:flex-start;}
-            #final-checkout .summary-header .arrow{margin-left:5px;}
-            #final-checkout .cart-header{display:flex;justify-content:space-between;font-weight:bold;margin:5px 0;}
             #cart-modal .or {margin:10px 0;}
             #cart-modal footer a {color:#000;margin:0 5px;font-size:0.8em;text-decoration:none;}
             #cart-modal button:not(.pay-btn):hover,#cart-modal button:not(.pay-btn):focus,#cart-modal button:not(.pay-btn):active,#cart-modal footer a:hover,#cart-modal footer a:focus,#cart-modal footer a:active{border:2px solid red;color:red;background:#fff;}
@@ -242,25 +221,13 @@ function createCartModal() {
             .consent-text {font-size:0.7rem;margin-top:10px;}
             #final-checkout{text-align:center;}
             #final-checkout input {display:block;width:90%;margin:5px auto;padding:8px;}
-            .checkout-header{display:flex;flex-direction:column;align-items:center;}
-            .checkout-domain,.checkout-title{margin-top:5px;}
+            .checkout-domain{margin-top:5px;}
             .credit-card input{width:90%;}
             #cart-modal .logo-container{width:80px;height:80px;margin:0 auto;}
             #cart-modal .logo-container iframe{width:100%;height:100%;border:none;}
             #cart-modal .cart-time{text-align:center;font-size:0.7rem;font-weight:600;margin-top:5px;}
         `;
         document.head.appendChild(style);
-    }
-
-    const toggle = modal.querySelector('#order-summary-toggle');
-    const details = modal.querySelector('#order-summary');
-    if (toggle && details) {
-        toggle.addEventListener('click', () => {
-            const expanded = details.style.display === 'block';
-            details.style.display = expanded ? 'none' : 'block';
-            const arrow = toggle.querySelector('.arrow');
-            if (arrow) arrow.innerHTML = expanded ? '&#9660;' : '&#9650;';
-        });
     }
 
     return modal;
@@ -371,36 +338,6 @@ function showFinalPage(root = document.getElementById('cart-modal')) {
     const finalPage = root.querySelector('#final-checkout');
     if (finalPage) {
         finalPage.style.display = 'block';
-        const toggle = finalPage.querySelector('#order-summary-toggle');
-        const details = finalPage.querySelector('#order-summary');
-        if (toggle && details && !toggle.dataset.bound) {
-            toggle.dataset.bound = 'true';
-            toggle.addEventListener('click', () => {
-                const expanded = details.style.display === 'block';
-                details.style.display = expanded ? 'none' : 'block';
-                const arrow = toggle.querySelector('.arrow');
-                if (arrow) arrow.innerHTML = expanded ? '&#9660;' : '&#9650;';
-            });
-        }
-        const total = cart.reduce((sum, item) => sum + parseFloat(item.price), 0);
-        const summary = finalPage.querySelector('.cart-summary');
-        summary.innerHTML = '<div class="cart-header"><span>Product image</span><span>Description</span><span>Quantity</span><span>Price</span></div>';
-        cart.forEach(item => {
-            summary.innerHTML += `
-                <div class="cart-item">
-                    <img src="${item.image}" alt="${item.name}">
-                    <div class="cart-item-info">
-                        <span>${item.name}</span>
-                        ${item.style || item.color || item.size ? `<div>${[item.style, item.color, item.size].filter(Boolean).join(' / ')}</div>` : ''}
-                    </div>
-                    <span>1</span>
-                    <span>$${parseFloat(item.price).toFixed(2)}</span>
-                </div>`;
-        });
-        finalPage.querySelector('.item-count').textContent = `${cart.length} Item(s)`;
-        finalPage.querySelector('#order-summary .original-total').textContent = `$${total.toFixed(2)}`;
-        finalPage.querySelector('#order-summary .subtotal').textContent = `$${total.toFixed(2)}`;
-        finalPage.querySelector('#order-summary .total').textContent = `$${total.toFixed(2)}`;
         setupFinalForm(finalPage.querySelector('#final-form'));
     }
 }


### PR DESCRIPTION
## Summary
- Remove order summary and cart headers from final checkout
- Show only maybenot.com above signup callout
- Simplify JS checkout flow to hide extra info

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cf8556ee88321a90ff59d1e60d41b