### PR TITLE
Ensure logo long-press navigates home across site

### DIFF
--- a/about.html
+++ b/about.html
@@ -101,7 +101,7 @@ if (logoOverlay) {
     const moveHandler = () => { moved = true; };
     const start = () => {
         moved = false;
-        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'shop.html'; }, 1000);
+        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'index.html'; }, 1000);
         document.addEventListener("mousemove", moveHandler);
         document.addEventListener("touchmove", moveHandler);
         document.addEventListener("mouseup", cancel);

--- a/accessibility.html
+++ b/accessibility.html
@@ -94,7 +94,7 @@ if (logoOverlay) {
     const moveHandler = () => { moved = true; };
     const start = () => {
         moved = false;
-        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'shop.html'; }, 1000);
+        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'index.html'; }, 1000);
         document.addEventListener("mousemove", moveHandler);
         document.addEventListener("touchmove", moveHandler);
         document.addEventListener("mouseup", cancel);

--- a/contact.html
+++ b/contact.html
@@ -120,7 +120,7 @@ if (logoOverlay) {
     const moveHandler = () => { moved = true; };
     const start = () => {
         moved = false;
-        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'shop.html'; }, 1000);
+        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'index.html'; }, 1000);
         document.addEventListener("mousemove", moveHandler);
         document.addEventListener("touchmove", moveHandler);
         document.addEventListener("mouseup", cancel);

--- a/faq.html
+++ b/faq.html
@@ -100,7 +100,7 @@ if (logoOverlay) {
     const moveHandler = () => { moved = true; };
     const start = () => {
         moved = false;
-        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'shop.html'; }, 1000);
+        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'index.html'; }, 1000);
         document.addEventListener("mousemove", moveHandler);
         document.addEventListener("touchmove", moveHandler);
         document.addEventListener("mouseup", cancel);

--- a/mailinglist.html
+++ b/mailinglist.html
@@ -176,7 +176,7 @@ if (logoOverlay) {
     const moveHandler = () => { moved = true; };
     const start = () => {
         moved = false;
-        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'shop.html'; }, 1000);
+        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'index.html'; }, 1000);
         document.addEventListener("mousemove", moveHandler);
         document.addEventListener("touchmove", moveHandler);
         document.addEventListener("mouseup", cancel);

--- a/news.html
+++ b/news.html
@@ -115,7 +115,7 @@ if (logoOverlay) {
     const moveHandler = () => { moved = true; };
     const start = () => {
         moved = false;
-        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'shop.html'; }, 1000);
+        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'index.html'; }, 1000);
         document.addEventListener("mousemove", moveHandler);
         document.addEventListener("touchmove", moveHandler);
         document.addEventListener("mouseup", cancel);

--- a/privacy.html
+++ b/privacy.html
@@ -98,7 +98,7 @@ if (logoOverlay) {
     const moveHandler = () => { moved = true; };
     const start = () => {
         moved = false;
-        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'shop.html'; }, 1000);
+        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'index.html'; }, 1000);
         document.addEventListener("mousemove", moveHandler);
         document.addEventListener("touchmove", moveHandler);
         document.addEventListener("mouseup", cancel);

--- a/random.html
+++ b/random.html
@@ -102,7 +102,7 @@ if (logoOverlay) {
     const moveHandler = () => { moved = true; };
     const start = () => {
         moved = false;
-        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'shop.html'; }, 1000);
+        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'index.html'; }, 1000);
         document.addEventListener("mousemove", moveHandler);
         document.addEventListener("touchmove", moveHandler);
         document.addEventListener("mouseup", cancel);

--- a/stores.html
+++ b/stores.html
@@ -107,7 +107,7 @@ if (logoOverlay) {
     const moveHandler = () => { moved = true; };
     const start = () => {
         moved = false;
-        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'shop.html'; }, 1000);
+        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'index.html'; }, 1000);
         document.addEventListener("mousemove", moveHandler);
         document.addEventListener("touchmove", moveHandler);
         document.addEventListener("mouseup", cancel);

--- a/terms.html
+++ b/terms.html
@@ -98,7 +98,7 @@ if (logoOverlay) {
     const moveHandler = () => { moved = true; };
     const start = () => {
         moved = false;
-        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'shop.html'; }, 1000);
+        pressTimer = setTimeout(() => { if (!moved) window.location.href = 'index.html'; }, 1000);
         document.addEventListener("mousemove", moveHandler);
         document.addEventListener("touchmove", moveHandler);
         document.addEventListener("mouseup", cancel);


### PR DESCRIPTION
## Summary
- Redirect 3D logo long-press to home page on remaining standalone pages
- Keep existing press duration while standardizing destination to `index.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a24c5c6a508321b91807ca584afecb