### PR TITLE
Ensure mobile centering of Remember Me checkbox and show tax in checkout

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -296,14 +296,13 @@
         }
         .remember-check {
             width: 100%;
-            text-align: center;
+            display: flex;
+            justify-content: center;
             margin-top: 5px;
         }
         .remember-check input {
             width: 20px;
             height: 20px;
-            display: block;
-            margin: 0 auto;
         }
         .remember-text {
             display: block;
@@ -515,7 +514,7 @@
     <div class="cart-items"></div>
     <div class="cost-summary">
         <div><span>Subtotal</span><span class="subtotal">$0.00</span></div>
-        <div><span>Tax</span><span class="tax">Calculated at checkout</span></div>
+        <div><span>Tax</span><span class="tax">$0.00</span></div>
         <div><span>Shipping</span><span class="shipping">Calculated at checkout</span></div>
         <div><strong>Total</strong><strong class="total">$0.00</strong></div>
     </div>
@@ -661,7 +660,7 @@
                 <div class="cart-items"></div>
                 <div class="cost-summary">
                     <div><span>Subtotal</span><span class="subtotal">$0.00</span></div>
-                    <div><span>Tax</span><span class="tax">Calculated at checkout</span></div>
+                    <div><span>Tax</span><span class="tax">$0.00</span></div>
                     <div><span>Shipping</span><span class="shipping">Calculated at checkout</span></div>
                     <div><strong>Total</strong><strong class="total">$0.00</strong></div>
                 </div>

--- a/cart.js
+++ b/cart.js
@@ -160,7 +160,7 @@ function createCartModal() {
                 <div class="cart-items"></div>
                 <div class="cost-summary">
                     <div><span>Subtotal</span><span class="subtotal">$0.00</span></div>
-                    <div><span>Tax</span><span class="tax">Calculated at checkout</span></div>
+                    <div><span>Tax</span><span class="tax">$0.00</span></div>
                     <div><span>Shipping</span><span class="shipping">Calculated at checkout</span></div>
                     <div><strong>Total</strong><strong class="total">$0.00</strong></div>
                 </div>
@@ -420,8 +420,8 @@ function createCartModal() {
             #login-btn:hover{color:red;}
             .remember-section{text-align:center;margin-top:10px;}
             .remember-heading{display:block;font-weight:700;text-align:center;}
-            .remember-check{width:100%;text-align:center;margin-top:5px;}
-            .remember-check input{width:20px;height:20px;display:block;margin:0 auto;}
+            .remember-check{width:100%;display:flex;justify-content:center;margin-top:5px;}
+            .remember-check input{width:20px;height:20px;}
             .remember-text{display:block;margin-top:5px;text-align:center;}
             .phone-input{position:relative;margin-top:5px;}
             .phone-input .phone-icon{position:absolute;left:10px;top:50%;transform:translateY(-50%);}

--- a/checkout.html
+++ b/checkout.html
@@ -289,14 +289,13 @@
         }
         .remember-check {
             width: 100%;
-            text-align: center;
+            display: flex;
+            justify-content: center;
             margin-top: 5px;
         }
         .remember-check input {
             width: 20px;
             height: 20px;
-            display: block;
-            margin: 0 auto;
         }
         .remember-text {
             display: block;


### PR DESCRIPTION
## Summary
- Center the "Remember me" checkbox on mobile by using flex layout in cart modal, cart page and checkout page
- Display tax as $0.00 by default so order summaries always show calculated tax in cart and checkout forms

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d71a433c8321918609bc92d9749c