### PR TITLE
Show tax and shipping in top order summary

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -237,6 +237,8 @@ function createCartModal() {
                         <div class="cart-items"></div>
                         <div class="cost-summary">
                             <div><span>Subtotal</span><span class="subtotal">$0.00</span></div>
+                            <div><span>Tax</span><span class="tax">$0.00</span></div>
+                            <div><span>Shipping</span><span class="shipping">Select shipping method</span></div>
                             <div><strong>Total</strong><strong class="total">$0.00</strong></div>
                         </div>
                     </div>

--- a/checkout.html
+++ b/checkout.html
@@ -540,6 +540,8 @@
                 <div class="cart-items"></div>
                 <div class="cost-summary">
                     <div><span>Subtotal</span><span class="subtotal">$0.00</span></div>
+                    <div><span>Tax</span><span class="tax">$0.00</span></div>
+                    <div><span>Shipping</span><span class="shipping">Select shipping method</span></div>
                     <div><strong>Total</strong><strong class="total">$0.00</strong></div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Add tax and shipping lines to the checkout page's top order summary to match the bottom summary
- Mirror those lines in the cart modal's checkout summary

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a15e56ae448321952bddaa8f5fdca5