### PR TITLE
Center cart X buttons and refine product image shadows

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -135,8 +135,9 @@
         .cart-item img {
             width: 50px;
             height: 50px;
-            object-fit: cover;
+            object-fit: contain;
             margin-right: 10px;
+            filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.1));
         }
         .cart-item-info {
             text-align: left;
@@ -158,6 +159,7 @@
             justify-content: center;
             line-height: 1;
             padding: 0;
+            text-align: center;
         }
         .pay-option[data-method="paypal"] img {
             width: 60px;

--- a/cart.js
+++ b/cart.js
@@ -232,7 +232,7 @@ function createCartModal() {
         style.textContent = `
             #cart-modal {position:fixed;top:0;left:0;right:0;bottom:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,0.5);z-index:1000;}
             #cart-modal .cart-content {background:#fff;padding:20px;max-width:400px;width:90%;text-align:center;position:relative;font-family:sans-serif;max-height:90vh;overflow-y:auto;}
-            #cart-modal .close-btn {position:absolute;top:10px;left:10px;background:#000;color:#fff;border:none;width:20px;height:20px;display:flex;align-items:center;justify-content:center;line-height:1;padding:0;font-size:14px;cursor:pointer;}
+            #cart-modal .close-btn {position:absolute;top:10px;left:10px;background:#000;color:#fff;border:none;width:20px;height:20px;display:flex;align-items:center;justify-content:center;text-align:center;line-height:1;padding:0;font-size:14px;cursor:pointer;}
             #cart-modal .cart-buttons {display:flex;flex-direction:column;align-items:center;}
             #cart-modal button:not(.pay-btn){background:#000;color:#fff;border:none;padding:10px;margin:5px auto;cursor:pointer;display:block;}
             #cart-modal .pay-btn{background:transparent;border:none;margin:0;padding:0;display:flex;justify-content:center;align-items:center;}
@@ -244,9 +244,9 @@ function createCartModal() {
             #cart-modal .cost-summary div{display:flex;justify-content:space-between;margin:5px 0;}
             #cart-modal .cart-item{display:flex;align-items:center;justify-content:space-between;margin:5px 0;position:relative;padding-top:10px;}
             #cart-modal .cart-item.no-remove{padding-top:0;}
-            #cart-modal .cart-item img{width:50px;height:50px;object-fit:contain;margin-right:10px;box-shadow:0 4px 8px rgba(0,0,0,0.1);}
+            #cart-modal .cart-item img{width:50px;height:50px;object-fit:contain;margin-right:10px;filter:drop-shadow(0 4px 8px rgba(0,0,0,0.1));}
             #cart-modal .cart-item .cart-item-info{text-align:left;flex:1;}
-            #cart-modal .cart-item .remove-item{background:#000;color:#fff;border:none;position:absolute;top:0;right:0;cursor:pointer;font-size:14px;width:20px;height:20px;display:flex;align-items:center;justify-content:center;line-height:1;padding:0;}
+            #cart-modal .cart-item .remove-item{background:#000;color:#fff;border:none;position:absolute;top:0;right:0;cursor:pointer;font-size:14px;width:20px;height:20px;display:flex;align-items:center;justify-content:center;text-align:center;line-height:1;padding:0;}
             #cart-modal .or {margin:10px 0;}
             #cart-modal footer a {color:#000;margin:0 5px;font-size:0.8em;text-decoration:none;}
             #cart-modal button:not(.pay-btn):hover,#cart-modal button:not(.pay-btn):focus,#cart-modal button:not(.pay-btn):active,#cart-modal footer a:hover,#cart-modal footer a:focus,#cart-modal footer a:active{border:2px solid red;color:red;background:#fff;}
@@ -653,7 +653,7 @@ function ensureCartCounter() {
     if (!document.getElementById('cart-counter-style')) {
         const style = document.createElement('style');
         style.id = 'cart-counter-style';
-        style.textContent = '.cart-counter{font-size:0.7rem;text-align:center;font-weight:600;cursor:pointer;}.header-line{border-top:1px solid #000;width:100%;}.product-item{aspect-ratio:2/3;}.product-item img{width:100%;height:100%;object-fit:contain;box-shadow:0 4px 8px rgba(0,0,0,0.1);}.payment-icons{display:grid;grid-template-columns:repeat(3,1fr);gap:5px;justify-items:center;margin:10px 0;}.pay-option{background:transparent;border:2px solid transparent;padding:5px;cursor:pointer;display:flex;align-items:center;justify-content:center;}.pay-option.selected{border-color:#000;}.pay-option.shop-pay span{margin-left:5px;font-size:0.8em;}.pay-btn.paypal{background:#ffc439;width:80px;height:40px;padding:0;}.pay-btn.paypal img{width:100%;height:100%;object-fit:contain;}.pay-option[data-method="paypal"] img{width:60px;}.redirect-icon{text-align:center;font-size:2rem;}.paypal-inline{height:1em;vertical-align:middle;filter:invert(1);}.empty-cart-message{text-align:center;}';
+        style.textContent = '.cart-counter{font-size:0.7rem;text-align:center;font-weight:600;cursor:pointer;}.header-line{border-top:1px solid #000;width:100%;}.product-item{aspect-ratio:2/3;}.product-item img{width:100%;height:100%;object-fit:contain;filter:drop-shadow(0 4px 8px rgba(0,0,0,0.1));}.payment-icons{display:grid;grid-template-columns:repeat(3,1fr);gap:5px;justify-items:center;margin:10px 0;}.pay-option{background:transparent;border:2px solid transparent;padding:5px;cursor:pointer;display:flex;align-items:center;justify-content:center;}.pay-option.selected{border-color:#000;}.pay-option.shop-pay span{margin-left:5px;font-size:0.8em;}.pay-btn.paypal{background:#ffc439;width:80px;height:40px;padding:0;}.pay-btn.paypal img{width:100%;height:100%;object-fit:contain;}.pay-option[data-method="paypal"] img{width:60px;}.redirect-icon{text-align:center;font-size:2rem;}.paypal-inline{height:1em;vertical-align:middle;filter:invert(1);}.empty-cart-message{text-align:center;}';
         document.head.appendChild(style);
     }
 }


### PR DESCRIPTION
## Summary
- Centered cart close and remove buttons using a shared layout to keep the “x” glyph centered
- Switched product image styling to `filter: drop-shadow` so shadows follow PNG contours

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d473f5a988321b58598191d10eae6