### PR TITLE
Add standalone checkout page with order summary

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -110,6 +110,19 @@ function createCartModal() {
             <div id="final-checkout" style="display:none;">
                 <form id="final-form">
                     <h2 class="checkout-domain">maybenot.com</h2>
+                    <div class="order-summary-bar">
+                        <button class="summary-toggle">Order summary <span class="arrow">&#9660;</span></button>
+                        <strong class="order-total">$0.00</strong>
+                    </div>
+                    <div class="order-summary-details" style="display:none;">
+                        <div class="cart-items"></div>
+                        <div class="cost-summary">
+                            <div><span>Subtotal</span><span class="subtotal">$0.00</span></div>
+                            <div><span>Tax</span><span class="tax">Calculated at checkout</span></div>
+                            <div><span>Shipping</span><span class="shipping">Calculated at checkout</span></div>
+                            <div><strong>Total</strong><strong class="total">$0.00</strong></div>
+                        </div>
+                    </div>
                     <h3>Sign up and know first!</h3>
                     <input type="email" name="signup_email" placeholder="Enter an email" required>
                     <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from maybenot.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
@@ -362,6 +375,49 @@ function showCheckoutForm(root = document.getElementById('cart-modal')) {
     root.querySelector('#checkout-form').style.display = 'block';
 }
 
+function populateOrderSummary(section) {
+    if (!section) return;
+    const itemsContainer = section.querySelector('.order-summary-details .cart-items');
+    const subtotalEl = section.querySelector('.order-summary-details .subtotal');
+    const totalEl = section.querySelector('.order-summary-details .total');
+    const orderTotalEl = section.querySelector('.order-summary-bar .order-total');
+    const bar = section.querySelector('.order-summary-bar');
+    const details = section.querySelector('.order-summary-details');
+    if (!itemsContainer || !subtotalEl || !totalEl || !orderTotalEl || !bar || !details) return;
+    itemsContainer.innerHTML = '';
+    let total = 0;
+    cart.forEach(item => {
+        const div = document.createElement('div');
+        div.className = 'cart-item';
+        div.innerHTML = `
+            <img src="${item.image}" alt="${item.name}">
+            <div class="cart-item-info">
+                <span>${item.name}</span>
+                ${item.style ? `<div>Style: ${item.style}</div>` : ''}
+                ${item.color ? `<div>Color: ${item.color}</div>` : ''}
+                ${item.size ? `<div>Size: ${item.size}</div>` : ''}
+            </div>
+            <span>$${parseFloat(item.price).toFixed(2)}</span>`;
+        itemsContainer.appendChild(div);
+        total += parseFloat(item.price);
+    });
+    subtotalEl.textContent = `$${total.toFixed(2)}`;
+    totalEl.textContent = `$${total.toFixed(2)}`;
+    orderTotalEl.textContent = `$${total.toFixed(2)}`;
+    bar.style.display = 'flex';
+    details.style.display = 'none';
+    const toggle = section.querySelector('.summary-toggle');
+    const arrow = bar.querySelector('.arrow');
+    if (toggle && !toggle.dataset.bound) {
+        toggle.addEventListener('click', () => {
+            const hidden = details.style.display === 'none';
+            details.style.display = hidden ? 'block' : 'none';
+            if (arrow) arrow.textContent = hidden ? '▲' : '▼';
+        });
+        toggle.dataset.bound = 'true';
+    }
+}
+
 function showFinalPage(root = document.getElementById('cart-modal')) {
     root.querySelector('#checkout-form').style.display = 'none';
     const bar = root.querySelector('.order-summary-bar');
@@ -381,6 +437,7 @@ function showFinalPage(root = document.getElementById('cart-modal')) {
     const finalPage = root.querySelector('#final-checkout');
     if (finalPage) {
         finalPage.style.display = 'block';
+        populateOrderSummary(finalPage);
         setupFinalForm(finalPage.querySelector('#final-form'));
     }
 }
@@ -485,7 +542,9 @@ function setupCartPage() {
     const page = document.getElementById('cart-page');
     if (!page) return;
     populateCartPage();
-    page.querySelector('#cart-checkout').addEventListener('click', () => showCheckoutForm(page));
+    page.querySelector('#cart-checkout').addEventListener('click', () => {
+        window.location.href = 'checkout.html';
+    });
     page.querySelectorAll('.pay-btn').forEach(btn => {
         btn.addEventListener('click', () => {
             alert(`${btn.dataset.method} payment not implemented.`);
@@ -505,6 +564,13 @@ function setupCartPage() {
             alert('Order submitted!');
         });
     }
+}
+
+function setupCheckoutPage() {
+    const finalPage = document.getElementById('final-checkout');
+    if (!finalPage) return;
+    populateOrderSummary(finalPage);
+    setupFinalForm(finalPage.querySelector('#final-form'));
 }
 
 function updateCartCounter() {
@@ -570,4 +636,5 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
     setupCartPage();
+    setupCheckoutPage();
 });

--- a/checkout.html
+++ b/checkout.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Cart</title>
+    <title>Checkout</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -13,40 +13,6 @@
             background-color: #f7f7f7;
             color: #000;
             text-align: center;
-        }
-        .header-container {
-            width: 100%;
-            padding: 10px;
-            background-color: #f7f7f7;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-        }
-        .logo-container {
-            position: static;
-            width: 20vw;
-            height: 20vh;
-        }
-        .time {
-            font-size: 0.7rem;
-            text-align: center;
-            margin-top: 0;
-            font-weight: 600;
-        }
-        iframe {
-            width: 100%;
-            height: 100%;
-            border: none;
-        }
-        .header-line {
-            border-top: 1px solid #000;
-            width: 100%;
-            margin-top: 5px;
-        }
-        .cart-page {
-            max-width: 400px;
-            margin: 0 auto;
-            padding: 20px;
         }
         .cart-buttons {
             display: flex;
@@ -84,9 +50,6 @@
             height: 1em;
             vertical-align: middle;
             filter: invert(1);
-        }
-        .empty-cart-message {
-            text-align: center;
         }
         button:not(.pay-btn) {
             background: #000;
@@ -137,9 +100,6 @@
             text-align: left;
             flex: 1;
         }
-        .pay-option[data-method="paypal"] img {
-            width: 60px;
-        }
         .cost-summary div {
             display: flex;
             justify-content: space-between;
@@ -164,18 +124,15 @@
             color: red;
             background: #fff;
         }
-        #checkout-form input {
-            display: block;
-            width: 90%;
-            margin: 5px auto;
-            padding: 8px;
-        }
         .consent-text {
             font-size: 0.7rem;
             margin-top: 10px;
         }
         #final-checkout {
             text-align: center;
+            max-width: 400px;
+            margin: 0 auto;
+            padding: 20px;
         }
         #final-checkout input {
             display: block;
@@ -213,56 +170,7 @@
     </style>
 </head>
 <body>
-<header class="header-container">
-    <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
-        <div class="logo-overlay"></div>
-    </div>
-    <div class="time" id="current-time"></div>
-</header>
-<div class="header-line"></div>
-<div class="cart-counter">
-    <span class="cart-icon">🛒</span><span id="cart-count">0</span>
-</div>
-<div id="cart-page" class="cart-page">
-    <div class="cart-items"></div>
-    <div class="cost-summary">
-        <div><span>Subtotal</span><span class="subtotal">$0.00</span></div>
-        <div><span>Tax</span><span class="tax">Calculated at checkout</span></div>
-        <div><span>Shipping</span><span class="shipping">Calculated at checkout</span></div>
-        <div><strong>Total</strong><strong class="total">$0.00</strong></div>
-    </div>
-    <div class="cart-buttons">
-        <button id="cart-checkout">CHECKOUT</button>
-    </div>
-    <div class="or">OR</div>
-    <div class="express-checkout">
-        <h3>Express checkout</h3>
-        <div class="payment-icons">
-            <button class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
-            <button class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
-            <button class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
-            <button class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
-            <button class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna"></button>
-            <button class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
-        </div>
-    </div>
-    <form id="checkout-form" style="display:none;">
-        <h3>Sign up and know first!</h3>
-        <input type="email" name="email" placeholder="Email" required>
-        <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from maybenot.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
-        <button type="submit">Submit</button>
-        <h3>Express checkout</h3>
-        <div class="payment-icons">
-            <button class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
-            <button class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
-            <button class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
-            <button class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
-            <button class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna"></button>
-            <button class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
-        </div>
-    </form>
-    <div id="final-checkout" style="display:none;">
+    <div id="final-checkout">
         <form id="final-form">
             <h2 class="checkout-domain">maybenot.com</h2>
             <div class="order-summary-bar">
@@ -326,69 +234,14 @@
             <button id="final-order-submit" type="submit">Pay now</button>
             <p id="remember-message" style="display:none;">Your info will be saved to a Shop account. By continuing, you agree to Shop’s Terms of Service and acknowledge the Privacy Policy.</p>
         </form>
+        <footer class="cart-footer">
+            <a href="#">refund policy</a> |
+            <a href="#">shipping</a> |
+            <a href="#">privacy policy</a> |
+            <a href="#">terms of service</a> |
+            <a href="#">cookies</a>
+        </footer>
     </div>
-    <footer class="cart-footer">
-        <a href="#">refund policy</a> |
-        <a href="#">shipping</a> |
-        <a href="#">privacy policy</a> |
-        <a href="#">terms of service</a> |
-        <a href="#">cookies</a>
-    </footer>
-</div>
-<script src="cart.js"></script>
-<script>
-    function updateChicagoTime() {
-        const options = {
-            timeZone: 'America/Chicago',
-            hour: '2-digit',
-            minute: '2-digit',
-            year: 'numeric',
-            month: '2-digit',
-            day: '2-digit',
-        };
-        const currentTime = new Intl.DateTimeFormat('en-US', options).format(new Date()).replace(",", "");
-        document.getElementById('current-time').textContent = currentTime + " CHICAGO";
-    }
-    updateChicagoTime();
-    setInterval(updateChicagoTime, 1000);
-    const logoOverlay = document.querySelector(".logo-overlay");
-    if (logoOverlay) {
-        let pressTimer;
-        let moved = false;
-        const restoreOverlay = () => {
-            logoOverlay.style.display = "block";
-        };
-        const cancel = () => {
-            clearTimeout(pressTimer);
-            document.removeEventListener("mousemove", moveHandler);
-            document.removeEventListener("touchmove", moveHandler);
-            document.removeEventListener("mouseup", cancel);
-            document.removeEventListener("touchend", cancel);
-            document.removeEventListener("touchcancel", cancel);
-            logoOverlay.style.display = "none";
-            setTimeout(restoreOverlay, 1000);
-        };
-        const moveHandler = () => {
-            moved = true;
-            cancel();
-        };
-        const startPress = () => {
-            moved = false;
-            document.addEventListener("mousemove", moveHandler);
-            document.addEventListener("touchmove", moveHandler);
-            document.addEventListener("mouseup", cancel);
-            document.addEventListener("touchend", cancel);
-            document.addEventListener("touchcancel", cancel);
-            pressTimer = setTimeout(() => {
-                if (!moved) {
-                    window.location.href = "index.html";
-                }
-                cancel();
-            }, 600);
-        };
-        logoOverlay.addEventListener("mousedown", startPress);
-        logoOverlay.addEventListener("touchstart", startPress);
-    }
-</script>
+    <script src="cart.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show order summary with toggle and price in checkout form
- redirect cart checkout to new checkout page matching popup styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d0bb532348321bd08cc28f505d3c0