### PR TITLE
Add legal pages and footer navigation

### DIFF
--- a/accessibility.html
+++ b/accessibility.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Accessibility - MaybeNot</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+    <style>
+        body { margin:0; padding:20px; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; }
+        h1 { text-transform:lowercase; text-align:center; font-size:1.2rem; }
+        main { max-width:800px; margin:0 auto; font-size:0.9rem; line-height:1.4; }
+        .footer-links { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; margin-top:40px; }
+        .footer-links a { color:#000; text-decoration:none; font-size:0.7rem; }
+        .footer-links a:hover, .footer-links a:focus, .footer-links a:active { border:2px solid red; color:red; }
+    </style>
+</head>
+<body>
+<main>
+    <h1>accessibility</h1>
+    <p>MaybeNot is committed to providing a website that is accessible to all visitors. We follow best practices and regularly review our site to improve usability.</p>
+    <p>If you encounter any barriers, please contact <a href="mailto:access@maybenot.com">access@maybenot.com</a> so we can assist you.</p>
+    <p>Feedback helps us enhance accessibility features and ensure an inclusive experience for everyone.</p>
+    <div class="footer-links">
+        <a href="terms.html">terms</a>
+        <a href="privacy.html">privacy</a>
+        <a href="faq.html">f.a.q.</a>
+        <a href="accessibility.html">accessibility</a>
+    </div>
+</main>
+</body>
+</html>

--- a/faq.html
+++ b/faq.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>FAQ - MaybeNot</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+    <style>
+        body { margin:0; padding:20px; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; }
+        h1 { text-transform:lowercase; text-align:center; font-size:1.2rem; }
+        main { max-width:800px; margin:0 auto; font-size:0.9rem; line-height:1.4; }
+        h2 { font-size:1rem; margin-top:20px; }
+        .footer-links { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; margin-top:40px; }
+        .footer-links a { color:#000; text-decoration:none; font-size:0.7rem; }
+        .footer-links a:hover, .footer-links a:focus, .footer-links a:active { border:2px solid red; color:red; }
+    </style>
+</head>
+<body>
+<main>
+    <h1>f.a.q.</h1>
+    <h2>when do new items release?</h2>
+    <p>Products drop at random intervals. Check the news page and social accounts for updates.</p>
+    <h2>do you accept returns?</h2>
+    <p>All sales are final unless a product is defective.</p>
+    <h2>how can i track my order?</h2>
+    <p>Tracking details are emailed once your order ships.</p>
+    <h2>do you ship internationally?</h2>
+    <p>At this time orders ship only within the United States.</p>
+    <div class="footer-links">
+        <a href="terms.html">terms</a>
+        <a href="privacy.html">privacy</a>
+        <a href="faq.html">f.a.q.</a>
+        <a href="accessibility.html">accessibility</a>
+    </div>
+</main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -105,6 +105,27 @@
             background-color: white;
         }
 
+        footer .legal-links {
+            margin-top: 20px;
+            display: flex;
+            justify-content: center;
+            gap: 8px;
+            font-size: 0.7rem;
+        }
+
+        footer .legal-links a {
+            color: #000;
+            text-decoration: none;
+        }
+
+        footer .legal-links a:hover,
+        footer .legal-links a:focus,
+        footer .legal-links a:active {
+            border: 2px solid red;
+            color: red;
+            background-color: white;
+        }
+
         /* Social icons styling */
         footer .social-icons {
             display: flex;
@@ -225,7 +246,7 @@
 <body>
 
 <div class="cookie-banner" id="cookie-banner">
-    This site uses cookies to improve your experience. By continuing to browse, you agree to the use of cookies. Read the <a href="#">Privacy Policy</a> here.<span class="cookie-close" onclick="closeCookieBanner()">✖</span>
+    This site uses cookies to improve your experience. By continuing to browse, you agree to the use of cookies. Read the <a href="privacy.html">Privacy Policy</a> here.<span class="cookie-close" onclick="closeCookieBanner()">✖</span>
 </div>
 
 <div class="container">
@@ -239,15 +260,15 @@
     <!-- Desktop Nav -->
     <nav class="desktop-nav">
         <ul>
-            <li><a href="#">news</a></li> <!-- Fix for first link hover -->
+            <li><a href="news.html">news</a></li> <!-- Fix for first link hover -->
             <li><a href="soon.html">winter 2025 preview</a></li>
             <li><a href="soon.html">winter 2025 lookbook</a></li>
             <li><a href="shop.html">shop</a></li>
-            <li><a href="#">random</a></li>
-            <li><a href="#">about</a></li>
-            <li><a href="#">stores</a></li>
-            <li><a href="#">contact</a></li>
-            <li><a href="#">mailing list</a></li>
+            <li><a href="random.html">random</a></li>
+            <li><a href="about.html">about</a></li>
+            <li><a href="stores.html">stores</a></li>
+            <li><a href="contact.html">contact</a></li>
+            <li><a href="mailinglist.html">mailing list</a></li>
         </ul>
     </nav>
 
@@ -278,6 +299,12 @@
                     <img src="wechat.png" alt="WeChat">
                 </div>
             </a>
+        </div>
+        <div class="legal-links">
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="accessibility.html">accessibility</a>
         </div>
     </footer>
 </div>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Privacy - MaybeNot</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+    <style>
+        body { margin:0; padding:20px; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; }
+        h1 { text-transform:lowercase; text-align:center; font-size:1.2rem; }
+        main { max-width:800px; margin:0 auto; font-size:0.9rem; line-height:1.4; }
+        .footer-links { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; margin-top:40px; }
+        .footer-links a { color:#000; text-decoration:none; font-size:0.7rem; }
+        .footer-links a:hover, .footer-links a:focus, .footer-links a:active { border:2px solid red; color:red; }
+    </style>
+</head>
+<body>
+<main>
+    <h1>privacy policy</h1>
+    <p>We collect information you provide, such as contact details and order data, to process purchases and improve our services.</p>
+    <h2>cookies</h2>
+    <p>Cookies help remember your preferences. You can disable cookies in your browser, but some features may not function properly.</p>
+    <h2>sharing</h2>
+    <p>Information is shared with trusted service providers to fulfill orders and meet legal requirements.</p>
+    <h2>your rights</h2>
+    <p>Contact us to access, correct, or delete your personal data. We respond to reasonable requests as required by law.</p>
+    <div class="footer-links">
+        <a href="terms.html">terms</a>
+        <a href="privacy.html">privacy</a>
+        <a href="faq.html">f.a.q.</a>
+        <a href="accessibility.html">accessibility</a>
+    </div>
+</main>
+</body>
+</html>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Terms - MaybeNot</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+    <style>
+        body { margin:0; padding:20px; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; }
+        h1 { text-transform:lowercase; text-align:center; font-size:1.2rem; }
+        main { max-width:800px; margin:0 auto; font-size:0.9rem; line-height:1.4; }
+        .footer-links { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; margin-top:40px; }
+        .footer-links a { color:#000; text-decoration:none; font-size:0.7rem; }
+        .footer-links a:hover, .footer-links a:focus, .footer-links a:active { border:2px solid red; color:red; }
+    </style>
+</head>
+<body>
+<main>
+    <h1>terms of service</h1>
+    <p>These terms govern use of the MaybeNot website and purchases made through it. By accessing the site, you agree to follow our policies and applicable laws.</p>
+    <h2>orders</h2>
+    <p>Products are released in limited quantities and may sell out without notice. Orders are subject to acceptance and may be cancelled if fraud is suspected.</p>
+    <h2>returns</h2>
+    <p>All sales are final unless otherwise stated. Contact support if there is an issue with your order.</p>
+    <h2>user conduct</h2>
+    <p>Do not misuse the site or interfere with its operation. We may suspend access for violations of these terms.</p>
+    <div class="footer-links">
+        <a href="terms.html">terms</a>
+        <a href="privacy.html">privacy</a>
+        <a href="faq.html">f.a.q.</a>
+        <a href="accessibility.html">accessibility</a>
+    </div>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Link site navigation to news, random, about, stores, contact and mailing list pages
- Add footer legal links and connect cookie banner to privacy policy
- Introduce simple Terms, Privacy, FAQ and Accessibility pages

## Testing
- `python -m py_compile generate_category_pages.py`
- `htmlhint index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a22943c7c08321b5a3a2a9c0760200