### PR TITLE
Use local card logos and replace Stripe icon

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -594,14 +594,14 @@
                     <span class="payment-logos">
                         <img src="https://upload.wikimedia.org/wikipedia/commons/4/41/Visa_Logo.png" alt="Visa">
                         <img src="https://upload.wikimedia.org/wikipedia/commons/0/04/Mastercard-logo.png" alt="Mastercard">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/3/30/American_Express_logo_%282018%29.svg" alt="American Express">
+                        <img src="amex.png" alt="American Express">
                         <span class="more-logos" id="more-cards">+5
                             <div class="more-logos-box" id="more-cards-box">
-                                <img src="https://upload.wikimedia.org/wikipedia/commons/5/50/Discover_Card_logo.svg" alt="Discover">
-                                <img src="https://upload.wikimedia.org/wikipedia/commons/8/80/Elo_logo.svg" alt="Elo">
-                                <img src="https://upload.wikimedia.org/wikipedia/commons/2/2a/JCB_logo.svg" alt="JCB">
-                                <img src="https://upload.wikimedia.org/wikipedia/commons/1/1b/UnionPay_logo.svg" alt="UnionPay">
-                                <img src="https://upload.wikimedia.org/wikipedia/commons/b/b3/Stripe_Logo%2C_revised_2016.svg" alt="Stripe">
+                                <img src="discover.png" alt="Discover">
+                                <img src="elo.png" alt="Elo">
+                                <img src="jcb.png" alt="JCB">
+                                <img src="unionpay.png" alt="UnionPay">
+                                <img src="oo.png" alt="OO">
                             </div>
                         </span>
                     </span>

--- a/cart.js
+++ b/cart.js
@@ -252,14 +252,14 @@ function createCartModal() {
                             <span class="payment-logos">
                                 <img src="https://upload.wikimedia.org/wikipedia/commons/4/41/Visa_Logo.png" alt="Visa">
                                 <img src="https://upload.wikimedia.org/wikipedia/commons/0/04/Mastercard-logo.png" alt="Mastercard">
-                                <img src="https://upload.wikimedia.org/wikipedia/commons/3/30/American_Express_logo_%282018%29.svg" alt="American Express">
+                                <img src="amex.png" alt="American Express">
                                 <span class="more-logos" id="more-cards">+5
                                     <div class="more-logos-box" id="more-cards-box">
-                                        <img src="https://upload.wikimedia.org/wikipedia/commons/5/50/Discover_Card_logo.svg" alt="Discover">
-                                        <img src="https://upload.wikimedia.org/wikipedia/commons/8/80/Elo_logo.svg" alt="Elo">
-                                        <img src="https://upload.wikimedia.org/wikipedia/commons/2/2a/JCB_logo.svg" alt="JCB">
-                                        <img src="https://upload.wikimedia.org/wikipedia/commons/1/1b/UnionPay_logo.svg" alt="UnionPay">
-                                        <img src="https://upload.wikimedia.org/wikipedia/commons/b/b3/Stripe_Logo%2C_revised_2016.svg" alt="Stripe">
+                                        <img src="discover.png" alt="Discover">
+                                        <img src="elo.png" alt="Elo">
+                                        <img src="jcb.png" alt="JCB">
+                                        <img src="unionpay.png" alt="UnionPay">
+                                        <img src="oo.png" alt="OO">
                                     </div>
                                 </span>
                             </span>

--- a/checkout.html
+++ b/checkout.html
@@ -561,14 +561,14 @@
                     <span class="payment-logos">
                         <img src="https://upload.wikimedia.org/wikipedia/commons/4/41/Visa_Logo.png" alt="Visa">
                         <img src="https://upload.wikimedia.org/wikipedia/commons/0/04/Mastercard-logo.png" alt="Mastercard">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/3/30/American_Express_logo_%282018%29.svg" alt="American Express">
+                        <img src="amex.png" alt="American Express">
                         <span class="more-logos" id="more-cards">+5
                             <div class="more-logos-box" id="more-cards-box">
-                                <img src="https://upload.wikimedia.org/wikipedia/commons/5/50/Discover_Card_logo.svg" alt="Discover">
-                                <img src="https://upload.wikimedia.org/wikipedia/commons/8/80/Elo_logo.svg" alt="Elo">
-                                <img src="https://upload.wikimedia.org/wikipedia/commons/2/2a/JCB_logo.svg" alt="JCB">
-                                <img src="https://upload.wikimedia.org/wikipedia/commons/1/1b/UnionPay_logo.svg" alt="UnionPay">
-                                <img src="https://upload.wikimedia.org/wikipedia/commons/b/b3/Stripe_Logo%2C_revised_2016.svg" alt="Stripe">
+                                <img src="discover.png" alt="Discover">
+                                <img src="elo.png" alt="Elo">
+                                <img src="jcb.png" alt="JCB">
+                                <img src="unionpay.png" alt="UnionPay">
+                                <img src="oo.png" alt="OO">
                             </div>
                         </span>
                     </span>


### PR DESCRIPTION
## Summary
- Replace external American Express, Discover, Elo, JCB, UnionPay, and Stripe logos with newly added local images
- Swap Stripe logo for `oo.png` in card collections

## Testing
- `python -m py_compile generate_category_pages.py`
- `node --check cart.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0ebe5073c8321958ee6a616d4289d