### PR TITLE
Hide empty cart message when selection errors occur

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -139,7 +139,7 @@ function showSelectionError(message) {
         modal = createCartModal();
     }
     const content = modal.querySelector('.cart-content');
-    const hideSelectors = ['.logo-container', '#cart-current-time', 'h2', '.item-count', '.order-summary-bar', '#order-summary-details', '.cart-buttons', '.or', '.express-checkout', '#checkout-form', '.footer-links', '.cart-footer'];
+    const hideSelectors = ['.logo-container', '#cart-current-time', 'h2', '.item-count', '.order-summary-bar', '#order-summary-details', '.cart-buttons', '.or', '.express-checkout', '#checkout-form', '.footer-links', '.cart-footer', '.cart-empty-message'];
     hideSelectors.forEach(sel => {
         const el = content.querySelector(sel);
         if (el) el.style.display = 'none';


### PR DESCRIPTION
## Summary
- Avoid showing cart empty message when selection error prompts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2054d34448321bd8b055977c22904