### PR TITLE
Move translate button below header on privacy page

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -13,11 +13,12 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
+        .translate-container { text-align:center; }
         .translate-button { margin-top:10px; padding:0; border:none; background:transparent; cursor:pointer; }
         .translate-button img { width:24px; height:auto; }
         main { max-width:800px; margin:20px auto; font-size:0.9rem; line-height:1.4; text-align:center; }
         .print-link, .print-link:visited, .print-link:hover, .print-link:focus, .print-link:active { color:red; }
-        h1 { text-transform:lowercase; text-align:center; font-size:1.2rem; }
+        h1 { text-transform:none; text-align:center; font-size:1.2rem; }
         table { width:100%; border-collapse:collapse; margin:20px 0; }
         th, td { border:1px solid #000; padding:5px; font-size:0.7rem; text-align:center; }
         th:first-child, td:first-child { text-align:left; }
@@ -31,7 +32,6 @@
 </head>
 <body>
 <header class="header-container">
-    <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
     <div class="logo-container">
         <iframe id="logo-frame" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
         <div class="logo-overlay"></div>
@@ -39,8 +39,11 @@
     <div class="time" id="current-time"></div>
 </header>
 <div class="header-line"></div>
+<div class="translate-container">
+    <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
+</div>
 <main>
-    <h1>Consumer Privacy Policy Statement</h1>
+    <h1>Consumer Privacy Policy Settlement</h1>
     <p>At Maybe Not, we understand that you care how information about you is collected, used, and shared. This Privacy Statement describes information we may collect about you directly or indirectly, how and why we may collect, use and share your information, and the choices you have regarding your information. As more fully described below, we collect, use and share your information to better serve you and to improve our own business processes. By using our websites, mobile applications, or facilities, buying our products, participating in our promotions and events, or by providing your information to us in other ways, you agree to this Privacy Statement.</p>
     <h2>Categories of Information We Collect</h2>
     <p>In order to help us better understand you so that we can give you an excellent customer experience, we collect information that identifies you or that we can associate with you (your "personal information") as well as information that does not identify you (e.g., anonymous, deidentified, or aggregated data), and we may collect various categories of information directly (from you), or indirectly (from others), as more fully described below. The categories of personal information that we or our service providers have collected during the preceding 12 months are:</p>


### PR DESCRIPTION
## Summary
- Place Google Translate button below header line on privacy page
- Capitalize and update privacy page heading to "Consumer Privacy Policy Settlement"

## Testing
- `npx prettier --check privacy.html` (warn: code style issues)
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a256b8052483218297c79ab98d5a6c