### PR TITLE
Left align order summary toggle

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -218,6 +218,7 @@
         .order-summary-bar {
             display: flex;
             align-items: center;
+            justify-content: space-between;
             margin: 10px 0;
             width: 100%;
         }
@@ -232,6 +233,8 @@
             padding: 0;
             margin: 0;
             margin-left: 0;
+            flex-grow: 1;
+            text-align: left;
         }
         .summary-toggle .arrow {
             margin-left: 5px;

--- a/checkout.html
+++ b/checkout.html
@@ -178,6 +178,7 @@
         .order-summary-bar {
             display: flex;
             align-items: center;
+            justify-content: space-between;
             margin: 10px 0;
             width: 100%;
         }
@@ -192,6 +193,8 @@
             padding: 0;
             margin: 0;
             margin-left: 0;
+            flex-grow: 1;
+            text-align: left;
         }
         .summary-toggle .arrow {
             margin-left: 5px;


### PR DESCRIPTION
## Summary
- Left-align the order summary dropdown toggle with product thumbnails on checkout and cart pages
- Expand toggle using flexbox and space-between layout so order total stays right while toggle text starts at the left

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f2a56305c8321864ca5a4f289c9d3