### PR TITLE
Show empty cart message when clicking icon with no items

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -121,7 +121,13 @@ function openCart(showForm = false) {
     }
     populateCartModal();
     modal.style.display = 'flex';
-    if (showForm && cart.length > 0) {
+    if (cart.length === 0) {
+        const msg = modal.querySelector('.empty-cart-message');
+        if (msg) {
+            msg.textContent = 'Your cart is empty.';
+            msg.style.display = 'block';
+        }
+    } else if (showForm) {
         showCheckoutForm(modal);
     }
 }


### PR DESCRIPTION
## Summary
- Ensure openCart displays 'Your cart is empty.' when the shopping cart icon is clicked with an empty cart.

## Testing
- `node --check cart.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1635a72448321b4e205bd7acb8e4c