### PR TITLE
Add weekend processing note and update site footers

### DIFF
--- a/about.html
+++ b/about.html
@@ -45,7 +45,7 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
@@ -60,13 +60,13 @@
             <a href="about.html">about</a>
             <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
+            <a href="faq.html">f.a.q.</a>
             <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
             <a href="mailinglist.html">mailing list</a>
         </div>
     </div>

--- a/accessibility.html
+++ b/accessibility.html
@@ -39,11 +39,30 @@
     <p>Feedback helps us enhance accessibility features and ensure an inclusive experience for everyone.</p>
 </main>
 <footer>
-    <div class="footer-links">
-        <a href="terms.html">terms</a>
-        <a href="privacy.html">privacy</a>
-        <a href="faq.html">f.a.q.</a>
-        <a href="accessibility.html">accessibility</a>
+        <div class="footer-links">
+        <div class="footer-line extra-padding">
+            <a href="shop.html">shop</a>
+            <a href="all.html">view all</a>
+            <a href="soon.html">preview</a>
+            <a href="soon.html">lookbook</a>
+            <a href="news.html">news</a>
+        </div>
+        <br>
+        <br>
+        <div class="footer-line">
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
+            <a href="soon.html">sizing</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
+        </div>
+        <div class="footer-line less-padding">
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
+        </div>
     </div>
     <div class="full-site-link" id="full-site-link">
         <a href="index.html">full site</a>

--- a/accessories.html
+++ b/accessories.html
@@ -349,29 +349,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/all.html
+++ b/all.html
@@ -408,29 +408,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/americandenim.html
+++ b/americandenim.html
@@ -273,8 +273,30 @@
     </ul>
 </nav>
 <footer>
-    <div class="footer-links">
-        <a href="index.html">home</a>
+        <div class="footer-links">
+        <div class="footer-line extra-padding">
+            <a href="shop.html">shop</a>
+            <a href="all.html">view all</a>
+            <a href="soon.html">preview</a>
+            <a href="soon.html">lookbook</a>
+            <a href="news.html">news</a>
+        </div>
+        <br>
+        <br>
+        <div class="footer-line">
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
+            <a href="soon.html">sizing</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
+        </div>
+        <div class="footer-line less-padding">
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
+        </div>
     </div>
 </footer>
 <script src="cart.js"></script>

--- a/bags.html
+++ b/bags.html
@@ -349,29 +349,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/cart.html
+++ b/cart.html
@@ -719,20 +719,36 @@
     </div>
 </div>
 <footer>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
+        </div>
+        <br>
+        <br>
+        <div class="footer-line">
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
+            <a href="soon.html">sizing</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
+        </div>
+        <div class="footer-line less-padding">
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="cart-footer">
         <a href="#">refund policy</a> |
         <a href="#">shipping</a> |
-        <a href="#">privacy policy</a> |
-        <a href="#">terms of service</a> |
+        <a href="privacy.html">privacy policy</a> |
+        <a href="terms.html">terms of service</a> |
         <a href="#">cookies</a>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/cart.js
+++ b/cart.js
@@ -357,7 +357,7 @@ function createCartModal() {
                     <div class="remember-section">
                         <strong class="remember-heading">Remember me</strong>
                         <div class="remember-check">
-                            <input type="checkbox" name="remember" id="remember-me">
+                            <input type="checkbox" name="remember" id="remember-me" checked>
                         </div>
                         <label for="remember-me" class="remember-text">Save my information for a faster checkout with a Shop account</label>
                         <div id="phone-container" class="phone-input" style="display:none;">
@@ -374,6 +374,8 @@ function createCartModal() {
                     <div class="order-summary-bar">
                         <div class="summary-label">Order summary</div>
                     </div>
+                    <p class="order-note">PLEASE NOTE: WE DO NOT PROCESS ORDERS ON SATURDAYS AND SUNDAYS, PLEASE ALLOW AN ADDITIONAL 2 - 3 BUSINESS DAYS FOR PROCESSING TIME WHEN PLACED ON THE WEEKEND.
+ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
                     <div class="order-summary-details bottom-summary">
                         <div class="cart-items"></div>
                         <div class="cost-summary">
@@ -384,7 +386,7 @@ function createCartModal() {
                         </div>
                     </div>
                     <button id="final-order-submit" type="submit">Pay now</button>
-                    <p id="remember-message" style="display:none;">Your info will be saved to a Shop account. By continuing, you agree to Shop’s Terms of Service and acknowledge the Privacy Policy.</p>
+                    <p id="remember-message" style="display:none;">Your info will be saved to a Shop account. By continuing, you agree to Shop’s <a href="https://shop.app/terms-of-service" target="_blank">Terms of Service</a> and acknowledge the <a href="https://www.shopify.com/legal/privacy/consumers" target="_blank">Privacy Policy</a>.</p>
                 </form>
             </div>
             <footer>
@@ -394,14 +396,30 @@ function createCartModal() {
                         <a href="all.html">view all</a>
                         <a href="soon.html">preview</a>
                         <a href="soon.html">lookbook</a>
-                        <a href="soon.html">news</a>
+                        <a href="news.html">news</a>
+                    </div>
+                    <br>
+                    <br>
+                    <div class="footer-line">
+                        <a href="random.html">random</a>
+                        <a href="about.html">about</a>
+                        <a href="stores.html">stores</a>
+                        <a href="soon.html">sizing</a>
+                        <a href="faq.html">f.a.q.</a>
+                        <a href="contact.html">contact</a>
+                    </div>
+                    <div class="footer-line less-padding">
+                        <a href="terms.html">terms</a>
+                        <a href="privacy.html">privacy</a>
+                        <a href="accessibility.html">accessibility</a>
+                        <a href="mailinglist.html">mailing list</a>
                     </div>
                 </div>
                 <div class="cart-footer">
                     <a href="#">refund policy</a> |
                     <a href="#">shipping</a> |
-                    <a href="#">privacy policy</a> |
-                    <a href="#">terms of service</a> |
+                    <a href="privacy.html">privacy policy</a> |
+                    <a href="terms.html">terms of service</a> |
                     <a href="#">cookies</a>
                 </div>
             </footer>
@@ -478,6 +496,7 @@ function createCartModal() {
             .remember-check{margin-top:5px;display:flex;justify-content:center;align-items:center;width:auto;margin-left:auto;margin-right:auto;}
             .remember-check input{width:20px;height:20px;margin:0;}
             .remember-text{display:block;margin-top:5px;text-align:center;}
+            .order-note{text-align:left;font-size:0.8em;margin:0 0 10px;}
             .phone-input{margin-top:5px;display:flex;align-items:center;width:100%;}
             .phone-input .phone-icon{margin-right:5px;}
             .phone-input .phone-prefix{margin-right:5px;}
@@ -914,6 +933,10 @@ function setupFinalForm(form) {
             if (msg) msg.style.display = show ? 'block' : 'none';
             if (!show && warn) warn.style.display = 'none';
         });
+        if (remember.checked) {
+            if (phone) phone.style.display = 'flex';
+            if (msg) msg.style.display = 'block';
+        }
     }
     if (phoneInput) {
         phoneInput.addEventListener('input', () => {

--- a/category_template.html
+++ b/category_template.html
@@ -349,29 +349,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/checkout.html
+++ b/checkout.html
@@ -239,6 +239,12 @@
             background-color: white;
         }
 
+        .order-note {
+            text-align: left;
+            font-size: 0.8rem;
+            margin: 0 0 10px 0;
+        }
+
         .consent-text {
             font-size: 0.7rem;
             margin-top: 10px;
@@ -656,7 +662,7 @@
             <div class="remember-section">
                 <strong class="remember-heading">Remember me</strong>
                 <div class="remember-check">
-                    <input type="checkbox" name="remember" id="remember-me">
+                    <input type="checkbox" name="remember" id="remember-me" checked>
                 </div>
                 <label for="remember-me" class="remember-text">Save my information for a faster checkout with a Shop account</label>
                 <div id="phone-container" class="phone-input" style="display:none;">
@@ -673,6 +679,8 @@
             <div class="order-summary-bar">
                 <div class="summary-label">Order summary</div>
             </div>
+            <p class="order-note">PLEASE NOTE: WE DO NOT PROCESS ORDERS ON SATURDAYS AND SUNDAYS, PLEASE ALLOW AN ADDITIONAL 2 - 3 BUSINESS DAYS FOR PROCESSING TIME WHEN PLACED ON THE WEEKEND.
+ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
             <div class="order-summary-details bottom-summary">
                 <div class="cart-items"></div>
                 <div class="cost-summary">
@@ -683,24 +691,40 @@
                 </div>
             </div>
             <button id="final-order-submit" type="submit">Pay now</button>
-            <p id="remember-message" style="display:none;">Your info will be saved to a Shop account. By continuing, you agree to Shop’s Terms of Service and acknowledge the Privacy Policy.</p>
+            <p id="remember-message" style="display:none;">Your info will be saved to a Shop account. By continuing, you agree to Shop’s <a href="https://shop.app/terms-of-service" target="_blank">Terms of Service</a> and acknowledge the <a href="https://www.shopify.com/legal/privacy/consumers" target="_blank">Privacy Policy</a>.</p>
         </form>
     </div>
 <footer>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
+        </div>
+        <br>
+        <br>
+        <div class="footer-line">
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
+            <a href="soon.html">sizing</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
+        </div>
+        <div class="footer-line less-padding">
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="cart-footer">
         <a href="#">refund policy</a> |
         <a href="#">shipping</a> |
-        <a href="#">privacy policy</a> |
-        <a href="#">terms of service</a> |
+        <a href="privacy.html">privacy policy</a> |
+        <a href="terms.html">terms of service</a> |
         <a href="#">cookies</a>
     </div>
     <div class="full-site-link" id="full-site-link">
@@ -893,6 +917,10 @@
                 if (rememberMsg) rememberMsg.style.display = show ? 'block' : 'none';
                 if (!show && rememberWarning) rememberWarning.style.display = 'none';
             });
+            if (remember.checked) {
+                if (phone) phone.style.display = 'flex';
+                if (rememberMsg) rememberMsg.style.display = 'block';
+            }
         }
         if (phoneInput) {
             phoneInput.addEventListener('input', () => {

--- a/contact.html
+++ b/contact.html
@@ -60,7 +60,7 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
@@ -75,13 +75,13 @@
             <a href="about.html">about</a>
             <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
+            <a href="faq.html">f.a.q.</a>
             <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
             <a href="mailinglist.html">mailing list</a>
         </div>
     </div>

--- a/faq.html
+++ b/faq.html
@@ -45,11 +45,30 @@
     <p>At this time orders ship only within the United States.</p>
 </main>
 <footer>
-    <div class="footer-links">
-        <a href="terms.html">terms</a>
-        <a href="privacy.html">privacy</a>
-        <a href="faq.html">f.a.q.</a>
-        <a href="accessibility.html">accessibility</a>
+        <div class="footer-links">
+        <div class="footer-line extra-padding">
+            <a href="shop.html">shop</a>
+            <a href="all.html">view all</a>
+            <a href="soon.html">preview</a>
+            <a href="soon.html">lookbook</a>
+            <a href="news.html">news</a>
+        </div>
+        <br>
+        <br>
+        <div class="footer-line">
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
+            <a href="soon.html">sizing</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
+        </div>
+        <div class="footer-line less-padding">
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
+        </div>
     </div>
     <div class="full-site-link" id="full-site-link">
         <a href="index.html">full site</a>

--- a/gym.html
+++ b/gym.html
@@ -349,29 +349,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/hat.html
+++ b/hat.html
@@ -242,8 +242,30 @@
     </ul>
 </nav>
 <footer>
-    <div class="footer-links">
-        <a href="index.html">home</a>
+        <div class="footer-links">
+        <div class="footer-line extra-padding">
+            <a href="shop.html">shop</a>
+            <a href="all.html">view all</a>
+            <a href="soon.html">preview</a>
+            <a href="soon.html">lookbook</a>
+            <a href="news.html">news</a>
+        </div>
+        <br>
+        <br>
+        <div class="footer-line">
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
+            <a href="soon.html">sizing</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
+        </div>
+        <div class="footer-line less-padding">
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
+        </div>
     </div>
 </footer>
 <script src="cart.js"></script>

--- a/hats.html
+++ b/hats.html
@@ -358,29 +358,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/hoodie.html
+++ b/hoodie.html
@@ -118,8 +118,30 @@
     </ul>
 </nav>
 <footer>
-    <div class="footer-links">
-        <a href="index.html">home</a>
+        <div class="footer-links">
+        <div class="footer-line extra-padding">
+            <a href="shop.html">shop</a>
+            <a href="all.html">view all</a>
+            <a href="soon.html">preview</a>
+            <a href="soon.html">lookbook</a>
+            <a href="news.html">news</a>
+        </div>
+        <br>
+        <br>
+        <div class="footer-line">
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
+            <a href="soon.html">sizing</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
+        </div>
+        <div class="footer-line less-padding">
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
+        </div>
     </div>
 </footer>
 <script src="cart.js"></script>

--- a/jackets.html
+++ b/jackets.html
@@ -349,29 +349,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/mailinglist.html
+++ b/mailinglist.html
@@ -69,7 +69,7 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
@@ -84,13 +84,13 @@
             <a href="about.html">about</a>
             <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
+            <a href="faq.html">f.a.q.</a>
             <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
             <a href="mailinglist.html">mailing list</a>
         </div>
     </div>

--- a/new.html
+++ b/new.html
@@ -408,29 +408,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/news.html
+++ b/news.html
@@ -59,7 +59,7 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
@@ -74,13 +74,13 @@
             <a href="about.html">about</a>
             <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
+            <a href="faq.html">f.a.q.</a>
             <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
             <a href="mailinglist.html">mailing list</a>
         </div>
     </div>

--- a/pants.html
+++ b/pants.html
@@ -378,29 +378,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/privacy.html
+++ b/privacy.html
@@ -43,11 +43,30 @@
     <p>Contact us to access, correct, or delete your personal data. We respond to reasonable requests as required by law.</p>
 </main>
 <footer>
-    <div class="footer-links">
-        <a href="terms.html">terms</a>
-        <a href="privacy.html">privacy</a>
-        <a href="faq.html">f.a.q.</a>
-        <a href="accessibility.html">accessibility</a>
+        <div class="footer-links">
+        <div class="footer-line extra-padding">
+            <a href="shop.html">shop</a>
+            <a href="all.html">view all</a>
+            <a href="soon.html">preview</a>
+            <a href="soon.html">lookbook</a>
+            <a href="news.html">news</a>
+        </div>
+        <br>
+        <br>
+        <div class="footer-line">
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
+            <a href="soon.html">sizing</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
+        </div>
+        <div class="footer-line less-padding">
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
+        </div>
     </div>
     <div class="full-site-link" id="full-site-link">
         <a href="index.html">full site</a>

--- a/product.js
+++ b/product.js
@@ -110,26 +110,26 @@ document.addEventListener('DOMContentLoaded', () => {
     <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
-              <a href="all.html">view all</a>
+            <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/random.html
+++ b/random.html
@@ -46,7 +46,7 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
@@ -61,13 +61,13 @@
             <a href="about.html">about</a>
             <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
+            <a href="faq.html">f.a.q.</a>
             <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
             <a href="mailinglist.html">mailing list</a>
         </div>
     </div>

--- a/shirt.html
+++ b/shirt.html
@@ -242,8 +242,30 @@
     </ul>
 </nav>
 <footer>
-    <div class="footer-links">
-        <a href="index.html">home</a>
+        <div class="footer-links">
+        <div class="footer-line extra-padding">
+            <a href="shop.html">shop</a>
+            <a href="all.html">view all</a>
+            <a href="soon.html">preview</a>
+            <a href="soon.html">lookbook</a>
+            <a href="news.html">news</a>
+        </div>
+        <br>
+        <br>
+        <div class="footer-line">
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
+            <a href="soon.html">sizing</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
+        </div>
+        <div class="footer-line less-padding">
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
+        </div>
     </div>
 </footer>
 <script src="cart.js"></script>

--- a/shirts.html
+++ b/shirts.html
@@ -358,29 +358,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/shoes.html
+++ b/shoes.html
@@ -349,29 +349,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/shop.html
+++ b/shop.html
@@ -418,7 +418,7 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
@@ -433,13 +433,13 @@
             <a href="about.html">about</a>
             <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
+            <a href="faq.html">f.a.q.</a>
             <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
             <a href="mailinglist.html">mailing list</a>
         </div>
     </div>

--- a/skate.html
+++ b/skate.html
@@ -349,29 +349,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/soon.html
+++ b/soon.html
@@ -319,29 +319,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
-            <a href="#">preview</a>
-            <a href="#">lookbook</a>
-            <a href="#">news</a>
+            <a href="soon.html">preview</a>
+            <a href="soon.html">lookbook</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="#">random</a>
-            <a href="#">about</a>
-            <a href="#">stores</a>
-            <a href="#">sizing</a>
-            <a href="#">f.a.q.</a>
-            <a href="#">contact</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
+            <a href="soon.html">sizing</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="#">terms</a>
-            <a href="#">privacy</a>
-            <a href="#">accessibility</a>
-            <a href="#">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/stores.html
+++ b/stores.html
@@ -51,7 +51,7 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
@@ -66,13 +66,13 @@
             <a href="about.html">about</a>
             <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
+            <a href="faq.html">f.a.q.</a>
             <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
             <a href="mailinglist.html">mailing list</a>
         </div>
     </div>

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -358,29 +358,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -358,29 +358,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">

--- a/terms.html
+++ b/terms.html
@@ -43,11 +43,30 @@
     <p>Do not misuse the site or interfere with its operation. We may suspend access for violations of these terms.</p>
 </main>
 <footer>
-    <div class="footer-links">
-        <a href="terms.html">terms</a>
-        <a href="privacy.html">privacy</a>
-        <a href="faq.html">f.a.q.</a>
-        <a href="accessibility.html">accessibility</a>
+        <div class="footer-links">
+        <div class="footer-line extra-padding">
+            <a href="shop.html">shop</a>
+            <a href="all.html">view all</a>
+            <a href="soon.html">preview</a>
+            <a href="soon.html">lookbook</a>
+            <a href="news.html">news</a>
+        </div>
+        <br>
+        <br>
+        <div class="footer-line">
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
+            <a href="soon.html">sizing</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
+        </div>
+        <div class="footer-line less-padding">
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
+        </div>
     </div>
     <div class="full-site-link" id="full-site-link">
         <a href="index.html">full site</a>

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -349,29 +349,29 @@
 <footer>
     <br>
     <br>
-    <div class="footer-links">
+        <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
             <a href="soon.html">preview</a>
             <a href="soon.html">lookbook</a>
-            <a href="soon.html">news</a>
+            <a href="news.html">news</a>
         </div>
         <br>
         <br>
         <div class="footer-line">
-            <a href="soon.html">random</a>
-            <a href="soon.html">about</a>
-            <a href="soon.html">stores</a>
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
             <a href="soon.html">sizing</a>
-            <a href="soon.html">f.a.q.</a>
-            <a href="soon.html">contact</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
         </div>
         <div class="footer-line less-padding">
-            <a href="soon.html">terms</a>
-            <a href="soon.html">privacy</a>
-            <a href="soon.html">accessibility</a>
-            <a href="soon.html">mailing list</a>
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">


### PR DESCRIPTION
## Summary
- Add weekend processing disclaimer beneath the second order summary heading in checkout
- Preselect “Remember me” with Shop's Terms and Privacy links and display message on load
- Link footer navigation across shop, category, and product pages to the correct pages

## Testing
- `python -m py_compile generate_category_pages.py`
- `node --check cart.js product.js`


------
https://chatgpt.com/codex/tasks/task_e_68a23b6d5cbc8321ae0ce46d9c9bab22