### PR TITLE
Use Google Translate logo and center privacy content

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -13,8 +13,10 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        .translate-button { margin-top:10px; padding:5px 10px; border:1px solid #000; background-color:#f7f7f7; cursor:pointer; font-size:0.7rem; }
-        main { max-width:800px; margin:20px auto; font-size:0.9rem; line-height:1.4; text-align:left; }
+        .translate-button { margin-top:10px; padding:0; border:none; background:transparent; cursor:pointer; }
+        .translate-button img { width:24px; height:auto; }
+        main { max-width:800px; margin:20px auto; font-size:0.9rem; line-height:1.4; text-align:center; }
+        .print-link, .print-link:visited, .print-link:hover, .print-link:focus, .print-link:active { color:red; }
         h1 { text-transform:lowercase; text-align:center; font-size:1.2rem; }
         table { width:100%; border-collapse:collapse; margin:20px 0; }
         th, td { border:1px solid #000; padding:5px; font-size:0.7rem; text-align:center; }
@@ -29,7 +31,7 @@
 </head>
 <body>
 <header class="header-container">
-    <button id="translate-button" class="translate-button">Translate</button>
+    <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
     <div class="logo-container">
         <iframe id="logo-frame" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
@@ -142,7 +144,7 @@
     <p>If you submit a consumer privacy request on behalf of another person, you will be required to demonstrate your legal authority to act on behalf of that person, and we may contact you for verification purposes. For the protection of our customers, we must receive all information requested and must verify your authority to our satisfaction before we can fulfill your request.</p>
     <h2>Changes to This Privacy Statement</h2>
     <p>We will review our Privacy Statement periodically (at least annually), and we reserve the right, in our sole discretion, to revise, change or modify this Privacy Statement at any time. We will post any changes to this Privacy Statement to this page and they will be effective as of the date of posting. We encourage you to visit this page periodically to review this information. By engaging with us, including by visiting our website(s) or mobile application(s), after this Privacy Statement has been updated, you agree to the updated terms of this Privacy Statement. This Privacy Statement was last updated on October 1, 2024.</p>
-    <p><a href="#" onclick="window.print(); return false;">Print</a></p>
+    <p><a href="#" onclick="window.print(); return false;" class="print-link">Print</a></p>
 </main>
 <footer>
         <div class="footer-links">


### PR DESCRIPTION
## Summary
- Replace text-based translate button with Google Translate logo
- Center-align privacy page content and style print link in red

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a255acd8a08321ac38c91876b633ed