### PR TITLE
Bold current category link in navigation

### DIFF
--- a/footer-highlight.js
+++ b/footer-highlight.js
@@ -8,6 +8,13 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  // Bold the current category in navigation lists
+  document.querySelectorAll('.desktop-nav a, .mobile-nav a').forEach(link => {
+    if (link.getAttribute('href') === current) {
+      link.style.fontWeight = 'bold';
+    }
+  });
+
   document.querySelectorAll('.full-site-link a').forEach(link => {
     link.style.color = 'red';
   });


### PR DESCRIPTION
## Summary
- Enhance footer highlight script to also bold the current category in both desktop and mobile navigation lists
- Preserve existing footer highlighting behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a24d05b470832187d1f4409c46e1ab