### PR TITLE
Standardize category image sizes on desktop

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -196,8 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
-                max-width: calc(25% - 40px);
+                flex: 1 1 400px;
+                max-width: 400px;
                 margin: 10px;
             }
         }

--- a/all.html
+++ b/all.html
@@ -196,8 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
-                max-width: calc(25% - 40px);
+                flex: 1 1 400px;
+                max-width: 400px;
                 margin: 10px;
             }
         }

--- a/bags.html
+++ b/bags.html
@@ -196,8 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
-                max-width: calc(25% - 40px);
+                flex: 1 1 400px;
+                max-width: 400px;
                 margin: 10px;
             }
         }

--- a/category_template.html
+++ b/category_template.html
@@ -196,8 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
-                max-width: calc(25% - 40px);
+                flex: 1 1 400px;
+                max-width: 400px;
                 margin: 10px;
             }
         }

--- a/gym.html
+++ b/gym.html
@@ -196,8 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
-                max-width: calc(25% - 40px);
+                flex: 1 1 400px;
+                max-width: 400px;
                 margin: 10px;
             }
         }

--- a/hats.html
+++ b/hats.html
@@ -196,8 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
-                max-width: calc(25% - 40px);
+                flex: 1 1 400px;
+                max-width: 400px;
                 margin: 10px;
             }
         }

--- a/jackets.html
+++ b/jackets.html
@@ -196,8 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
-                max-width: calc(25% - 40px);
+                flex: 1 1 400px;
+                max-width: 400px;
                 margin: 10px;
             }
         }

--- a/new.html
+++ b/new.html
@@ -196,8 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
-                max-width: calc(25% - 40px);
+                flex: 1 1 400px;
+                max-width: 400px;
                 margin: 10px;
             }
         }

--- a/pants.html
+++ b/pants.html
@@ -196,8 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
-                max-width: calc(25% - 40px);
+                flex: 1 1 400px;
+                max-width: 400px;
                 margin: 10px;
             }
         }

--- a/shirts.html
+++ b/shirts.html
@@ -196,8 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
-                max-width: calc(25% - 40px);
+                flex: 1 1 400px;
+                max-width: 400px;
                 margin: 10px;
             }
         }

--- a/shoes.html
+++ b/shoes.html
@@ -196,8 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
-                max-width: calc(25% - 40px);
+                flex: 1 1 400px;
+                max-width: 400px;
                 margin: 10px;
             }
         }

--- a/skate.html
+++ b/skate.html
@@ -196,8 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
-                max-width: calc(25% - 40px);
+                flex: 1 1 400px;
+                max-width: 400px;
                 margin: 10px;
             }
         }

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -196,8 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
-                max-width: calc(25% - 40px);
+                flex: 1 1 400px;
+                max-width: 400px;
                 margin: 10px;
             }
         }

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -196,8 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
-                max-width: calc(25% - 40px);
+                flex: 1 1 400px;
+                max-width: 400px;
                 margin: 10px;
             }
         }

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -196,8 +196,8 @@
             }
 
             .product-item {
-                flex: 1 1 calc(25% - 40px);
-                max-width: calc(25% - 40px);
+                flex: 1 1 400px;
+                max-width: 400px;
                 margin: 10px;
             }
         }


### PR DESCRIPTION
## Summary
- expand product tile width to 400px for desktop layouts in category pages
- regenerate all category pages from updated template to ensure consistent sizing

## Testing
- `python generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_689f9b53856c832190c8aee6c826ec3c