### PR TITLE
Center align content on new pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,7 +14,7 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        main { max-width:600px; margin:20px auto; padding:0 10px; font-size:0.9rem; }
+        main { max-width:600px; margin:20px auto; padding:0 10px; font-size:0.9rem; text-align:center; }
         h1 { text-transform:lowercase; font-size:1.2rem; text-align:center; }
         .footer-links { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; background-color:#f7f7f7; }
         .footer-line { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; padding-bottom:10px; }

--- a/accessibility.html
+++ b/accessibility.html
@@ -13,7 +13,7 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        main { max-width:800px; margin:20px auto; font-size:0.9rem; line-height:1.4; }
+        main { max-width:800px; margin:20px auto; font-size:0.9rem; line-height:1.4; text-align:center; }
         h1 { text-transform:lowercase; text-align:center; font-size:1.2rem; }
         .footer-links { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; background-color:#f7f7f7; }
         .footer-links a { color:#000; text-decoration:none; font-size:0.7rem; }

--- a/faq.html
+++ b/faq.html
@@ -13,7 +13,7 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        main { max-width:800px; margin:20px auto; font-size:0.9rem; line-height:1.4; }
+        main { max-width:800px; margin:20px auto; font-size:0.9rem; line-height:1.4; text-align:center; }
         h1 { text-transform:lowercase; text-align:center; font-size:1.2rem; }
         h2 { font-size:1rem; margin-top:20px; }
         .footer-links { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; background-color:#f7f7f7; }

--- a/mailinglist.html
+++ b/mailinglist.html
@@ -14,7 +14,7 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        main { max-width:600px; margin:20px auto; padding:0 10px; font-size:0.9rem; }
+        main { max-width:600px; margin:20px auto; padding:0 10px; font-size:0.9rem; text-align:center; }
         h1 { text-transform:lowercase; font-size:1.2rem; text-align:center; }
         form { text-align:center; }
         input { padding:5px; margin-top:10px; }

--- a/news.html
+++ b/news.html
@@ -15,7 +15,7 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        main { max-width:600px; margin:20px auto; padding:0 10px; font-size:0.9rem; }
+        main { max-width:600px; margin:20px auto; padding:0 10px; font-size:0.9rem; text-align:center; }
         h1 { text-transform:lowercase; font-size:1.2rem; text-align:center; }
         .news-item { margin-bottom:20px; }
         .news-item h2 { margin-bottom:5px; font-size:1rem; }

--- a/privacy.html
+++ b/privacy.html
@@ -13,7 +13,7 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        main { max-width:800px; margin:20px auto; font-size:0.9rem; line-height:1.4; }
+        main { max-width:800px; margin:20px auto; font-size:0.9rem; line-height:1.4; text-align:center; }
         h1 { text-transform:lowercase; text-align:center; font-size:1.2rem; }
         .footer-links { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; background-color:#f7f7f7; }
         .footer-links a { color:#000; text-decoration:none; font-size:0.7rem; }

--- a/random.html
+++ b/random.html
@@ -14,7 +14,7 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        main { max-width:600px; margin:20px auto; padding:0 10px; font-size:0.9rem; }
+        main { max-width:600px; margin:20px auto; padding:0 10px; font-size:0.9rem; text-align:center; }
         h1 { text-transform:lowercase; font-size:1.2rem; text-align:center; }
         .footer-links { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; background-color:#f7f7f7; }
         .footer-line { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; padding-bottom:10px; }

--- a/stores.html
+++ b/stores.html
@@ -14,7 +14,8 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        main { max-width:600px; margin:20px auto; padding:0 10px; font-size:0.9rem; }
+        main { max-width:600px; margin:20px auto; padding:0 10px; font-size:0.9rem; text-align:center; }
+        ul { list-style-position: inside; padding-left:0; }
         h1 { text-transform:lowercase; font-size:1.2rem; text-align:center; }
         .footer-links { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; background-color:#f7f7f7; }
         .footer-line { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; padding-bottom:10px; }

--- a/terms.html
+++ b/terms.html
@@ -13,7 +13,7 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        main { max-width:800px; margin:20px auto; font-size:0.9rem; line-height:1.4; }
+        main { max-width:800px; margin:20px auto; font-size:0.9rem; line-height:1.4; text-align:center; }
         h1 { text-transform:lowercase; text-align:center; font-size:1.2rem; }
         .footer-links { display:flex; justify-content:center; flex-wrap:wrap; gap:15px; background-color:#f7f7f7; }
         .footer-links a { color:#000; text-decoration:none; font-size:0.7rem; }


### PR DESCRIPTION
## Summary
- Center content across news, random, about, stores, mailing list, terms, privacy, FAQ, and accessibility pages
- Align store locations list and maintain consistent layout

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a237000f608321913ccaa1e9a57692