### PR TITLE
Lift logo and tighten clock spacing

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -21,7 +21,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/all.html
+++ b/all.html
@@ -21,7 +21,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/americandenim.html
+++ b/americandenim.html
@@ -20,7 +20,7 @@
         }
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -49,7 +49,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
         .header-line {

--- a/bags.html
+++ b/bags.html
@@ -21,7 +21,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/cart.html
+++ b/cart.html
@@ -16,7 +16,7 @@
         }
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -30,7 +30,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
         iframe {

--- a/category_template.html
+++ b/category_template.html
@@ -21,7 +21,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/checkout.html
+++ b/checkout.html
@@ -16,7 +16,7 @@
         }
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -30,7 +30,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
         iframe {

--- a/gym.html
+++ b/gym.html
@@ -21,7 +21,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/hat.html
+++ b/hat.html
@@ -20,7 +20,7 @@
         }
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -49,7 +49,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
         .header-line {

--- a/hats.html
+++ b/hats.html
@@ -21,7 +21,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/hoodie.html
+++ b/hoodie.html
@@ -8,11 +8,11 @@
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; height:100%; display:flex; flex-direction:column; align-items:center; }
-        .header-container { width:100%; padding:10px; background-color:#f7f7f7; display:flex; flex-direction:column; align-items:center; }
+        .header-container { width:100%; padding: 5px 10px 10px; background-color:#f7f7f7; display:flex; flex-direction:column; align-items:center; }
         .logo-container { position:static; width:20vw; height:20vh; margin-top:0; }
         .logo-overlay { position:absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
         iframe { width:100%; height:100%; border:none; }
-        .time { font-size:0.7rem; text-align:center; margin-top: 0; font-weight:600; }
+        .time { font-size:0.7rem; text-align:center; margin-top: -5px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
         .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
         /* Mobile Navigation */

--- a/jackets.html
+++ b/jackets.html
@@ -21,7 +21,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/joggers.html
+++ b/joggers.html
@@ -8,11 +8,11 @@
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; height:100%; display:flex; flex-direction:column; align-items:center; }
-        .header-container { width:100%; padding:10px; background-color:#f7f7f7; display:flex; flex-direction:column; align-items:center; }
+        .header-container { width:100%; padding: 5px 10px 10px; background-color:#f7f7f7; display:flex; flex-direction:column; align-items:center; }
         .logo-container { position:static; width:20vw; height:20vh; margin-top:0; }
         .logo-overlay { position:absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
         iframe { width:100%; height:100%; border:none; }
-        .time { font-size:0.7rem; text-align:center; margin-top: 0; font-weight:600; }
+        .time { font-size:0.7rem; text-align:center; margin-top: -5px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
         .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
         /* Mobile Navigation */

--- a/new.html
+++ b/new.html
@@ -21,7 +21,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/pants.html
+++ b/pants.html
@@ -21,7 +21,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/shirt.html
+++ b/shirt.html
@@ -20,7 +20,7 @@
         }
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -49,7 +49,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
         .header-line {

--- a/shirts.html
+++ b/shirts.html
@@ -21,7 +21,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/shoes.html
+++ b/shoes.html
@@ -21,7 +21,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/shop.html
+++ b/shop.html
@@ -29,7 +29,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -63,7 +63,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/shorts.html
+++ b/shorts.html
@@ -20,7 +20,7 @@
         }
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -29,7 +29,7 @@
         .logo-container { position: static; width: 20vw; height: 20vh; margin-top: 0; }
         .logo-overlay { position: absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
         iframe { width:100%; height:100%; border:none; }
-        .time { font-size:0.7rem; text-align:center; margin-top: 0; font-weight:600; }
+        .time { font-size:0.7rem; text-align:center; margin-top: -5px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
         .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
         /* Mobile Navigation */

--- a/skate.html
+++ b/skate.html
@@ -21,7 +21,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/soon.html
+++ b/soon.html
@@ -28,7 +28,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7; /* Off-white background color for mobile header */
         }
 
@@ -62,7 +62,7 @@
                 .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -21,7 +21,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -21,7 +21,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -21,7 +21,7 @@
 
         .header-container {
             width: 100%;
-            padding: 10px;
+            padding: 5px 10px 10px;
             background-color: #f7f7f7;
             display: flex;
             flex-direction: column;
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
         }
 


### PR DESCRIPTION
## Summary
- Move logo closer to top by trimming header padding across non-index pages
- Reduce gap between logo and clock for a tighter header layout

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689d5059c2548321b6de249de8edcb32