### PR TITLE
Fix mobile payment logo overflow on mobile

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -417,10 +417,14 @@
                 align-items: center;
                 justify-content: flex-start;
                 gap: 5px;
+                flex-wrap: wrap;
             }
             .payment-logos {
                 margin-left: 5px;
                 margin-top: 0;
+                flex-wrap: wrap;
+                flex-shrink: 1;
+                max-width: 100%;
             }
         }
 

--- a/checkout.html
+++ b/checkout.html
@@ -407,10 +407,14 @@
                 align-items: center;
                 justify-content: flex-start;
                 gap: 5px;
+                flex-wrap: wrap;
             }
             .payment-logos {
                 margin-left: 5px;
                 margin-top: 0;
+                flex-wrap: wrap;
+                flex-shrink: 1;
+                max-width: 100%;
             }
         }
 


### PR DESCRIPTION
## Summary
- Allow payment option labels and logos to wrap on small screens so they stay within tab boundaries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0833c704883218edf687d7b5856ff