### PR TITLE
Improve form inputs and full site link styling

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -45,14 +45,10 @@
 <main>
     <h1>contact</h1>
     <form id="contact-form">
-        <label for="name">Name</label><br>
-        <input type="text" id="name" name="name" required><br>
-        <label for="email">Email</label><br>
-        <input type="email" id="email" name="email" required><br>
-        <label for="order">Order number (optional)</label><br>
-        <input type="text" id="order" name="order"><br>
-        <label for="message">Message</label><br>
-        <textarea id="message" name="message" rows="4" required></textarea><br>
+        <input type="text" id="name" name="name" placeholder="Name" required><br>
+        <input type="email" id="email" name="email" placeholder="Email" required><br>
+        <input type="text" id="order" name="order" placeholder="Order number (optional)"><br>
+        <textarea id="message" name="message" rows="4" placeholder="Message" required></textarea><br>
         <button type="submit">send</button>
     </form>
 </main>

--- a/footer-highlight.js
+++ b/footer-highlight.js
@@ -5,4 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
       link.style.fontWeight = 'bold';
     }
   });
+
+  document.querySelectorAll('.full-site-link a').forEach(link => {
+    link.style.color = 'red';
+  });
 });

--- a/mailinglist.html
+++ b/mailinglist.html
@@ -52,10 +52,8 @@
     <p>Our webstore is currently closed and will reopen soon with our Fall/Winter 2025 collection.</p>
     <p>For information regarding future news and releases, please sign up for our mailing list below.</p>
     <form>
-        <label for="name">Name</label><br>
-        <input type="text" id="name" name="name"><br>
-        <label for="email">Email</label><br>
-        <input type="email" id="email" name="email" required><br>
+        <input type="text" id="name" name="name" placeholder="Name"><br>
+        <input type="email" id="email" name="email" placeholder="Email" required><br>
         <div class="phone-input">
             <span class="phone-icon">📱</span>
             <span class="phone-prefix">+1</span>


### PR DESCRIPTION
## Summary
- Place instructional text inside input fields on contact and mailing list pages
- Color "full site" footer link red across pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2483c25bc8321b6d1010bac088381