### PR TITLE
Ensure footer navigation and full site link on cart and checkout pages

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -230,9 +230,6 @@
             background-color: white;
         }
 
-        .desktop-only {
-            display: none;
-        }
         #checkout-form input {
             display: block;
             width: 90%;
@@ -290,23 +287,14 @@
 
         .full-site-link {
             display: none;
-        }
-
-        @media (max-width: 768px) {
-            .full-site-link {
-                display: block;
-                width: 100%;
-                text-align: center;
-                padding: 10px;
-                background-color: #f7f7f7;
-                color: #000;
-            }
+            width: 100%;
+            text-align: center;
+            padding: 10px;
+            background-color: #f7f7f7;
+            color: #000;
         }
 
         @media (min-width: 769px) {
-            .full-site-link {
-                display: none !important;
-            }
             footer {
                 position: fixed;
                 bottom: 0;
@@ -328,12 +316,6 @@
             }
             .footer-links {
                 padding-bottom: 30px;
-            }
-            .desktop-only {
-                display: block;
-            }
-            .footer-line.desktop-only {
-                display: flex;
             }
         }
     </style>
@@ -458,7 +440,7 @@
 </div>
 <footer>
     <div class="footer-links">
-        <div class="footer-line extra-padding desktop-only">
+        <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
@@ -466,7 +448,7 @@
             <a href="soon.html">news</a>
         </div>
     </div>
-    <div class="cart-footer desktop-only">
+    <div class="cart-footer">
         <a href="#">refund policy</a> |
         <a href="#">shipping</a> |
         <a href="#">privacy policy</a> |
@@ -494,14 +476,16 @@
     updateChicagoTime();
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
     const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/cart.js
+++ b/cart.js
@@ -186,7 +186,7 @@ function createCartModal() {
             </div>
             <footer>
                 <div class="footer-links">
-                    <div class="footer-line extra-padding desktop-only">
+                    <div class="footer-line extra-padding">
                         <a href="shop.html">shop</a>
                         <a href="all.html">view all</a>
                         <a href="soon.html">preview</a>
@@ -194,7 +194,7 @@ function createCartModal() {
                         <a href="soon.html">news</a>
                     </div>
                 </div>
-                <div class="cart-footer desktop-only">
+                <div class="cart-footer">
                     <a href="#">refund policy</a> |
                     <a href="#">shipping</a> |
                     <a href="#">privacy policy</a> |
@@ -284,8 +284,7 @@ function createCartModal() {
             #cart-modal .footer-line.extra-padding{padding-bottom:10px;}
             #cart-modal .footer-links a{color:#000;text-decoration:none;font-size:0.7rem;transition:all 0.3s ease;background:#fff;}
             #cart-modal .footer-links a:hover,#cart-modal .footer-links a:focus,#cart-modal .footer-links a:active{border:2px solid red;color:red;background:#fff;}
-            #cart-modal .desktop-only{display:none;}
-            @media (min-width:769px){#cart-modal .desktop-only{display:block;}#cart-modal .footer-line.desktop-only{display:flex;}}
+            
         `;
         document.head.appendChild(style);
     }

--- a/checkout.html
+++ b/checkout.html
@@ -193,9 +193,6 @@
             background-color: white;
         }
 
-        .desktop-only {
-            display: none;
-        }
         .consent-text {
             font-size: 0.7rem;
             margin-top: 10px;
@@ -250,23 +247,14 @@
 
         .full-site-link {
             display: none;
-        }
-
-        @media (max-width: 768px) {
-            .full-site-link {
-                display: block;
-                width: 100%;
-                text-align: center;
-                padding: 10px;
-                background-color: #f7f7f7;
-                color: #000;
-            }
+            width: 100%;
+            text-align: center;
+            padding: 10px;
+            background-color: #f7f7f7;
+            color: #000;
         }
 
         @media (min-width: 769px) {
-            .full-site-link {
-                display: none !important;
-            }
             footer {
                 position: fixed;
                 bottom: 0;
@@ -288,12 +276,6 @@
             }
             .footer-links {
                 padding-bottom: 30px;
-            }
-            .desktop-only {
-                display: block;
-            }
-            .footer-line.desktop-only {
-                display: flex;
             }
         }
     </style>
@@ -374,7 +356,7 @@
     </div>
 <footer>
     <div class="footer-links">
-        <div class="footer-line extra-padding desktop-only">
+        <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
@@ -382,7 +364,7 @@
             <a href="soon.html">news</a>
         </div>
     </div>
-    <div class="cart-footer desktop-only">
+    <div class="cart-footer">
         <a href="#">refund policy</a> |
         <a href="#">shipping</a> |
         <a href="#">privacy policy</a> |
@@ -410,14 +392,16 @@
         updateChicagoTime();
         setInterval(updateChicagoTime, 1000);
 
-        window.addEventListener('scroll', function() {
+        function toggleFullSiteLink() {
             var fullSiteLink = document.getElementById('full-site-link');
-            if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+            if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
                 fullSiteLink.style.display = 'block';
             } else {
                 fullSiteLink.style.display = 'none';
             }
-        });
+        }
+        window.addEventListener('scroll', toggleFullSiteLink);
+        toggleFullSiteLink();
         const logoOverlay = document.querySelector(".logo-overlay");
         if (logoOverlay) {
             let pressTimer;


### PR DESCRIPTION
## Summary
- Show top footer navigation (shop, view all, preview, lookbook, news) on cart page, cart popup, and checkout page for all devices
- Display existing cart footer links on mobile
- Reveal "full site" link at bottom of cart and checkout pages on both desktop and mobile

## Testing
- `node --check cart.js`


------
https://chatgpt.com/codex/tasks/task_e_689f390c7df4832197791245a73bffee