### PR TITLE
Center Remember me checkbox on mobile

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -421,7 +421,7 @@ function createCartModal() {
             .remember-section{text-align:center;margin-top:10px;}
             .remember-heading{display:block;font-weight:700;text-align:center;}
             .remember-check{width:100%;text-align:center;margin-top:5px;}
-            .remember-check input{width:20px;height:20px;display:inline-block;}
+            .remember-check input{width:20px;height:20px;display:block;margin:0 auto;}
             .remember-text{display:block;margin-top:5px;text-align:center;}
             .phone-input{position:relative;margin-top:5px;}
             .phone-input .phone-icon{position:absolute;left:10px;top:50%;transform:translateY(-50%);}


### PR DESCRIPTION
## Summary
- Ensure the "Remember me" checkbox is centered on mobile in the cart pop-up by applying block display and auto margins

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ce6de3c48321a72911c4477d83e2