### PR TITLE
Refine checkout payment layout and summary

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -288,11 +288,14 @@
             font-weight: 700;
             text-align: center;
         }
-        .remember-label {
+        .remember-check {
             display: flex;
-            align-items: center;
             justify-content: center;
-            gap: 5px;
+            margin-top: 5px;
+        }
+        .remember-text {
+            display: block;
+            text-align: center;
             margin-top: 5px;
         }
         .phone-input {
@@ -316,10 +319,13 @@
         }
         .secure-row {
             display: flex;
-            justify-content: center;
+            justify-content: space-between;
             align-items: center;
-            gap: 5px;
             margin-top: 5px;
+            width: 100%;
+            max-width: 200px;
+            margin-left: auto;
+            margin-right: auto;
         }
         .secure-text {
             color: #888;
@@ -348,6 +354,7 @@
             align-items: center;
             border: 1px solid #ccc;
             padding: 10px;
+            padding-left: 0;
             margin: 5px 0;
             cursor: pointer;
             width: 100%;
@@ -355,7 +362,7 @@
             overflow: hidden;
         }
         .payment-option input {
-            margin-right: 10px;
+            margin: 0 10px 0 0;
         }
         .payment-option label {
             display: flex;
@@ -367,11 +374,9 @@
         .payment-label {
             flex: 1;
             text-align: left;
-            display: flex;
-            flex-direction: column;
-            overflow-wrap: anywhere;
         }
         .payment-label .subtext {
+            display: block;
             font-size: 0.8em;
         }
         .payment-logos {
@@ -394,7 +399,7 @@
         .more-logos-box {
             display: none;
             position: absolute;
-            top: 100%;
+            bottom: 100%;
             right: 0;
             background: #000;
             padding: 5px;
@@ -405,34 +410,9 @@
             margin: 0 2px;
             filter: invert(1);
         }
-        .order-summary-bar {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
+        .order-summary-details {
             margin: 10px 0;
-            width: 100%;
-        }
-        .summary-toggle {
-            background: #000;
-            color: #fff;
-            border: none;
-            font-size: 1em;
-            display: inline-flex;
-            align-items: center;
-            justify-content: flex-start;
-            cursor: pointer;
-            padding: 10px;
-            margin: 0;
-            margin-left: 0;
-            text-align: left;
-        }
-        .summary-toggle .arrow {
-            margin-left: 5px;
-        }
-        .order-total {
-            font-weight: bold;
-            margin: 0;
-            margin-left: auto;
+            text-align: center;
         }
 
         .full-site-link {
@@ -525,19 +505,6 @@
     <div id="final-checkout" style="display:none;">
         <form id="final-form">
             <h2 class="checkout-domain">maybenot.com</h2>
-            <div class="order-summary-bar">
-                <button class="summary-toggle" type="button">Order summary <span class="arrow">&#9660;</span></button>
-                <strong class="order-total">$0.00</strong>
-            </div>
-            <div class="order-summary-details" style="display:none;">
-                <div class="cart-items"></div>
-                <div class="cost-summary">
-                    <div><span>Subtotal</span><span class="subtotal">$0.00</span></div>
-                    <div><span>Tax</span><span class="tax">Calculated at checkout</span></div>
-                    <div><span>Shipping</span><span class="shipping">Calculated at checkout</span></div>
-                    <div><strong>Total</strong><strong class="total">$0.00</strong></div>
-                </div>
-            </div>
             <h3>Sign up and know first!</h3>
             <input type="email" name="signup_email" placeholder="Enter an email" required>
             <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from maybenot.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
@@ -625,7 +592,10 @@
             <div id="payment-message"></div>
             <div class="remember-section">
                 <strong class="remember-heading">Remember me</strong>
-                <label class="remember-label"><input type="checkbox" name="remember" id="remember-me"> Save my information for a faster checkout with a Shop account</label>
+                <div class="remember-check">
+                    <input type="checkbox" name="remember" id="remember-me">
+                </div>
+                <label for="remember-me" class="remember-text">Save my information for a faster checkout with a Shop account</label>
                 <div id="phone-container" class="phone-input" style="display:none;">
                     <span class="phone-icon">📱</span>
                     <span class="phone-prefix">+1</span>
@@ -635,6 +605,15 @@
                 <div class="secure-row">
                     <span class="secure-text">Secure and encrypted</span>
                     <div class="shop-logo"><img src="shoppay.png" alt="Shop Pay"></div>
+                </div>
+            </div>
+            <div class="order-summary-details">
+                <div class="cart-items"></div>
+                <div class="cost-summary">
+                    <div><span>Subtotal</span><span class="subtotal">$0.00</span></div>
+                    <div><span>Tax</span><span class="tax">Calculated at checkout</span></div>
+                    <div><span>Shipping</span><span class="shipping">Calculated at checkout</span></div>
+                    <div><strong>Total</strong><strong class="total">$0.00</strong></div>
                 </div>
             </div>
             <button id="final-order-submit" type="submit">Pay now</button>

--- a/cart.js
+++ b/cart.js
@@ -186,19 +186,6 @@ function createCartModal() {
             <div id="final-checkout" style="display:none;">
                 <form id="final-form">
                     <h2 class="checkout-domain">maybenot.com</h2>
-                    <div class="order-summary-bar">
-                        <button class="summary-toggle" type="button">Order summary <span class="arrow">&#9660;</span></button>
-                        <strong class="order-total">$0.00</strong>
-                    </div>
-                    <div class="order-summary-details" style="display:none;">
-                        <div class="cart-items"></div>
-                        <div class="cost-summary">
-                            <div><span>Subtotal</span><span class="subtotal">$0.00</span></div>
-                            <div><span>Tax</span><span class="tax">Calculated at checkout</span></div>
-                            <div><span>Shipping</span><span class="shipping">Calculated at checkout</span></div>
-                            <div><strong>Total</strong><strong class="total">$0.00</strong></div>
-                        </div>
-                    </div>
                     <h3>Sign up and know first!</h3>
                     <input type="email" name="signup_email" placeholder="Enter an email" required>
                     <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from maybenot.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
@@ -286,7 +273,10 @@ function createCartModal() {
                     <div id="payment-message"></div>
                     <div class="remember-section">
                         <strong class="remember-heading">Remember me</strong>
-                        <label class="remember-label"><input type="checkbox" name="remember" id="remember-me"> Save my information for a faster checkout with a Shop account</label>
+                        <div class="remember-check">
+                            <input type="checkbox" name="remember" id="remember-me">
+                        </div>
+                        <label for="remember-me" class="remember-text">Save my information for a faster checkout with a Shop account</label>
                         <div id="phone-container" class="phone-input" style="display:none;">
                             <span class="phone-icon">📱</span>
                             <span class="phone-prefix">+1</span>
@@ -296,6 +286,15 @@ function createCartModal() {
                         <div class="secure-row">
                             <span class="secure-text">Secure and encrypted</span>
                             <div class="shop-logo"><img src="shoppay.png" alt="Shop Pay"></div>
+                        </div>
+                    </div>
+                    <div class="order-summary-details">
+                        <div class="cart-items"></div>
+                        <div class="cost-summary">
+                            <div><span>Subtotal</span><span class="subtotal">$0.00</span></div>
+                            <div><span>Tax</span><span class="tax">Calculated at checkout</span></div>
+                            <div><span>Shipping</span><span class="shipping">Calculated at checkout</span></div>
+                            <div><strong>Total</strong><strong class="total">$0.00</strong></div>
                         </div>
                     </div>
                     <button id="final-order-submit" type="submit">Pay now</button>
@@ -388,26 +387,27 @@ function createCartModal() {
             #login-btn:hover{color:red;}
             .remember-section{text-align:center;margin-top:10px;}
             .remember-heading{display:block;font-weight:700;text-align:center;}
-            .remember-label{display:flex;align-items:center;justify-content:center;gap:5px;margin-top:5px;}
+            .remember-check{display:flex;justify-content:center;margin-top:5px;}
+            .remember-text{display:block;text-align:center;margin-top:5px;}
             .phone-input{position:relative;margin-top:5px;}
             .phone-input .phone-icon{position:absolute;left:10px;top:50%;transform:translateY(-50%);}
             .phone-input .phone-prefix{position:absolute;left:35px;top:50%;transform:translateY(-50%);}
             .phone-input input{padding-left:60px;}
-            .secure-row{display:flex;justify-content:center;align-items:center;gap:5px;margin-top:5px;}
+            .secure-row{display:flex;justify-content:space-between;align-items:center;margin-top:5px;width:100%;max-width:200px;margin-left:auto;margin-right:auto;}
             .secure-text{color:#888;font-size:0.8em;}
             .shop-logo{overflow:hidden;width:40px;height:20px;}
             .shop-logo img{width:80px;height:100%;object-fit:cover;object-position:-15px 0;filter:grayscale(100%);}
             .checkout-domain{margin-top:5px;}
             .credit-card-fields input{width:100%;}
-            .payment-option{display:flex;align-items:center;border:1px solid #ccc;padding:10px;margin:5px 0;cursor:pointer;width:100%;box-sizing:border-box;overflow:hidden;}
-            .payment-option input{margin-right:10px;}
+            .payment-option{display:flex;align-items:center;border:1px solid #ccc;padding:10px;padding-left:0;margin:5px 0;cursor:pointer;width:100%;box-sizing:border-box;overflow:hidden;}
+            .payment-option input{margin:0 10px 0 0;}
             .payment-option label{display:flex;align-items:center;width:100%;cursor:pointer;flex-wrap:nowrap;}
-            .payment-label{flex:1;text-align:left;display:flex;flex-direction:column;overflow-wrap:anywhere;}
-            .payment-label .subtext{font-size:0.8em;}
+            .payment-label{flex:1;text-align:left;}
+            .payment-label .subtext{display:block;font-size:0.8em;}
             .payment-logos{margin-left:auto;display:flex;align-items:center;flex-shrink:0;}
             .payment-logos img{height:20px;margin-left:5px;}
             .more-logos{position:relative;margin-left:5px;cursor:pointer;color:#000;font-weight:600;}
-            .more-logos-box{display:none;position:absolute;top:100%;right:0;background:#000;padding:5px;z-index:10;}
+            .more-logos-box{display:none;position:absolute;bottom:100%;right:0;background:#000;padding:5px;z-index:10;}
             .more-logos-box img{height:20px;margin:0 2px;filter:invert(1);}
             #cart-modal .logo-container{width:80px;height:80px;margin:0 auto;}
             #cart-modal .logo-container iframe{width:100%;height:100%;border:none;}
@@ -563,10 +563,7 @@ function populateOrderSummary(section) {
     const itemsContainer = section.querySelector('.order-summary-details .cart-items');
     const subtotalEl = section.querySelector('.order-summary-details .subtotal');
     const totalEl = section.querySelector('.order-summary-details .total');
-    const orderTotalEl = section.querySelector('.order-summary-bar .order-total');
-    const bar = section.querySelector('.order-summary-bar');
-    const details = section.querySelector('.order-summary-details');
-    if (!itemsContainer || !subtotalEl || !totalEl || !orderTotalEl || !bar || !details) return;
+    if (!itemsContainer || !subtotalEl || !totalEl) return;
     itemsContainer.innerHTML = '';
     let total = 0;
     cart.forEach(item => {
@@ -586,20 +583,6 @@ function populateOrderSummary(section) {
     });
     subtotalEl.textContent = `$${total.toFixed(2)}`;
     totalEl.textContent = `$${total.toFixed(2)}`;
-    orderTotalEl.textContent = `$${total.toFixed(2)}`;
-    bar.style.display = 'flex';
-    details.style.display = 'none';
-    const toggle = section.querySelector('.summary-toggle');
-    const arrow = bar.querySelector('.arrow');
-    if (toggle && !toggle.dataset.bound) {
-        toggle.addEventListener('click', (e) => {
-            e.preventDefault();
-            const hidden = details.style.display === 'none';
-            details.style.display = hidden ? 'block' : 'none';
-            if (arrow) arrow.textContent = hidden ? '▲' : '▼';
-        });
-        toggle.dataset.bound = 'true';
-    }
 }
 
 function showFinalPage(root = document.getElementById('cart-modal')) {

--- a/checkout.html
+++ b/checkout.html
@@ -245,11 +245,14 @@
             font-weight: 700;
             text-align: center;
         }
-        .remember-label {
+        .remember-check {
             display: flex;
-            align-items: center;
             justify-content: center;
-            gap: 5px;
+            margin-top: 5px;
+        }
+        .remember-text {
+            display: block;
+            text-align: center;
             margin-top: 5px;
         }
         .phone-input {
@@ -264,19 +267,22 @@
         }
         .phone-input .phone-prefix {
             position: absolute;
-            left: 45px;
+            left: 35px;
             top: 50%;
             transform: translateY(-50%);
         }
         .phone-input input {
-            padding-left: 90px;
+            padding-left: 60px;
         }
         .secure-row {
             display: flex;
-            justify-content: center;
+            justify-content: space-between;
             align-items: center;
-            gap: 5px;
             margin-top: 5px;
+            width: 100%;
+            max-width: 200px;
+            margin-left: auto;
+            margin-right: auto;
         }
         .secure-text {
             color: #888;
@@ -305,6 +311,7 @@
             align-items: center;
             border: 1px solid #ccc;
             padding: 10px;
+            padding-left: 0;
             margin: 5px 0;
             cursor: pointer;
             width: 100%;
@@ -312,7 +319,7 @@
             overflow: hidden;
         }
         .payment-option input {
-            margin-right: 10px;
+            margin: 0 10px 0 0;
         }
         .payment-option label {
             display: flex;
@@ -322,13 +329,11 @@
             flex-wrap: nowrap;
         }
         .payment-label {
-            text-align: left;
             flex: 1;
-            overflow-wrap: anywhere;
-            display: flex;
-            flex-direction: column;
+            text-align: left;
         }
         .payment-label .subtext {
+            display: block;
             font-size: 0.8em;
         }
         .payment-logos {
@@ -351,7 +356,7 @@
         .more-logos-box {
             display: none;
             position: absolute;
-            top: 100%;
+            bottom: 100%;
             right: 0;
             background: #000;
             padding: 5px;
@@ -369,34 +374,9 @@
             padding: 10px;
             margin: 5px 0;
         }
-        .order-summary-bar {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
+        .order-summary-details {
             margin: 10px 0;
-            width: 100%;
-        }
-        .summary-toggle {
-            background: #000;
-            color: #fff;
-            border: none;
-            font-size: 1em;
-            display: inline-flex;
-            align-items: center;
-            justify-content: flex-start;
-            cursor: pointer;
-            padding: 10px;
-            margin: 0;
-            margin-left: 0;
-            text-align: left;
-        }
-        .summary-toggle .arrow {
-            margin-left: 5px;
-        }
-        .order-total {
-            font-weight: bold;
-            margin: 0;
-            margin-left: auto;
+            text-align: center;
         }
 
         .full-site-link {
@@ -445,19 +425,6 @@
     <div id="final-checkout">
         <form id="final-form">
             <h2 class="checkout-domain">maybenot.com</h2>
-            <div class="order-summary-bar">
-                <button class="summary-toggle" type="button">Order summary <span class="arrow">&#9660;</span></button>
-                <strong class="order-total">$0.00</strong>
-            </div>
-            <div class="order-summary-details" style="display:none;">
-                <div class="cart-items"></div>
-                <div class="cost-summary">
-                    <div><span>Subtotal</span><span class="subtotal">$0.00</span></div>
-                    <div><span>Tax</span><span class="tax">Calculated at checkout</span></div>
-                    <div><span>Shipping</span><span class="shipping">Calculated at checkout</span></div>
-                    <div><strong>Total</strong><strong class="total">$0.00</strong></div>
-                </div>
-            </div>
             <h3>Sign up and know first!</h3>
             <input type="email" name="signup_email" placeholder="Enter an email" required>
             <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from maybenot.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
@@ -546,7 +513,10 @@
             <div id="payment-message"></div>
             <div class="remember-section">
                 <strong class="remember-heading">Remember me</strong>
-                <label class="remember-label"><input type="checkbox" name="remember" id="remember-me"> Save my information for a faster checkout with a Shop account</label>
+                <div class="remember-check">
+                    <input type="checkbox" name="remember" id="remember-me">
+                </div>
+                <label for="remember-me" class="remember-text">Save my information for a faster checkout with a Shop account</label>
                 <div id="phone-container" class="phone-input" style="display:none;">
                     <span class="phone-icon">📱</span>
                     <span class="phone-prefix">+1</span>
@@ -556,6 +526,15 @@
                 <div class="secure-row">
                     <span class="secure-text">Secure and encrypted</span>
                     <div class="shop-logo"><img src="shoppay.png" alt="Shop Pay"></div>
+                </div>
+            </div>
+            <div class="order-summary-details">
+                <div class="cart-items"></div>
+                <div class="cost-summary">
+                    <div><span>Subtotal</span><span class="subtotal">$0.00</span></div>
+                    <div><span>Tax</span><span class="tax">Calculated at checkout</span></div>
+                    <div><span>Shipping</span><span class="shipping">Calculated at checkout</span></div>
+                    <div><strong>Total</strong><strong class="total">$0.00</strong></div>
                 </div>
             </div>
             <button id="final-order-submit" type="submit">Pay now</button>


### PR DESCRIPTION
## Summary
- Align payment option radios left and keep labels horizontal
- Center and tidy Remember me section with phone prefix fix and secure row alignment
- Always display order summary under Remember me with +5 card dropdown above

## Testing
- `node --check cart.js`


------
https://chatgpt.com/codex/tasks/task_e_689fcfac7f788321b62d1961f1ed0d06