### PR TITLE
Tighten header spacing and align cart controls

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -31,7 +31,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 

--- a/all.html
+++ b/all.html
@@ -31,7 +31,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 

--- a/americandenim.html
+++ b/americandenim.html
@@ -29,7 +29,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
         .logo-overlay {
@@ -49,7 +49,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
         .header-line {

--- a/bags.html
+++ b/bags.html
@@ -31,7 +31,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 

--- a/cart.html
+++ b/cart.html
@@ -25,12 +25,12 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
         }
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
         iframe {
@@ -158,6 +158,7 @@
             align-items: center;
             justify-content: center;
             padding: 0;
+            line-height: 20px;
             text-align: center;
         }
         .pay-option[data-method="paypal"] img {
@@ -228,7 +229,7 @@
             cursor: pointer;
             padding: 0;
             margin: 0;
-            margin-left: -20px;
+            margin-left: 0;
         }
         .summary-toggle .arrow {
             margin-left: 5px;

--- a/cart.js
+++ b/cart.js
@@ -232,7 +232,7 @@ function createCartModal() {
         style.textContent = `
             #cart-modal {position:fixed;top:0;left:0;right:0;bottom:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,0.5);z-index:1000;}
             #cart-modal .cart-content {background:#fff;padding:20px;max-width:400px;width:90%;text-align:center;position:relative;font-family:sans-serif;max-height:90vh;overflow-y:auto;}
-            #cart-modal .close-btn {position:absolute;top:10px;left:10px;background:#000;color:#fff;border:none;width:20px;height:20px;display:flex;align-items:center;justify-content:center;text-align:center;padding:0;font-size:14px;cursor:pointer;}
+            #cart-modal .close-btn {position:absolute;top:10px;left:10px;background:#000;color:#fff;border:none;width:20px;height:20px;display:flex;align-items:center;justify-content:center;text-align:center;padding:0;font-size:14px;line-height:20px;cursor:pointer;}
             #cart-modal .cart-buttons {display:flex;flex-direction:column;align-items:center;}
             #cart-modal button:not(.pay-btn){background:#000;color:#fff;border:none;padding:10px;margin:5px auto;cursor:pointer;display:block;}
             #cart-modal .pay-btn{background:transparent;border:none;margin:0;padding:0;display:flex;justify-content:center;align-items:center;}
@@ -246,7 +246,7 @@ function createCartModal() {
             #cart-modal .cart-item.no-remove{padding-top:0;}
             #cart-modal .cart-item img{width:50px;height:50px;object-fit:contain;margin-right:10px;filter:drop-shadow(0 4px 8px rgba(0,0,0,0.1));}
             #cart-modal .cart-item .cart-item-info{text-align:left;flex:1;}
-            #cart-modal .cart-item .remove-item{background:#000;color:#fff;border:none;position:absolute;top:0;right:0;cursor:pointer;font-size:14px;width:20px;height:20px;display:flex;align-items:center;justify-content:center;text-align:center;padding:0;}
+            #cart-modal .cart-item .remove-item{background:#000;color:#fff;border:none;position:absolute;top:0;right:0;cursor:pointer;font-size:14px;width:20px;height:20px;display:flex;align-items:center;justify-content:center;text-align:center;padding:0;line-height:20px;}
             #cart-modal .or {margin:10px 0;}
             #cart-modal footer a {color:#000;margin:0 5px;font-size:0.8em;text-decoration:none;}
             #cart-modal button:not(.pay-btn):hover,#cart-modal button:not(.pay-btn):focus,#cart-modal button:not(.pay-btn):active,#cart-modal footer a:hover,#cart-modal footer a:focus,#cart-modal footer a:active{border:2px solid red;color:red;background:#fff;}
@@ -260,7 +260,7 @@ function createCartModal() {
             #cart-modal .logo-container iframe{width:100%;height:100%;border:none;}
             #cart-modal .cart-time{text-align:center;font-size:0.7rem;font-weight:600;margin-top:5px;}
             #cart-modal .order-summary-bar{display:flex;align-items:center;justify-content:space-between;margin:10px 0;width:100%;}
-            #cart-modal .summary-toggle{background:transparent;border:none;font-size:1em;display:flex;align-items:center;cursor:pointer;padding:0;margin:0;margin-left:-20px;}
+            #cart-modal .summary-toggle{background:transparent;border:none;font-size:1em;display:flex;align-items:center;cursor:pointer;padding:0;margin:0;margin-left:0;}
             #cart-modal .summary-toggle .arrow{margin-left:5px;}
             #cart-modal .order-total{font-weight:bold;margin:0;}
         `;

--- a/category_template.html
+++ b/category_template.html
@@ -31,7 +31,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 

--- a/checkout.html
+++ b/checkout.html
@@ -25,12 +25,12 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
         }
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
         iframe {
@@ -191,7 +191,7 @@
             cursor: pointer;
             padding: 0;
             margin: 0;
-            margin-left: -20px;
+            margin-left: 0;
         }
         .summary-toggle .arrow {
             margin-left: 5px;

--- a/gym.html
+++ b/gym.html
@@ -31,7 +31,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 

--- a/hat.html
+++ b/hat.html
@@ -29,7 +29,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
         .logo-overlay {
@@ -49,7 +49,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
         .header-line {

--- a/hats.html
+++ b/hats.html
@@ -31,7 +31,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 

--- a/hoodie.html
+++ b/hoodie.html
@@ -12,7 +12,7 @@
         .logo-container { position:static; width:20vw; height:20vh; margin-top:0; }
         .logo-overlay { position:absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
         iframe { width:100%; height:100%; border:none; }
-        .time { font-size:0.7rem; text-align:center; margin-top: -10px; font-weight:600; }
+        .time { font-size:0.7rem; text-align:center; margin-top: -15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
         .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
         /* Mobile Navigation */

--- a/jackets.html
+++ b/jackets.html
@@ -31,7 +31,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 

--- a/joggers.html
+++ b/joggers.html
@@ -12,7 +12,7 @@
         .logo-container { position:static; width:20vw; height:20vh; margin-top:0; }
         .logo-overlay { position:absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
         iframe { width:100%; height:100%; border:none; }
-        .time { font-size:0.7rem; text-align:center; margin-top: -10px; font-weight:600; }
+        .time { font-size:0.7rem; text-align:center; margin-top: -15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
         .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
         /* Mobile Navigation */

--- a/new.html
+++ b/new.html
@@ -31,7 +31,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 

--- a/pants.html
+++ b/pants.html
@@ -31,7 +31,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 

--- a/shirt.html
+++ b/shirt.html
@@ -29,7 +29,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
         .logo-overlay {
@@ -49,7 +49,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
         .header-line {

--- a/shirts.html
+++ b/shirts.html
@@ -31,7 +31,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 

--- a/shoes.html
+++ b/shoes.html
@@ -31,7 +31,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 

--- a/shop.html
+++ b/shop.html
@@ -39,7 +39,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -63,7 +63,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 
@@ -259,7 +259,7 @@
                 left: 50%;
                 transform: translateX(-50%);
                 width: 20vw;
-                height: 20vh;
+                height: 15vh;
             }
 
             .time {
@@ -311,7 +311,7 @@
             transform: none;
             margin-top: 0;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
         }
         .time {
             margin-top: 10px;

--- a/shorts.html
+++ b/shorts.html
@@ -26,10 +26,10 @@
             flex-direction: column;
             align-items: center;
         }
-        .logo-container { position: static; width: 20vw; height: 20vh; margin-top: 0; }
+        .logo-container { position: static; width: 20vw; height: 15vh; margin-top: 0; }
         .logo-overlay { position: absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
         iframe { width:100%; height:100%; border:none; }
-        .time { font-size:0.7rem; text-align:center; margin-top: -10px; font-weight:600; }
+        .time { font-size:0.7rem; text-align:center; margin-top: -15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
         .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
         /* Mobile Navigation */

--- a/skate.html
+++ b/skate.html
@@ -31,7 +31,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 

--- a/soon.html
+++ b/soon.html
@@ -38,7 +38,7 @@
             left: 50%;
             transform: translateX(-50%);
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: -40px;
         }
 
@@ -62,7 +62,7 @@
                 .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 
@@ -185,7 +185,7 @@
             left: 50%;
             transform: translateX(-50%);
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: -40px;
         }
 
@@ -254,7 +254,7 @@
             transform: none;
             margin-top: 0;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
         }
         .time {
             margin-top: 0;

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -31,7 +31,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -31,7 +31,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -31,7 +31,7 @@
         .logo-container {
             position: static;
             width: 20vw;
-            height: 20vh;
+            height: 15vh;
             margin-top: 0;
         }
 
@@ -55,7 +55,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -10px;
+            margin-top: -15px;
             font-weight: 600;
         }
 


### PR DESCRIPTION
## Summary
- Shift site logos upward and reduce clock spacing across pages for a tighter header.
- Center cart pop-up close button and item removal icons.
- Align order summary toggles with product listings in cart and checkout views.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d578ca9888321b118847db905c531