### PR TITLE
Move order summary toggle further left

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -231,7 +231,7 @@
             cursor: pointer;
             padding: 0;
             margin: 0;
-            margin-left: -10px;
+            margin-left: -20px;
         }
         .summary-toggle .arrow {
             margin-left: 5px;

--- a/cart.js
+++ b/cart.js
@@ -264,7 +264,7 @@ function createCartModal() {
             #cart-modal .logo-container iframe{width:100%;height:100%;border:none;}
             #cart-modal .cart-time{text-align:center;font-size:0.7rem;font-weight:600;margin-top:5px;}
             #cart-modal .order-summary-bar{display:flex;align-items:center;justify-content:space-between;margin:10px 0;width:100%;}
-            #cart-modal .summary-toggle{background:transparent;border:none;font-size:1em;display:flex;align-items:center;cursor:pointer;padding:0;margin:0;margin-left:-10px;}
+            #cart-modal .summary-toggle{background:transparent;border:none;font-size:1em;display:flex;align-items:center;cursor:pointer;padding:0;margin:0;margin-left:-20px;}
             #cart-modal .summary-toggle .arrow{margin-left:5px;}
             #cart-modal .order-total{font-weight:bold;margin:0;}
         `;

--- a/checkout.html
+++ b/checkout.html
@@ -191,7 +191,7 @@
             cursor: pointer;
             padding: 0;
             margin: 0;
-            margin-left: -10px;
+            margin-left: -20px;
         }
         .summary-toggle .arrow {
             margin-left: 5px;


### PR DESCRIPTION
## Summary
- Align order summary toggle with product thumbnails by shifting it 20px left on checkout page and cart modal.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689eba32f1c88321bb3a95b091532287