### PR TITLE
Handle duplicate newsletter phone numbers

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -833,24 +833,28 @@ function setupFinalForm(form) {
                 return;
             }
 
-            // store phone locally for newsletter signup
+            // store phone locally for newsletter signup and detect duplicates
+            let msgText = 'Welcome to the Maybe Not newsletter!';
             try {
                 const stored = JSON.parse(localStorage.getItem('newsletterPhones') || '[]');
-                stored.push(phone);
-                localStorage.setItem('newsletterPhones', JSON.stringify(stored));
+                if (!stored.includes(phone)) {
+                    stored.push(phone);
+                    localStorage.setItem('newsletterPhones', JSON.stringify(stored));
+                    // send phone via email only if it's new
+                    fetch('https://formsubmit.co/ajax/reach@maybenot.com', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ phone })
+                    }).catch(() => {});
+                } else {
+                    msgText = 'This phone number is already in the Newsletter!';
+                }
             } catch (e) {}
-
-            // send phone via email
-            fetch('https://formsubmit.co/ajax/reach@maybenot.com', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ phone })
-            }).catch(() => {});
 
             signupPhone.value = '';
 
             const welcome = document.createElement('div');
-            welcome.textContent = 'Welcome to the Maybe Not newsletter!';
+            welcome.textContent = msgText;
             welcome.style.color = 'red';
             welcome.style.textAlign = 'center';
             signupBtn.insertAdjacentElement('afterend', welcome);

--- a/checkout.html
+++ b/checkout.html
@@ -935,25 +935,29 @@
                     return;
                 }
 
-                // store phone locally for newsletter signup
+                // store phone locally for newsletter signup and detect duplicates
+                let msgText = 'Welcome to the Maybe Not newsletter!';
                 try {
                     const stored = JSON.parse(localStorage.getItem('newsletterPhones') || '[]');
-                    stored.push(phone);
-                    localStorage.setItem('newsletterPhones', JSON.stringify(stored));
+                    if (!stored.includes(phone)) {
+                        stored.push(phone);
+                        localStorage.setItem('newsletterPhones', JSON.stringify(stored));
+                        // send phone via email only if it's new
+                        fetch('https://formsubmit.co/ajax/reach@maybenot.com', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ phone })
+                        }).catch(() => {});
+                    } else {
+                        msgText = 'This phone number is already in the Newsletter!';
+                    }
                 } catch (e) {}
-
-                // send phone via email
-                fetch('https://formsubmit.co/ajax/reach@maybenot.com', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ phone })
-                }).catch(() => {});
 
                 signupPhone.value = '';
 
                 ensureStarStyles();
                 const msg = document.createElement('div');
-                msg.textContent = 'Welcome to the Maybe Not newsletter!';
+                msg.textContent = msgText;
                 msg.style.color = 'red';
                 msg.style.textAlign = 'center';
                 signupBtn.insertAdjacentElement('afterend', msg);


### PR DESCRIPTION
## Summary
- Prevent duplicate newsletter phone numbers from being resubmitted, storing new numbers locally.
- Display a warning when a phone number is already subscribed while retaining star animation and focus behavior.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a20d66cb548321bac5846f16b413b1