### PR TITLE
Add bottom order summary heading and tweak Shop Pay logo

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -137,6 +137,15 @@
         .summary-toggle .arrow {
             margin-left: 5px;
         }
+        .summary-label {
+            background: #000;
+            color: #fff;
+            font-size: 1em;
+            display: inline-block;
+            padding: 10px;
+            margin: 0;
+            margin-left: 0;
+        }
         .order-total {
             font-weight: bold;
             margin-left: auto;
@@ -328,9 +337,8 @@
             width: 80px;
             height: 100%;
             object-fit: cover;
-            object-position: right;
+            object-position: left;
             filter: grayscale(100%);
-            transform: translateX(-5px);
         }
         .checkout-domain {
             margin-top: 5px;
@@ -601,6 +609,9 @@
                     <span class="secure-text">Secure and encrypted</span>
                     <div class="shop-logo"><img src="shoppay.png" alt="Shop Pay"></div>
                 </div>
+            </div>
+            <div class="order-summary-bar">
+                <div class="summary-label">Order summary</div>
             </div>
             <div class="order-summary-details bottom-summary">
                 <div class="cart-items"></div>


### PR DESCRIPTION
## Summary
- Add fixed "Order summary" label above final cost breakdown
- Style new bottom summary header to match initial summary block
- Shift Shop Pay logo alignment so right edge crops and left edge is visible

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ffc3e33748321b70d6af837b7de27