### PR TITLE
Align category page product image sizing

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -173,6 +173,7 @@
             width: 100%;
             height: 100%;
             object-fit: contain;
+            object-position: center;
             display: block;
             margin: 0 auto;
         }

--- a/all.html
+++ b/all.html
@@ -173,6 +173,7 @@
             width: 100%;
             height: 100%;
             object-fit: contain;
+            object-position: center;
             display: block;
             margin: 0 auto;
         }

--- a/bags.html
+++ b/bags.html
@@ -173,6 +173,7 @@
             width: 100%;
             height: 100%;
             object-fit: contain;
+            object-position: center;
             display: block;
             margin: 0 auto;
         }

--- a/gym.html
+++ b/gym.html
@@ -173,6 +173,7 @@
             width: 100%;
             height: 100%;
             object-fit: contain;
+            object-position: center;
             display: block;
             margin: 0 auto;
         }

--- a/hats.html
+++ b/hats.html
@@ -173,6 +173,7 @@
             width: 100%;
             height: 100%;
             object-fit: contain;
+            object-position: center;
             display: block;
             margin: 0 auto;
         }

--- a/jackets.html
+++ b/jackets.html
@@ -173,6 +173,7 @@
             width: 100%;
             height: 100%;
             object-fit: contain;
+            object-position: center;
             display: block;
             margin: 0 auto;
         }

--- a/new.html
+++ b/new.html
@@ -173,6 +173,7 @@
             width: 100%;
             height: 100%;
             object-fit: contain;
+            object-position: center;
             display: block;
             margin: 0 auto;
         }

--- a/pants.html
+++ b/pants.html
@@ -173,6 +173,7 @@
             width: 100%;
             height: 100%;
             object-fit: contain;
+            object-position: center;
             display: block;
             margin: 0 auto;
         }

--- a/shirts.html
+++ b/shirts.html
@@ -173,6 +173,7 @@
             width: 100%;
             height: 100%;
             object-fit: contain;
+            object-position: center;
             display: block;
             margin: 0 auto;
         }

--- a/shoes.html
+++ b/shoes.html
@@ -173,6 +173,7 @@
             width: 100%;
             height: 100%;
             object-fit: contain;
+            object-position: center;
             display: block;
             margin: 0 auto;
         }

--- a/skate.html
+++ b/skate.html
@@ -173,6 +173,7 @@
             width: 100%;
             height: 100%;
             object-fit: contain;
+            object-position: center;
             display: block;
             margin: 0 auto;
         }

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -173,6 +173,7 @@
             width: 100%;
             height: 100%;
             object-fit: contain;
+            object-position: center;
             display: block;
             margin: 0 auto;
         }

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -173,6 +173,7 @@
             width: 100%;
             height: 100%;
             object-fit: contain;
+            object-position: center;
             display: block;
             margin: 0 auto;
         }

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -173,6 +173,7 @@
             width: 100%;
             height: 100%;
             object-fit: contain;
+            object-position: center;
             display: block;
             margin: 0 auto;
         }


### PR DESCRIPTION
## Summary
- Ensure all category pages center product images for consistent desktop sizing
- Regenerate category HTML pages from template

## Testing
- `python3 generate_category_pages.py`
- `python3 -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689f949f307483218927e9730dbccc86