### PR TITLE
Fix mobile layout for checkout payment options

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -410,6 +410,17 @@
             height: 30px;
         }
 
+        @media (max-width: 480px) {
+            .payment-option label {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+            .payment-logos {
+                margin-left: 0;
+                margin-top: 5px;
+            }
+        }
+
         .more-logos {
             position: relative;
             margin-left: 5px;

--- a/checkout.html
+++ b/checkout.html
@@ -400,6 +400,17 @@
             height: 30px;
         }
 
+        @media (max-width: 480px) {
+            .payment-option label {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+            .payment-logos {
+                margin-left: 0;
+                margin-top: 5px;
+            }
+        }
+
         .more-logos {
             position: relative;
             margin-left: 5px;


### PR DESCRIPTION
## Summary
- Stack payment option labels and logos vertically on narrow screens
- Apply shared responsive payment-option styles to checkout popup and page

## Testing
- `python -m py_compile generate_category_pages.py`

------
https://chatgpt.com/codex/tasks/task_e_68a06ffb6dd0832191d3147be5a05917