### PR TITLE
Fix credit card logo display and enforce checkout selections

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -463,14 +463,15 @@
             bottom: 100%;
             left: 50%;
             transform: translateX(-50%);
-            background: #000;
+            background: #fff;
             padding: 5px;
             z-index: 10;
+            border: 1px solid #ccc;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.15);
         }
         .more-logos-box img {
             height: 20px;
             margin: 0 2px;
-            filter: invert(1);
         }
         .order-summary-details {
             margin: 10px 0;

--- a/cart.js
+++ b/cart.js
@@ -62,11 +62,13 @@ function addToCart(button) {
     if (hasColor && !colorSelected) missing.push('color');
 
     if (missing.length) {
-        let msg = 'Please select ';
+        let msg = '';
         if (missing.length === 2) {
-            msg += 'a size and color.';
+            msg = 'Please select a style/color and size.';
+        } else if (missing[0] === 'color') {
+            msg = 'Please select a style/color.';
         } else {
-            msg += `a ${missing[0]}.`;
+            msg = 'Please select a size.';
         }
         showSelectionError(msg);
         return;
@@ -141,6 +143,16 @@ function showSelectionError(message) {
         modal.style.display = 'none';
         populateCartModal();
     }, 2000);
+}
+
+function highlightField(field) {
+    if (!field) return;
+    field.focus();
+    field.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    field.style.outline = '2px solid red';
+    field.addEventListener('input', () => {
+        field.style.outline = '';
+    }, { once: true });
 }
 
 function createCartModal() {
@@ -457,8 +469,8 @@ function createCartModal() {
             .payment-logos img[alt="Apple Pay"]{height:30px;}
             .payment-logos img.klarna-logo{height:40px;}
             .more-logos{position:relative;margin-left:5px;cursor:pointer;color:#000;font-weight:600;}
-            .more-logos-box{display:none;position:absolute;bottom:100%;left:50%;transform:translateX(-50%);background:#000;padding:5px;z-index:10;}
-            .more-logos-box img{height:20px;margin:0 2px;filter:invert(1);}
+            .more-logos-box{display:none;position:absolute;bottom:100%;left:50%;transform:translateX(-50%);background:#fff;padding:5px;z-index:10;border:1px solid #ccc;box-shadow:0 2px 8px rgba(0,0,0,0.15);}
+            .more-logos-box img{height:20px;margin:0 2px;}
             .shipping-method{display:flex;justify-content:space-between;border:1px solid #ccc;padding:10px;margin:5px 0;}
             #cart-modal .logo-container{width:80px;height:80px;margin:0 auto;}
             #cart-modal .logo-container iframe{width:100%;height:100%;border:none;}
@@ -803,22 +815,29 @@ function setupFinalForm(form) {
     form.addEventListener('submit', e => {
         e.preventDefault();
         let valid = true;
+        let firstInvalid = null;
         if (remember && remember.checked && phoneInput && phoneInput.value.trim() === '') {
             if (warn) warn.style.display = 'block';
+            firstInvalid = firstInvalid || phoneInput;
             valid = false;
         }
         if (creditRadio && creditRadio.checked) {
-            const empty = Array.from(cardInputs).some(inp => inp.value.trim() === '');
-            if (empty) {
+            const emptyInput = Array.from(cardInputs).find(inp => inp.value.trim() === '');
+            if (emptyInput) {
                 if (cardWarning) cardWarning.style.display = 'block';
+                firstInvalid = firstInvalid || emptyInput;
                 valid = false;
             }
         }
         if (emailInput && emailInput.value.trim() === '') {
             if (emailWarning) emailWarning.style.display = 'block';
+            firstInvalid = firstInvalid || emailInput;
             valid = false;
         }
-        if (!valid) return;
+        if (!valid) {
+            highlightField(firstInvalid);
+            return;
+        }
         if (phoneInput && phoneInput.value.trim() && !phoneInput.value.startsWith('+1')) {
             phoneInput.value = '+1' + phoneInput.value;
         }

--- a/checkout.html
+++ b/checkout.html
@@ -453,14 +453,15 @@
             bottom: 100%;
             left: 50%;
             transform: translateX(-50%);
-            background: #000;
+            background: #fff;
             padding: 5px;
             z-index: 10;
+            border: 1px solid #ccc;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.15);
         }
         .more-logos-box img {
             height: 20px;
             margin: 0 2px;
-            filter: invert(1);
         }
         .shipping-method {
             display: flex;
@@ -763,13 +764,19 @@
         const moreCards = document.getElementById('more-cards');
         const moreCardsBox = document.getElementById('more-cards-box');
         if (moreCards && moreCardsBox) {
+            const showBox = () => { moreCardsBox.style.display = 'flex'; };
+            const hideBox = () => { moreCardsBox.style.display = 'none'; };
+            moreCards.addEventListener('mouseenter', showBox);
+            moreCards.addEventListener('mouseleave', hideBox);
             moreCards.addEventListener('click', function(e) {
                 e.stopPropagation();
-                moreCardsBox.style.display = moreCardsBox.style.display === 'flex' ? 'none' : 'flex';
+                if (moreCardsBox.style.display === 'flex') {
+                    hideBox();
+                } else {
+                    showBox();
+                }
             });
-            document.addEventListener('click', function() {
-                moreCardsBox.style.display = 'none';
-            });
+            document.addEventListener('click', hideBox);
         }
 
         const summaryToggle = document.getElementById('toggle-order-summary');
@@ -791,6 +798,28 @@
         const rememberMsg = document.getElementById('remember-message');
         const phoneInput = phone ? phone.querySelector('input[name="remember_phone"]') : null;
         const rememberWarning = document.querySelector('.remember-warning');
+        const emailInput = document.querySelector('input[name="contact_email"]');
+        const emailWarning = document.querySelector('.email-warning');
+        const creditRadio = document.getElementById('pay-credit');
+        const cardInputs = document.querySelectorAll('.credit-card-fields input');
+        const cardWarning = document.querySelector('.card-warning');
+
+        function highlightField(field) {
+            if (!field) return;
+            field.focus();
+            field.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            field.style.outline = '2px solid red';
+            field.addEventListener('input', () => { field.style.outline = ''; }, { once: true });
+        }
+
+        cardInputs.forEach(inp => inp.addEventListener('input', () => {
+            if (cardWarning) cardWarning.style.display = 'none';
+        }));
+        if (emailInput) {
+            emailInput.addEventListener('input', () => {
+                if (emailWarning) emailWarning.style.display = 'none';
+            });
+        }
         if (remember) {
             remember.addEventListener('change', () => {
                 const show = remember.checked;
@@ -807,9 +836,29 @@
             const finalForm = document.getElementById('final-form');
             if (finalForm) {
                 finalForm.addEventListener('submit', e => {
+                    let valid = true;
+                    let firstInvalid = null;
                     if (remember && remember.checked && phoneInput.value.trim() === '') {
-                        e.preventDefault();
                         if (rememberWarning) rememberWarning.style.display = 'block';
+                        firstInvalid = firstInvalid || phoneInput;
+                        valid = false;
+                    }
+                    if (creditRadio && creditRadio.checked) {
+                        const emptyInput = Array.from(cardInputs).find(inp => inp.value.trim() === '');
+                        if (emptyInput) {
+                            if (cardWarning) cardWarning.style.display = 'block';
+                            firstInvalid = firstInvalid || emptyInput;
+                            valid = false;
+                        }
+                    }
+                    if (emailInput && emailInput.value.trim() === '') {
+                        if (emailWarning) emailWarning.style.display = 'block';
+                        firstInvalid = firstInvalid || emailInput;
+                        valid = false;
+                    }
+                    if (!valid) {
+                        e.preventDefault();
+                        highlightField(firstInvalid);
                         return;
                     }
                     if (phoneInput.value.trim() && !phoneInput.value.startsWith('+1')) {


### PR DESCRIPTION
## Summary
- Show all credit card logos with a white popup background
- Warn customers when color or size is missing on add to cart
- Highlight and focus checkout fields that need input

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check cart.js`


------
https://chatgpt.com/codex/tasks/task_e_68a13b3d1c2c8321abfe1b569234bf21