### PR TITLE
Align order summary toggle with item list

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -229,6 +229,7 @@
             cursor: pointer;
             padding: 0;
             margin: 0;
+            margin-left: -10px;
         }
         .summary-toggle .arrow {
             margin-left: 5px;

--- a/cart.js
+++ b/cart.js
@@ -260,7 +260,7 @@ function createCartModal() {
             #cart-modal .logo-container iframe{width:100%;height:100%;border:none;}
             #cart-modal .cart-time{text-align:center;font-size:0.7rem;font-weight:600;margin-top:5px;}
             #cart-modal .order-summary-bar{display:flex;align-items:center;justify-content:space-between;margin:10px 0;width:100%;}
-            #cart-modal .summary-toggle{background:transparent;border:none;font-size:1em;display:flex;align-items:center;cursor:pointer;padding:0;margin:0;}
+            #cart-modal .summary-toggle{background:transparent;border:none;font-size:1em;display:flex;align-items:center;cursor:pointer;padding:0;margin:0;margin-left:-10px;}
             #cart-modal .summary-toggle .arrow{margin-left:5px;}
             #cart-modal .order-total{font-weight:bold;margin:0;}
         `;

--- a/checkout.html
+++ b/checkout.html
@@ -191,6 +191,7 @@
             cursor: pointer;
             padding: 0;
             margin: 0;
+            margin-left: -10px;
         }
         .summary-toggle .arrow {
             margin-left: 5px;


### PR DESCRIPTION
## Summary
- Shift order summary dropdown button left to line up with product list on cart and checkout pages
- Ensure cart modal uses the same left alignment for its summary toggle

## Testing
- `node --check cart.js`

------
https://chatgpt.com/codex/tasks/task_e_689d4b903e848321b7e047826d48fb2f