### PR TITLE
Align order summary and match checkout page to popup

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -191,9 +191,9 @@
         }
         .order-summary-bar {
             display: flex;
-            justify-content: space-between;
             align-items: center;
             margin: 10px 0;
+            width: 100%;
         }
         .summary-toggle {
             background: transparent;
@@ -203,12 +203,14 @@
             align-items: center;
             cursor: pointer;
             padding: 0;
+            margin-right: auto;
         }
         .summary-toggle .arrow {
             margin-left: 5px;
         }
         .order-total {
             font-weight: bold;
+            margin-left: auto;
         }
     </style>
 </head>
@@ -233,7 +235,7 @@
         <div><strong>Total</strong><strong class="total">$0.00</strong></div>
     </div>
     <div class="cart-buttons">
-        <button id="cart-checkout">CHECKOUT</button>
+        <button id="cart-checkout" onclick="window.location.href='checkout.html'">CHECKOUT</button>
     </div>
     <div class="or">OR</div>
     <div class="express-checkout">

--- a/cart.js
+++ b/cart.js
@@ -245,10 +245,10 @@ function createCartModal() {
             #cart-modal .logo-container{width:80px;height:80px;margin:0 auto;}
             #cart-modal .logo-container iframe{width:100%;height:100%;border:none;}
             #cart-modal .cart-time{text-align:center;font-size:0.7rem;font-weight:600;margin-top:5px;}
-            #cart-modal .order-summary-bar{display:flex;justify-content:space-between;align-items:center;margin:10px 0;}
-            #cart-modal .summary-toggle{background:transparent;border:none;font-size:1em;display:flex;align-items:center;cursor:pointer;padding:0;}
+            #cart-modal .order-summary-bar{display:flex;align-items:center;margin:10px 0;width:100%;}
+            #cart-modal .summary-toggle{background:transparent;border:none;font-size:1em;display:flex;align-items:center;cursor:pointer;padding:0;margin-right:auto;}
             #cart-modal .summary-toggle .arrow{margin-left:5px;}
-            #cart-modal .order-total{font-weight:bold;}
+            #cart-modal .order-total{font-weight:bold;margin-left:auto;}
         `;
         document.head.appendChild(style);
     }

--- a/checkout.html
+++ b/checkout.html
@@ -14,6 +14,35 @@
             color: #000;
             text-align: center;
         }
+        .header-container {
+            width: 100%;
+            padding: 10px;
+            background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .logo-container {
+            position: static;
+            width: 20vw;
+            height: 20vh;
+        }
+        .time {
+            font-size: 0.7rem;
+            text-align: center;
+            margin-top: 0;
+            font-weight: 600;
+        }
+        iframe {
+            width: 100%;
+            height: 100%;
+            border: none;
+        }
+        .header-line {
+            border-top: 1px solid #000;
+            width: 100%;
+            margin-top: 5px;
+        }
         .cart-buttons {
             display: flex;
             flex-direction: column;
@@ -148,9 +177,9 @@
         }
         .order-summary-bar {
             display: flex;
-            justify-content: space-between;
             align-items: center;
             margin: 10px 0;
+            width: 100%;
         }
         .summary-toggle {
             background: transparent;
@@ -160,16 +189,26 @@
             align-items: center;
             cursor: pointer;
             padding: 0;
+            margin-right: auto;
         }
         .summary-toggle .arrow {
             margin-left: 5px;
         }
         .order-total {
             font-weight: bold;
+            margin-left: auto;
         }
     </style>
 </head>
 <body>
+    <header class="header-container">
+        <div class="logo-container">
+            <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+            <div class="logo-overlay"></div>
+        </div>
+        <div class="time" id="current-time"></div>
+    </header>
+    <div class="header-line"></div>
     <div id="final-checkout">
         <form id="final-form">
             <h2 class="checkout-domain">maybenot.com</h2>
@@ -243,5 +282,59 @@
         </footer>
     </div>
     <script src="cart.js"></script>
+    <script>
+        function updateChicagoTime() {
+            const options = {
+                timeZone: 'America/Chicago',
+                hour: '2-digit',
+                minute: '2-digit',
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+            };
+            const currentTime = new Intl.DateTimeFormat('en-US', options).format(new Date()).replace(",", "");
+            document.getElementById('current-time').textContent = currentTime + " CHICAGO";
+        }
+        updateChicagoTime();
+        setInterval(updateChicagoTime, 1000);
+        const logoOverlay = document.querySelector(".logo-overlay");
+        if (logoOverlay) {
+            let pressTimer;
+            let moved = false;
+            const restoreOverlay = () => {
+                logoOverlay.style.display = "block";
+            };
+            const cancel = () => {
+                clearTimeout(pressTimer);
+                document.removeEventListener("mousemove", moveHandler);
+                document.removeEventListener("touchmove", moveHandler);
+                document.removeEventListener("mouseup", cancel);
+                document.removeEventListener("touchend", cancel);
+                document.removeEventListener("touchcancel", cancel);
+                logoOverlay.style.display = "none";
+                setTimeout(restoreOverlay, 1000);
+            };
+            const moveHandler = () => {
+                moved = true;
+                cancel();
+            };
+            const startPress = () => {
+                moved = false;
+                document.addEventListener("mousemove", moveHandler);
+                document.addEventListener("touchmove", moveHandler);
+                document.addEventListener("mouseup", cancel);
+                document.addEventListener("touchend", cancel);
+                document.addEventListener("touchcancel", cancel);
+                pressTimer = setTimeout(() => {
+                    if (!moved) {
+                        window.location.href = "index.html";
+                    }
+                    cancel();
+                }, 600);
+            };
+            logoOverlay.addEventListener("mousedown", startPress);
+            logoOverlay.addEventListener("touchstart", startPress);
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Align "Order summary" toggles to the left across cart popup, cart page, and checkout page
- Add logo and Chicago clock header to checkout page for consistency with popup
- Ensure cart page checkout button links to new checkout page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689d11124f6883218f738c400401cf11