### PR TITLE
Align order summary toggle with product thumbnail

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -264,7 +264,7 @@ function createCartModal() {
             #cart-modal .logo-container iframe{width:100%;height:100%;border:none;}
             #cart-modal .cart-time{text-align:center;font-size:0.7rem;font-weight:600;margin-top:5px;}
             #cart-modal .order-summary-bar{display:flex;align-items:center;justify-content:space-between;margin:10px 0;width:100%;}
-            #cart-modal .summary-toggle{background:transparent;border:none;font-size:1em;display:flex;align-items:center;cursor:pointer;padding:0;margin:0;}
+            #cart-modal .summary-toggle{background:transparent;border:none;font-size:1em;display:flex;align-items:center;cursor:pointer;padding:0;margin:0;margin-left:-10px;}
             #cart-modal .summary-toggle .arrow{margin-left:5px;}
             #cart-modal .order-total{font-weight:bold;margin:0;}
         `;

--- a/checkout.html
+++ b/checkout.html
@@ -191,6 +191,7 @@
             cursor: pointer;
             padding: 0;
             margin: 0;
+            margin-left: -10px;
         }
         .summary-toggle .arrow {
             margin-left: 5px;


### PR DESCRIPTION
## Summary
- Shift checkout page order summary toggle left to align with product thumbnails.
- Adjust pop-up checkout form styles so summary toggle aligns with mini product images.

## Testing
- `node --check cart.js`
- `tidy -e checkout.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eb714de8c83218f0dcf53c06103fb