### PR TITLE
Fix mobile checkout option layout and center remember-me checkbox

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -299,7 +299,8 @@
         .remember-check input {
             width: 20px;
             height: 20px;
-            display: inline-block;
+            display: block;
+            margin: 0 auto;
         }
         .remember-text {
             display: block;
@@ -409,6 +410,20 @@
         }
         .payment-logos img.klarna-logo {
             height: 30px;
+        }
+        @media (max-width: 480px) {
+            .payment-option label {
+                flex-wrap: wrap;
+            }
+            .payment-logos {
+                margin-left: 0;
+                flex-basis: 100%;
+                justify-content: flex-start;
+                margin-top: 5px;
+            }
+            .payment-logos img {
+                height: 18px;
+            }
         }
         .more-logos {
             position: relative;

--- a/checkout.html
+++ b/checkout.html
@@ -281,7 +281,8 @@
         .remember-check input {
             width: 20px;
             height: 20px;
-            display: inline-block;
+            display: block;
+            margin: 0 auto;
         }
         .remember-text {
             display: block;
@@ -391,6 +392,20 @@
         }
         .payment-logos img.klarna-logo {
             height: 30px;
+        }
+        @media (max-width: 480px) {
+            .payment-option label {
+                flex-wrap: wrap;
+            }
+            .payment-logos {
+                margin-left: 0;
+                flex-basis: 100%;
+                justify-content: flex-start;
+                margin-top: 5px;
+            }
+            .payment-logos img {
+                height: 18px;
+            }
         }
         .more-logos {
             position: relative;


### PR DESCRIPTION
## Summary
- Ensure payment option logos and labels wrap within tabs on small screens for both cart popup and checkout page
- Allow Shop Pay label to span two lines and center the 'Remember me' checkbox

## Testing
- `python -m py_compile generate_category_pages.py`
- `node --check cart.js`


------
https://chatgpt.com/codex/tasks/task_e_689ffa197eec83219cbc4790acb9cc2f