### PR TITLE
Display missing selection warnings and highlight fields

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -70,6 +70,12 @@ function addToCart(button) {
         } else {
             msg = 'Please select a size.';
         }
+        if (missing.includes('color')) {
+            highlightField(item.querySelector('.color-options'));
+        }
+        if (missing.includes('size')) {
+            highlightField(item.querySelector('.size-select select'));
+        }
         showSelectionError(msg);
         return;
     }
@@ -131,15 +137,19 @@ function showSelectionError(message) {
         const el = content.querySelector(sel);
         if (el) el.style.display = 'none';
     });
-    let msg = content.querySelector('.empty-cart-message');
+    let msg = content.querySelector('.selection-error');
     if (!msg) {
         msg = document.createElement('div');
-        msg.className = 'empty-cart-message';
+        msg.className = 'selection-error';
+        msg.style.textAlign = 'center';
+        msg.style.color = 'red';
+        msg.style.fontWeight = 'bold';
         content.appendChild(msg);
     }
     msg.textContent = message;
     modal.style.display = 'flex';
     setTimeout(() => {
+        msg.remove();
         modal.style.display = 'none';
         populateCartModal();
     }, 2000);
@@ -150,9 +160,10 @@ function highlightField(field) {
     field.focus();
     field.scrollIntoView({ behavior: 'smooth', block: 'center' });
     field.style.outline = '2px solid red';
-    field.addEventListener('input', () => {
-        field.style.outline = '';
-    }, { once: true });
+    const clear = () => { field.style.outline = ''; };
+    field.addEventListener('input', clear, { once: true });
+    field.addEventListener('change', clear, { once: true });
+    field.addEventListener('click', clear, { once: true });
 }
 
 function createCartModal() {


### PR DESCRIPTION
## Summary
- Show cart error messages for missing color and size selections in a dedicated element with red styling
- Highlight missing color or size options when attempting to add to cart
- Reset red outlines after user interacts with highlighted fields

## Testing
- `node --check cart.js`
- `node --check product.js`

------
https://chatgpt.com/codex/tasks/task_e_68a1452c3a6883219cf551a4e5ee9b43