### PR TITLE
Improve mobile image and checkout button highlighting

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -200,6 +200,10 @@ function createCartModal() {
     });
     modal.querySelector('#cart-checkout').addEventListener('click', () => showCheckoutForm(modal));
     modal.querySelectorAll('.pay-btn').forEach(btn => {
+        btn.addEventListener('pointerdown', () => {
+            modal.querySelectorAll('.pay-btn').forEach(b => b.classList.remove('selected'));
+            btn.classList.add('selected');
+        });
         btn.addEventListener('click', () => {
             alert(`${btn.dataset.method} payment not implemented.`);
         });
@@ -584,6 +588,10 @@ function setupCartPage() {
         window.location.href = 'checkout.html';
     });
     page.querySelectorAll('.pay-btn').forEach(btn => {
+        btn.addEventListener('pointerdown', () => {
+            page.querySelectorAll('.pay-btn').forEach(b => b.classList.remove('selected'));
+            btn.classList.add('selected');
+        });
         btn.addEventListener('click', () => {
             alert(`${btn.dataset.method} payment not implemented.`);
         });
@@ -655,7 +663,7 @@ function ensureCartCounter() {
     if (!document.getElementById('cart-counter-style')) {
         const style = document.createElement('style');
         style.id = 'cart-counter-style';
-        style.textContent = '.cart-counter{font-size:0.7rem;text-align:center;font-weight:600;cursor:pointer;display:inline-block;outline:2px solid transparent;padding:2px;} .cart-counter:hover,.cart-counter:focus,.cart-counter:active{outline-color:red;} .header-line{border-top:1px solid #000;width:100%;} .product-item{aspect-ratio:1/1;} .product-item img{width:100%;height:100%;object-fit:contain;filter:drop-shadow(0 4px 8px rgba(0,0,0,0.1));} .product-item a:hover img,.product-item a:focus img,.product-item a:active img{outline:2px solid red;} .payment-icons{display:grid;grid-template-columns:repeat(3,1fr);gap:5px;justify-items:center;margin:10px 0;} .pay-option{background:transparent;border:2px solid transparent;padding:5px;cursor:pointer;display:flex;align-items:center;justify-content:center;} .pay-option:hover,.pay-option:focus,.pay-option:active,.pay-option.selected{border-color:red;} .pay-option.shop-pay span{margin-left:5px;font-size:0.8em;} .pay-btn.paypal{background:#ffc439;width:80px;height:40px;padding:0;} .pay-btn.paypal img{width:100%;height:100%;object-fit:contain;} .pay-option[data-method="paypal"] img{width:60px;} .redirect-icon{text-align:center;font-size:2rem;} .paypal-inline{height:1em;vertical-align:middle;filter:invert(1);} .empty-cart-message{text-align:center;}';
+        style.textContent = '.cart-counter{font-size:0.7rem;text-align:center;font-weight:600;cursor:pointer;display:inline-block;outline:2px solid transparent;padding:2px;} .cart-counter:hover,.cart-counter:focus,.cart-counter:active{outline-color:red;} .header-line{border-top:1px solid #000;width:100%;} .product-item{aspect-ratio:1/1;} .product-item img{width:100%;height:100%;object-fit:contain;filter:drop-shadow(0 4px 8px rgba(0,0,0,0.1));} .product-item a:hover img,.product-item a:focus img,.product-item a:active img{outline:2px solid red;} .payment-icons{display:grid;grid-template-columns:repeat(3,1fr);gap:5px;justify-items:center;margin:10px 0;} .pay-option{background:transparent;border:2px solid transparent;padding:5px;cursor:pointer;display:flex;align-items:center;justify-content:center;} .pay-option:hover,.pay-option:focus,.pay-option:active,.pay-option.selected{border-color:red;} .pay-option.shop-pay span{margin-left:5px;font-size:0.8em;} .pay-btn{outline:2px solid transparent;} .pay-btn:hover,.pay-btn:focus,.pay-btn:active,.pay-btn.selected{outline-color:red;} .pay-btn.paypal{background:#ffc439;width:80px;height:40px;padding:0;} .pay-btn.paypal img{width:100%;height:100%;object-fit:contain;} .pay-option[data-method="paypal"] img{width:60px;} .redirect-icon{text-align:center;font-size:2rem;} .paypal-inline{height:1em;vertical-align:middle;filter:invert(1);} .empty-cart-message{text-align:center;}';
         document.head.appendChild(style);
     }
 }

--- a/product.js
+++ b/product.js
@@ -12,8 +12,8 @@ function initSliders() {
       img.style.width = '100%';
       img.style.height = '100%';
       img.style.objectFit = 'contain';
-      // allow clicking the image to toggle a persistent red highlight
-      img.addEventListener('click', () => {
+      // allow tapping or clicking the image to toggle a persistent red highlight
+      img.addEventListener('pointerdown', () => {
         img.classList.toggle('selected');
       });
     }
@@ -159,6 +159,7 @@ document.addEventListener('DOMContentLoaded', () => {
       object-fit:cover;
     }
     .image-slider img:hover,
+    .image-slider img:active,
     .image-slider img.selected {
       border:2px solid red;
       box-sizing:border-box;


### PR DESCRIPTION
## Summary
- Ensure product images highlight on mobile tap by listening to pointer events and handling :active styles
- Add red-outline hover/click feedback for express checkout payment buttons

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `node --check product.js`
- `node --check cart.js`


------
https://chatgpt.com/codex/tasks/task_e_689de8252788832196e19740c9c3169b