### PR TITLE
Align order summary toggle with product thumbnails

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -218,7 +218,6 @@
         .order-summary-bar {
             display: flex;
             align-items: center;
-            justify-content: space-between;
             margin: 10px 0;
             width: 100%;
         }
@@ -239,6 +238,7 @@
         .order-total {
             font-weight: bold;
             margin: 0;
+            margin-left: auto;
         }
 
         .full-site-link {

--- a/cart.js
+++ b/cart.js
@@ -263,10 +263,10 @@ function createCartModal() {
             #cart-modal .logo-container{width:80px;height:80px;margin:0 auto;}
             #cart-modal .logo-container iframe{width:100%;height:100%;border:none;}
             #cart-modal .cart-time{text-align:center;font-size:0.7rem;font-weight:600;margin-top:5px;}
-            #cart-modal .order-summary-bar{display:flex;align-items:center;justify-content:space-between;margin:10px 0;width:100%;}
+            #cart-modal .order-summary-bar{display:flex;align-items:center;margin:10px 0;width:100%;}
             #cart-modal .summary-toggle{background:transparent;border:none;font-size:1em;display:flex;align-items:center;cursor:pointer;padding:0;margin:0;margin-left:0;}
             #cart-modal .summary-toggle .arrow{margin-left:5px;}
-            #cart-modal .order-total{font-weight:bold;margin:0;}
+            #cart-modal .order-total{font-weight:bold;margin:0;margin-left:auto;}
         `;
         document.head.appendChild(style);
     }

--- a/checkout.html
+++ b/checkout.html
@@ -178,7 +178,6 @@
         .order-summary-bar {
             display: flex;
             align-items: center;
-            justify-content: space-between;
             margin: 10px 0;
             width: 100%;
         }
@@ -199,6 +198,7 @@
         .order-total {
             font-weight: bold;
             margin: 0;
+            margin-left: auto;
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- Align order summary dropdown button to the left by removing space-between justification and using auto margins on totals in checkout and cart pages
- Apply the same left alignment to the cart modal's order summary toggle styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f207b55c883219e15dec8017ba64e