### PR TITLE
Fix desktop product image sizing across categories

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -196,7 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
+                /* Fix width so items don't expand on sparse categories */
+                flex: 0 0 calc(25% - 40px);
                 max-width: calc(25% - 40px);
                 margin: 10px;
             }

--- a/all.html
+++ b/all.html
@@ -196,7 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
+                /* Fix width so items don't expand on sparse categories */
+                flex: 0 0 calc(25% - 40px);
                 max-width: calc(25% - 40px);
                 margin: 10px;
             }

--- a/bags.html
+++ b/bags.html
@@ -196,7 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
+                /* Fix width so items don't expand on sparse categories */
+                flex: 0 0 calc(25% - 40px);
                 max-width: calc(25% - 40px);
                 margin: 10px;
             }

--- a/category_template.html
+++ b/category_template.html
@@ -196,7 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
+                /* Fix width so items don't expand on sparse categories */
+                flex: 0 0 calc(25% - 40px);
                 max-width: calc(25% - 40px);
                 margin: 10px;
             }

--- a/gym.html
+++ b/gym.html
@@ -196,7 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
+                /* Fix width so items don't expand on sparse categories */
+                flex: 0 0 calc(25% - 40px);
                 max-width: calc(25% - 40px);
                 margin: 10px;
             }

--- a/hats.html
+++ b/hats.html
@@ -196,7 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
+                /* Fix width so items don't expand on sparse categories */
+                flex: 0 0 calc(25% - 40px);
                 max-width: calc(25% - 40px);
                 margin: 10px;
             }

--- a/jackets.html
+++ b/jackets.html
@@ -196,7 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
+                /* Fix width so items don't expand on sparse categories */
+                flex: 0 0 calc(25% - 40px);
                 max-width: calc(25% - 40px);
                 margin: 10px;
             }

--- a/new.html
+++ b/new.html
@@ -196,7 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
+                /* Fix width so items don't expand on sparse categories */
+                flex: 0 0 calc(25% - 40px);
                 max-width: calc(25% - 40px);
                 margin: 10px;
             }

--- a/pants.html
+++ b/pants.html
@@ -196,7 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
+                /* Fix width so items don't expand on sparse categories */
+                flex: 0 0 calc(25% - 40px);
                 max-width: calc(25% - 40px);
                 margin: 10px;
             }

--- a/shirts.html
+++ b/shirts.html
@@ -196,7 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
+                /* Fix width so items don't expand on sparse categories */
+                flex: 0 0 calc(25% - 40px);
                 max-width: calc(25% - 40px);
                 margin: 10px;
             }

--- a/shoes.html
+++ b/shoes.html
@@ -196,7 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
+                /* Fix width so items don't expand on sparse categories */
+                flex: 0 0 calc(25% - 40px);
                 max-width: calc(25% - 40px);
                 margin: 10px;
             }

--- a/skate.html
+++ b/skate.html
@@ -196,7 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
+                /* Fix width so items don't expand on sparse categories */
+                flex: 0 0 calc(25% - 40px);
                 max-width: calc(25% - 40px);
                 margin: 10px;
             }

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -196,7 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
+                /* Fix width so items don't expand on sparse categories */
+                flex: 0 0 calc(25% - 40px);
                 max-width: calc(25% - 40px);
                 margin: 10px;
             }

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -196,7 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
+                /* Fix width so items don't expand on sparse categories */
+                flex: 0 0 calc(25% - 40px);
                 max-width: calc(25% - 40px);
                 margin: 10px;
             }

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -196,7 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
+                /* Fix width so items don't expand on sparse categories */
+                flex: 0 0 calc(25% - 40px);
                 max-width: calc(25% - 40px);
                 margin: 10px;
             }


### PR DESCRIPTION
## Summary
- ensure category product cards have fixed width on desktop so single-item categories don't expand
- update category template and regenerate category pages

## Testing
- `python3 -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689f845da87c8321a5f7dcfd4f084f99