### PR TITLE
Limit cart and checkout footers to desktop-only links

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -230,7 +230,7 @@
             background-color: white;
         }
 
-        .footer-line.desktop-only {
+        .desktop-only {
             display: none;
         }
         #checkout-form input {
@@ -328,6 +328,9 @@
             }
             .footer-links {
                 padding-bottom: 30px;
+            }
+            .desktop-only {
+                display: block;
             }
             .footer-line.desktop-only {
                 display: flex;
@@ -455,29 +458,15 @@
 </div>
 <footer>
     <div class="footer-links">
-        <div class="footer-line extra-padding">
+        <div class="footer-line extra-padding desktop-only">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
             <a href="soon.html">news</a>
         </div>
-        <div class="footer-line desktop-only">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
-            <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
-        </div>
-        <div class="footer-line less-padding desktop-only">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
-        </div>
     </div>
-    <div class="cart-footer">
+    <div class="cart-footer desktop-only">
         <a href="#">refund policy</a> |
         <a href="#">shipping</a> |
         <a href="#">privacy policy</a> |

--- a/cart.js
+++ b/cart.js
@@ -186,29 +186,15 @@ function createCartModal() {
             </div>
             <footer>
                 <div class="footer-links">
-                    <div class="footer-line extra-padding">
+                    <div class="footer-line extra-padding desktop-only">
                         <a href="shop.html">shop</a>
                         <a href="all.html">view all</a>
                         <a href="soon.html">preview</a>
                         <a href="soon.html">lookbook</a>
                         <a href="soon.html">news</a>
                     </div>
-                    <div class="footer-line desktop-only">
-                        <a href="soon.html">random</a>
-                        <a href="soon.html">about</a>
-                        <a href="soon.html">stores</a>
-                        <a href="soon.html">sizing</a>
-                        <a href="soon.html">f.a.q.</a>
-                        <a href="soon.html">contact</a>
-                    </div>
-                    <div class="footer-line less-padding desktop-only">
-                        <a href="soon.html">terms</a>
-                        <a href="soon.html">privacy</a>
-                        <a href="soon.html">accessibility</a>
-                        <a href="soon.html">mailing list</a>
-                    </div>
                 </div>
-                <div class="cart-footer">
+                <div class="cart-footer desktop-only">
                     <a href="#">refund policy</a> |
                     <a href="#">shipping</a> |
                     <a href="#">privacy policy</a> |
@@ -296,11 +282,10 @@ function createCartModal() {
             #cart-modal .footer-links{display:flex;justify-content:center;flex-wrap:wrap;gap:15px;background:#fff;}
             #cart-modal .footer-line{display:flex;justify-content:center;flex-wrap:wrap;gap:15px;padding-bottom:10px;}
             #cart-modal .footer-line.extra-padding{padding-bottom:10px;}
-            #cart-modal .footer-line.less-padding{padding-bottom:25px;}
             #cart-modal .footer-links a{color:#000;text-decoration:none;font-size:0.7rem;transition:all 0.3s ease;background:#fff;}
             #cart-modal .footer-links a:hover,#cart-modal .footer-links a:focus,#cart-modal .footer-links a:active{border:2px solid red;color:red;background:#fff;}
-            #cart-modal .footer-line.desktop-only{display:none;}
-            @media (min-width:769px){#cart-modal .footer-line.desktop-only{display:flex;}}
+            #cart-modal .desktop-only{display:none;}
+            @media (min-width:769px){#cart-modal .desktop-only{display:block;}#cart-modal .footer-line.desktop-only{display:flex;}}
         `;
         document.head.appendChild(style);
     }

--- a/checkout.html
+++ b/checkout.html
@@ -193,7 +193,7 @@
             background-color: white;
         }
 
-        .footer-line.desktop-only {
+        .desktop-only {
             display: none;
         }
         .consent-text {
@@ -289,6 +289,9 @@
             .footer-links {
                 padding-bottom: 30px;
             }
+            .desktop-only {
+                display: block;
+            }
             .footer-line.desktop-only {
                 display: flex;
             }
@@ -371,29 +374,15 @@
     </div>
 <footer>
     <div class="footer-links">
-        <div class="footer-line extra-padding">
+        <div class="footer-line extra-padding desktop-only">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
             <a href="soon.html">news</a>
         </div>
-        <div class="footer-line desktop-only">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
-            <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
-        </div>
-        <div class="footer-line less-padding desktop-only">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
-        </div>
     </div>
-    <div class="cart-footer">
+    <div class="cart-footer desktop-only">
         <a href="#">refund policy</a> |
         <a href="#">shipping</a> |
         <a href="#">privacy policy</a> |


### PR DESCRIPTION
## Summary
- Remove extraneous footer entries from cart popup, cart page, and checkout page
- Show "shop" and policy links only on desktop, keeping mobile footer minimal
- Add desktop-only styling to cart modal

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689f36d6ade08321aae1139cee688d70