### PR TITLE
Align mobile payment option layout

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -361,14 +361,14 @@
             display: flex;
             align-items: center;
             border: 1px solid #ccc;
-            padding: 10px;
+            padding: 10px 10px 10px 5px;
             margin: 5px 0;
             cursor: pointer;
             width: 100%;
             box-sizing: border-box;
         }
         .payment-option input {
-            margin: 0 10px 0 0;
+            margin: 0 5px 0 0;
         }
         .payment-option label {
             display: flex;
@@ -412,12 +412,14 @@
 
         @media (max-width: 480px) {
             .payment-option label {
-                flex-direction: column;
-                align-items: flex-start;
+                flex-direction: row;
+                align-items: center;
+                justify-content: flex-start;
+                gap: 5px;
             }
             .payment-logos {
-                margin-left: 0;
-                margin-top: 5px;
+                margin-left: 5px;
+                margin-top: 0;
             }
         }
 

--- a/checkout.html
+++ b/checkout.html
@@ -351,14 +351,14 @@
             display: flex;
             align-items: center;
             border: 1px solid #ccc;
-            padding: 10px;
+            padding: 10px 10px 10px 5px;
             margin: 5px 0;
             cursor: pointer;
             width: 100%;
             box-sizing: border-box;
         }
         .payment-option input {
-            margin: 0 10px 0 0;
+            margin: 0 5px 0 0;
         }
         .payment-option label {
             display: flex;
@@ -402,12 +402,14 @@
 
         @media (max-width: 480px) {
             .payment-option label {
-                flex-direction: column;
-                align-items: flex-start;
+                flex-direction: row;
+                align-items: center;
+                justify-content: flex-start;
+                gap: 5px;
             }
             .payment-logos {
-                margin-left: 0;
-                margin-top: 5px;
+                margin-left: 5px;
+                margin-top: 0;
             }
         }
 


### PR DESCRIPTION
## Summary
- Align payment method radio buttons to left within their tabs
- Tighten spacing for mobile payment labels and logos for better fit

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a07396f4a48321a9db9b224f47011a