### PR TITLE
Fix payment option overflow on desktop

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -361,6 +361,7 @@
             width: 100%;
             box-sizing: border-box;
             gap: 10px;
+            flex-wrap: wrap;
         }
         .payment-option input {
             margin: 0;
@@ -373,6 +374,8 @@
             flex: 1;
             cursor: pointer;
             gap: 10px;
+            flex-wrap: wrap;
+            width: 100%;
         }
         .payment-label {
             flex: 1;
@@ -410,14 +413,9 @@
         }
 
         @media (max-width: 480px) {
-            .payment-option {
-                flex-wrap: wrap;
-            }
             .payment-option label {
                 flex-direction: row;
                 align-items: center;
-                flex-wrap: wrap;
-                width: 100%;
             }
             .payment-logos {
                 margin-left: 10px;


### PR DESCRIPTION
## Summary
- allow payment option containers and labels to wrap so logos stay within bounds

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0c09927588321bf3a82ae84c5d9bb