### PR TITLE
Fix product image cropping and add image shadow

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -244,7 +244,7 @@ function createCartModal() {
             #cart-modal .cost-summary div{display:flex;justify-content:space-between;margin:5px 0;}
             #cart-modal .cart-item{display:flex;align-items:center;justify-content:space-between;margin:5px 0;position:relative;padding-top:10px;}
             #cart-modal .cart-item.no-remove{padding-top:0;}
-            #cart-modal .cart-item img{width:50px;height:50px;object-fit:cover;margin-right:10px;}
+            #cart-modal .cart-item img{width:50px;height:50px;object-fit:contain;margin-right:10px;box-shadow:0 4px 8px rgba(0,0,0,0.1);}
             #cart-modal .cart-item .cart-item-info{text-align:left;flex:1;}
             #cart-modal .cart-item .remove-item{background:#000;color:#fff;border:none;position:absolute;top:0;right:0;cursor:pointer;font-size:0.8rem;width:20px;height:20px;display:flex;align-items:center;justify-content:center;line-height:1;padding:0;}
             #cart-modal .or {margin:10px 0;}
@@ -651,7 +651,7 @@ function ensureCartCounter() {
     if (!document.getElementById('cart-counter-style')) {
         const style = document.createElement('style');
         style.id = 'cart-counter-style';
-        style.textContent = '.cart-counter{font-size:0.7rem;text-align:center;font-weight:600;cursor:pointer;}.header-line{border-top:1px solid #000;width:100%;}.product-item img{width:300px;height:450px;object-fit:contain;}.payment-icons{display:grid;grid-template-columns:repeat(3,1fr);gap:5px;justify-items:center;margin:10px 0;}.pay-option{background:transparent;border:2px solid transparent;padding:5px;cursor:pointer;display:flex;align-items:center;justify-content:center;}.pay-option.selected{border-color:#000;}.pay-option.shop-pay span{margin-left:5px;font-size:0.8em;}.pay-btn.paypal{background:#ffc439;width:80px;height:40px;padding:0;}.pay-btn.paypal img{width:100%;height:100%;object-fit:contain;}.pay-option[data-method="paypal"] img{width:60px;}.redirect-icon{text-align:center;font-size:2rem;}.paypal-inline{height:1em;vertical-align:middle;filter:invert(1);}.empty-cart-message{text-align:center;}';
+        style.textContent = '.cart-counter{font-size:0.7rem;text-align:center;font-weight:600;cursor:pointer;}.header-line{border-top:1px solid #000;width:100%;}.product-item{aspect-ratio:2/3;}.product-item img{width:100%;height:100%;object-fit:contain;box-shadow:0 4px 8px rgba(0,0,0,0.1);}.payment-icons{display:grid;grid-template-columns:repeat(3,1fr);gap:5px;justify-items:center;margin:10px 0;}.pay-option{background:transparent;border:2px solid transparent;padding:5px;cursor:pointer;display:flex;align-items:center;justify-content:center;}.pay-option.selected{border-color:#000;}.pay-option.shop-pay span{margin-left:5px;font-size:0.8em;}.pay-btn.paypal{background:#ffc439;width:80px;height:40px;padding:0;}.pay-btn.paypal img{width:100%;height:100%;object-fit:contain;}.pay-option[data-method="paypal"] img{width:60px;}.redirect-icon{text-align:center;font-size:2rem;}.paypal-inline{height:1em;vertical-align:middle;filter:invert(1);}.empty-cart-message{text-align:center;}';
         document.head.appendChild(style);
     }
 }


### PR DESCRIPTION
## Summary
- Prevent product images from cropping by overriding global styles and increasing aspect ratio
- Add consistent drop shadow around product images across the site

## Testing
- `node --check cart.js`
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689d421935a8832187405e4702687b8f