### PR TITLE
Refine Shop Pay display and PayPal alignment

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -60,6 +60,7 @@
             margin: 10px auto;
             justify-content: center;
             justify-items: center;
+            align-items: center;
             max-width: 260px;
             width: 100%;
         }
@@ -114,7 +115,8 @@
             width: 80px;
             height: 40px;
             padding: 0;
-            margin-top: 5px;
+            margin-top: 10px;
+            align-self: center;
         }
         .payment-icons img {
             width: 80px;
@@ -399,6 +401,8 @@
             display: flex;
             flex-direction: column;
             align-items: flex-start;
+            overflow: visible;
+            text-overflow: unset;
         }
         .payment-option.shop-pay .payment-label .subtext {
             font-size: 0.8em;
@@ -440,7 +444,10 @@
                 flex-wrap: wrap;
                 flex-shrink: 1;
                 max-width: 100%;
-        }
+            }
+            .payment-option.shop-pay .payment-label .subtext {
+                font-size: 0.6em;
+            }
         }
 
         .more-logos {

--- a/checkout.html
+++ b/checkout.html
@@ -55,6 +55,7 @@
             margin: 10px auto;
             justify-content: center;
             justify-items: center;
+            align-items: center;
             max-width: 260px;
             width: 100%;
         }
@@ -106,7 +107,8 @@
             width: 80px;
             height: 40px;
             padding: 0;
-            margin-top: 5px;
+            margin-top: 10px;
+            align-self: center;
         }
         .payment-icons img {
             width: 80px;
@@ -434,7 +436,7 @@
                 justify-content: flex-start;
             }
             .payment-option.shop-pay .payment-label .subtext {
-                font-size: 0.7em;
+                font-size: 0.6em;
             }
         }
 


### PR DESCRIPTION
## Summary
- Ensure Shop Pay option shows subtext on a second line with mobile-friendly sizing
- Center PayPal express button with other payment icons

## Testing
- `npx --yes htmlhint cart.html checkout.html` (fails: 403 Forbidden)
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a0f2f9ad8483219b5a630d1a106040