### PR TITLE
Use Shop Pay half logo in remember section

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -659,7 +659,7 @@
                 <p class="phone-error" style="display:none;color:red;">The specified phone number does not match the expected pattern.</p>
                 <div class="secure-row">
                     <span class="secure-text">Secure and encrypted</span>
-                    <div class="shop-logo"><img src="shoppay.png" alt="Shop Pay"></div>
+                    <div class="shop-logo"><img src="shoppayhalf.png" alt="Shop Pay"></div>
                 </div>
             </div>
             <div class="order-summary-details">

--- a/cart.js
+++ b/cart.js
@@ -317,7 +317,7 @@ function createCartModal() {
                         <p class="phone-error" style="display:none;color:red;">The specified phone number does not match the expected pattern.</p>
                         <div class="secure-row">
                             <span class="secure-text">Secure and encrypted</span>
-                            <div class="shop-logo"><img src="shoppay.png" alt="Shop Pay"></div>
+                            <div class="shop-logo"><img src="shoppayhalf.png" alt="Shop Pay"></div>
                         </div>
                     </div>
                     <div class="order-summary-bar">

--- a/checkout.html
+++ b/checkout.html
@@ -344,8 +344,9 @@
             width: 80px;
             height: 100%;
             object-fit: cover;
-            object-position: left;
+            object-position: right;
             filter: grayscale(100%);
+            transform: translateX(-5px);
         }
         .checkout-domain {
             margin-top: 5px;
@@ -625,7 +626,7 @@
                 <p class="phone-error" style="display:none;color:red;">The specified phone number does not match the expected pattern.</p>
                 <div class="secure-row">
                     <span class="secure-text">Secure and encrypted</span>
-                    <div class="shop-logo"><img src="shoppay.png" alt="Shop Pay"></div>
+                    <div class="shop-logo"><img src="shoppayhalf.png" alt="Shop Pay"></div>
                 </div>
             </div>
             <div class="order-summary-bar">


### PR DESCRIPTION
## Summary
- swap in new `shoppayhalf.png` for the Shop Pay logo shown under the “Remember me” area
- keep grayscale style and right-aligned placement on checkout page

## Testing
- `node --check cart.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e7582e948321a9a4f53f58c3590e