### PR TITLE
Add padding above product descriptions

### DIFF
--- a/product.js
+++ b/product.js
@@ -169,7 +169,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .product-item button { background:#000; color:#fff; border:2px solid #000; font-family:'Courier New', Courier, monospace; cursor:pointer; margin-top:10px; }
     .product-item button:hover, .product-item button:active, .product-item button:focus { background:#fff; color:red; border-color:red; }
     .product-item h1, .product-item p, .product-details { text-align:center; }
-    .product-details { width:100%; margin-bottom:15px; }
+    .product-details { width:100%; margin:15px 0; padding:10px 0; }
     .product-details p { max-width:90%; margin:0 auto; }
     .color-options { margin-top:10px; }
     .color-option { width:20px; height:20px; display:inline-block; cursor:pointer; margin:0 5px; border:1px solid #000; }


### PR DESCRIPTION
## Summary
- Add margin and padding to product descriptions to create space above size selector and around text on product pages

## Testing
- `node --check product.js`


------
https://chatgpt.com/codex/tasks/task_e_689f9d0093388321baa4d26b08e4d558