### PR TITLE
Improve footer placement and form interactions

### DIFF
--- a/about.html
+++ b/about.html
@@ -39,7 +39,7 @@
 
 <main>
     <h1>about</h1>
-    <p>Maybe Not started in 2016 on the south side of Chicago. We design objects and apparel in limited numbers. Everything is released when we feel like it—maybe now, maybe not.</p>
+    <p>Maybe Not started in 2016 on the south side of Chicago. We design objects and apparel in limited numbers. We've been grinding since day one with collections and shows along the way.</p>
 </main>
 
 <footer>

--- a/contact.html
+++ b/contact.html
@@ -16,6 +16,11 @@
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
         main { max-width:600px; margin:20px auto; padding:0 10px; font-size:0.9rem; }
         h1 { text-transform:lowercase; font-size:1.2rem; text-align:center; }
+        form { text-align:center; }
+        input, textarea { padding:5px; margin-top:10px; font-family:'Courier New', Courier, monospace; }
+        textarea { width:100%; max-width:100%; height:100px; }
+        button { margin-top:10px; background:#000; color:#fff; border:none; padding:8px 16px; cursor:pointer; font-family:'Courier New', Courier, monospace; }
+        button:hover, button:focus, button:active { background:red; color:#fff; }
         .footer-links { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; background-color:#f7f7f7; }
         .footer-line { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; padding-bottom:10px; }
         .footer-line.extra-padding { padding-bottom:10px; }
@@ -39,8 +44,17 @@
 
 <main>
     <h1>contact</h1>
-    <p>Email us at <a href="mailto:info@maybenot.com">info@maybenot.com</a>.</p>
-    <p>For support: <a href="mailto:support@maybenot.com">support@maybenot.com</a>.</p>
+    <form id="contact-form">
+        <label for="name">Name</label><br>
+        <input type="text" id="name" name="name" required><br>
+        <label for="email">Email</label><br>
+        <input type="email" id="email" name="email" required><br>
+        <label for="order">Order number (optional)</label><br>
+        <input type="text" id="order" name="order"><br>
+        <label for="message">Message</label><br>
+        <textarea id="message" name="message" rows="4" required></textarea><br>
+        <button type="submit">send</button>
+    </form>
 </main>
 
 <footer>
@@ -84,6 +98,14 @@ function updateChicagoTime() {
 }
 setInterval(updateChicagoTime, 1000);
 updateChicagoTime();
+const contactForm = document.getElementById('contact-form');
+if (contactForm) {
+    contactForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        alert('Thank you for reaching out. We take service very seriously, We will get back with you shortly!');
+        contactForm.reset();
+    });
+}
 const logoOverlay = document.querySelector('.logo-overlay');
 if (logoOverlay) {
     let pressTimer;

--- a/index.html
+++ b/index.html
@@ -105,6 +105,10 @@
             background-color: white;
         }
 
+        footer {
+            margin-top: auto;
+        }
+
         footer .legal-links {
             margin-top: 20px;
             display: flex;

--- a/mailinglist.html
+++ b/mailinglist.html
@@ -20,6 +20,8 @@
         input { padding:5px; margin-top:10px; }
         button { margin-top:10px; background:#000; color:#fff; border:none; padding:8px 16px; cursor:pointer; font-family: 'Courier New', Courier, monospace; }
         button:hover, button:focus, button:active { background:red; color:#fff; }
+        .shooting-star{position:fixed;font-size:30px;color:#FFD700;pointer-events:none;animation:shoot 1s ease-in-out forwards;text-shadow:0 0 6px #FFD700,0 0 12px #FFD700,0 0 20px #FFD700;z-index:9999;}
+        @keyframes shoot{0%{transform:translate(0,0) scale(1);opacity:1;}50%{transform:translate(calc(var(--dx)/2),calc(var(--dy)/2 - 80px)) scale(1.8);opacity:1;}100%{transform:translate(var(--dx),var(--dy)) scale(0.5);opacity:0;}}
         .footer-links { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; background-color:#f7f7f7; }
         .footer-line { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; padding-bottom:10px; }
         .footer-line.extra-padding { padding-bottom:10px; }
@@ -92,6 +94,42 @@ function updateChicagoTime() {
 }
 setInterval(updateChicagoTime, 1000);
 updateChicagoTime();
+const form = document.querySelector('form');
+if (form) {
+    form.addEventListener('submit', function(e) {
+        e.preventDefault();
+        const emailInput = document.getElementById('email');
+        const email = emailInput.value.trim();
+        if (email === '') return;
+        let msgText = 'Welcome to the Maybe Not Newsletter!';
+        try {
+            const stored = JSON.parse(localStorage.getItem('newsletterEmails') || '[]');
+            if (!stored.includes(email)) {
+                stored.push(email);
+                localStorage.setItem('newsletterEmails', JSON.stringify(stored));
+            } else {
+                msgText = 'This email is already in the Newsletter!';
+            }
+        } catch (err) {}
+        form.reset();
+        const msg = document.createElement('div');
+        msg.textContent = msgText;
+        msg.style.color = 'red';
+        msg.style.textAlign = 'center';
+        form.appendChild(msg);
+        setTimeout(() => msg.remove(), 3000);
+        const star = document.createElement('div');
+        star.className = 'shooting-star';
+        star.textContent = '★';
+        document.body.appendChild(star);
+        const rect = form.querySelector('button').getBoundingClientRect();
+        star.style.left = rect.left + rect.width / 2 + 'px';
+        star.style.top = rect.top + rect.height / 2 + 'px';
+        star.style.setProperty('--dx', '0px');
+        star.style.setProperty('--dy', '-200px');
+        star.addEventListener('animationend', () => star.remove());
+    });
+}
 const logoOverlay = document.querySelector('.logo-overlay');
 if (logoOverlay) {
     let pressTimer;


### PR DESCRIPTION
## Summary
- Anchor homepage footer to bottom of viewport
- Add full contact form with optional order number and confirmation popup
- Enhance mailing list sign‑up with rising star animation, duplicate email check, and red confirmation message
- Refresh about page copy to reflect ongoing work

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a22d74de0083218060fe0b0028830b