### PR TITLE
Ensure Shop Pay option layout is responsive

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -397,10 +397,12 @@
             display: flex;
             flex-direction: column;
             align-items: flex-start;
+            overflow: visible;
+            text-overflow: unset;
         }
         .payment-option.shop-pay .payment-label .subtext {
             font-size: 0.8em;
-            white-space: nowrap;
+            white-space: normal;
             margin-top: 2px;
         }
         .payment-logos {
@@ -430,6 +432,9 @@
             .payment-logos {
                 margin-left: 10px;
                 justify-content: flex-start;
+            }
+            .payment-option.shop-pay .payment-label .subtext {
+                font-size: 0.7em;
             }
         }
 


### PR DESCRIPTION
## Summary
- prevent Shop Pay label from truncating and stack subtext below
- shrink Shop Pay subtext on small screens for better fit

## Testing
- `npm test` (fails: could not read package.json)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0f0893d448321bc0844545eb543e1