### PR TITLE
Fix mobile layout for payment options

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -50,7 +50,7 @@
         }
         .payment-icons {
             display: grid;
-            grid-template-columns: repeat(auto-fit, 80px);
+            grid-template-columns: repeat(3, 1fr);
             gap: 5px;
             margin: 10px auto;
             justify-content: center;
@@ -241,6 +241,8 @@
             max-width: 400px;
             margin: 0 auto;
             padding: 20px;
+            width: 100%;
+            box-sizing: border-box;
         }
         #final-checkout input {
             display: block;
@@ -368,6 +370,8 @@
             width: 100%;
             cursor: pointer;
             gap: 10px;
+            flex-wrap: wrap;
+            box-sizing: border-box;
         }
         .payment-label {
             flex: 1;
@@ -388,33 +392,25 @@
             margin-top: 2px;
         }
         .payment-logos {
-            flex-shrink: 0;
+            flex-shrink: 1;
             margin-left: 10px;
             display: flex;
             align-items: center;
             gap: 5px;
+            flex-wrap: wrap;
+            max-width: 100%;
         }
         .payment-logos img {
             height: 20px;
+            max-width: 100%;
         }
         .payment-logos img.klarna-logo {
             height: 30px;
         }
 
         @media (max-width: 480px) {
-            .payment-option label {
-                flex-direction: row;
-                align-items: center;
-                justify-content: flex-start;
-                gap: 5px;
-                flex-wrap: wrap;
-            }
             .payment-logos {
                 margin-left: 5px;
-                margin-top: 0;
-                flex-wrap: wrap;
-                flex-shrink: 1;
-                max-width: 100%;
             }
         }
 


### PR DESCRIPTION
## Summary
- Ensure payment method section fits within mobile viewport by sizing the checkout container to the screen and allowing option labels and logos to wrap cleanly.
- Restore express checkout layout to show three payment logos per row.

## Testing
- `npx htmlhint checkout.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68a09195bdf083219c62d92a4dceebc1