### PR TITLE
Enlarge PayPal logo in pay button

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -85,7 +85,7 @@
             text-align: center;
         }
         .paypal-inline {
-            height: 1em;
+            height: 1.5em;
             vertical-align: middle;
             filter: brightness(0) invert(1);
         }

--- a/checkout.html
+++ b/checkout.html
@@ -80,7 +80,7 @@
             text-align: center;
         }
         .paypal-inline {
-            height: 1em;
+            height: 1.5em;
             vertical-align: middle;
             filter: brightness(0) invert(1);
         }


### PR DESCRIPTION
## Summary
- Increase PayPal logo size in "Pay now with PayPal" button across cart and checkout pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a21cac6ea08321906de1ae108ffa65