### PR TITLE
Fix cart remove buttons and center close icon

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -147,7 +147,7 @@
             color: #fff;
             border: none;
             position: absolute;
-            top: -10px;
+            top: 0;
             right: 0;
             cursor: pointer;
             font-size: 0.8rem;
@@ -156,7 +156,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            line-height: 20px;
+            line-height: 1;
             padding: 0;
         }
         .pay-option[data-method="paypal"] img {

--- a/cart.js
+++ b/cart.js
@@ -231,7 +231,7 @@ function createCartModal() {
         style.textContent = `
             #cart-modal {position:fixed;top:0;left:0;right:0;bottom:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,0.5);z-index:1000;}
             #cart-modal .cart-content {background:#fff;padding:20px;max-width:400px;width:90%;text-align:center;position:relative;font-family:sans-serif;max-height:90vh;overflow-y:auto;}
-            #cart-modal .close-btn {position:absolute;top:10px;left:10px;background:#000;color:#fff;border:none;width:20px;height:20px;line-height:20px;padding:0;font-size:14px;cursor:pointer;}
+            #cart-modal .close-btn {position:absolute;top:10px;left:10px;background:#000;color:#fff;border:none;width:20px;height:20px;display:flex;align-items:center;justify-content:center;line-height:1;padding:0;font-size:14px;cursor:pointer;}
             #cart-modal .cart-buttons {display:flex;flex-direction:column;align-items:center;}
             #cart-modal button:not(.pay-btn){background:#000;color:#fff;border:none;padding:10px;margin:5px auto;cursor:pointer;display:block;}
             #cart-modal .pay-btn{background:transparent;border:none;margin:0;padding:0;display:flex;justify-content:center;align-items:center;}
@@ -245,7 +245,7 @@ function createCartModal() {
             #cart-modal .cart-item.no-remove{padding-top:0;}
             #cart-modal .cart-item img{width:50px;height:50px;object-fit:cover;margin-right:10px;}
             #cart-modal .cart-item .cart-item-info{text-align:left;flex:1;}
-            #cart-modal .cart-item .remove-item{background:#000;color:#fff;border:none;position:absolute;top:-10px;right:0;cursor:pointer;font-size:0.8rem;width:20px;height:20px;display:flex;align-items:center;justify-content:center;line-height:20px;padding:0;}
+            #cart-modal .cart-item .remove-item{background:#000;color:#fff;border:none;position:absolute;top:0;right:0;cursor:pointer;font-size:0.8rem;width:20px;height:20px;display:flex;align-items:center;justify-content:center;line-height:1;padding:0;}
             #cart-modal .or {margin:10px 0;}
             #cart-modal footer a {color:#000;margin:0 5px;font-size:0.8em;text-decoration:none;}
             #cart-modal button:not(.pay-btn):hover,#cart-modal button:not(.pay-btn):focus,#cart-modal button:not(.pay-btn):active,#cart-modal footer a:hover,#cart-modal footer a:focus,#cart-modal footer a:active{border:2px solid red;color:red;background:#fff;}
@@ -294,9 +294,9 @@ function populateCartModal() {
         return;
     }
     let total = 0;
-    cart.forEach(item => {
+    cart.forEach((item, index) => {
         const div = document.createElement('div');
-        div.className = 'cart-item no-remove';
+        div.className = 'cart-item';
         div.innerHTML = `
             <img src="${item.image}" alt="${item.name}">
             <div class="cart-item-info">
@@ -305,9 +305,13 @@ function populateCartModal() {
                 ${item.color ? `<div>Color: ${item.color}</div>` : ''}
                 ${item.size ? `<div>Size: ${item.size}</div>` : ''}
             </div>
-            <span>$${parseFloat(item.price).toFixed(2)}</span>`;
+            <span>$${parseFloat(item.price).toFixed(2)}</span>
+            <button class="remove-item" data-index="${index}">&times;</button>`;
         itemsContainer.appendChild(div);
         total += parseFloat(item.price);
+    });
+    itemsContainer.querySelectorAll('.remove-item').forEach(btn => {
+        btn.addEventListener('click', () => removeFromCart(parseInt(btn.dataset.index)));
     });
     modal.querySelector('.item-count').textContent = `${cart.length} Item(s)`;
     modal.querySelector('.subtotal').textContent = `$${total.toFixed(2)}`;


### PR DESCRIPTION
## Summary
- allow items to be removed directly from the cart popup
- center the close (×) icon and item remove buttons in their black squares

## Testing
- `node --check cart.js`


------
https://chatgpt.com/codex/tasks/task_e_689d3857d36483218daf42966ae0bafb