### PR TITLE
Make translate widget sticky and fix pants overlay

### DIFF
--- a/pants.html
+++ b/pants.html
@@ -166,6 +166,8 @@
             display: block;
             text-decoration: none;
             color: inherit;
+            width: 100%;
+            height: 100%;
         }
 
         .product-item img {
@@ -220,7 +222,7 @@
         }
 
         .product-item:hover .product-info,
-        .product-item:focus .product-info {
+        .product-item:focus-within .product-info {
             opacity: 1;
         }
 
@@ -308,31 +310,31 @@
 <div class="product-item">
     <a href="joggers.html">
         <img src="blackjoggers.png" alt="Joggers">
-        <div class="product-info">
-            <p>Joggers</p>
-            <p>$60</p>
-        </div>
     </a>
+    <div class="product-info">
+        <p>Joggers</p>
+        <p>$60</p>
+    </div>
 </div>
-    
+
 <div class="product-item">
     <a href="shorts.html">
         <img src="blackshorts.png" alt="Shorts">
-        <div class="product-info">
-            <p>Shorts</p>
-            <p>$50</p>
-        </div>
     </a>
+    <div class="product-info">
+        <p>Shorts</p>
+        <p>$50</p>
+    </div>
 </div>
-    
+
 <div class="product-item">
     <a href="americandenim.html">
         <img src="bluejeans.png" alt="American Denim">
-        <div class="product-info">
-            <p>American Denim</p>
-            <p>$90</p>
-        </div>
     </a>
+    <div class="product-info">
+        <p>American Denim</p>
+        <p>$90</p>
+    </div>
 </div>
 </div>
 

--- a/privacy.html
+++ b/privacy.html
@@ -13,9 +13,10 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        .translate-container { text-align:center; }
+        .translate-container { text-align:center; position:sticky; top:0; background:#f7f7f7; z-index:1000; }
         .translate-button { margin-top:10px; padding:0; border:none; background:transparent; cursor:pointer; }
         .translate-button img { width:24px; height:auto; }
+        #google_translate_element { display:none; margin-top:5px; }
         main { max-width:800px; margin:20px auto; font-size:0.9rem; line-height:1.4; text-align:center; }
         .print-link, .print-link:visited, .print-link:hover, .print-link:focus, .print-link:active { color:red; }
         h1 { text-transform:none; text-align:center; font-size:1.2rem; }
@@ -41,6 +42,7 @@
 <div class="header-line"></div>
 <div class="translate-container">
     <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
+    <div id="google_translate_element"></div>
 </div>
 <main>
     <h1>Consumer Privacy Policy Settlement</h1>
@@ -218,14 +220,14 @@ if (logoOverlay) {
 </script>
 <script src="footer-highlight.js"></script>
 <!-- Google Translate -->
-<div id="google_translate_element" style="display:none;"></div>
 <script type="text/javascript">
 function googleTranslateElementInit() {
   new google.translate.TranslateElement({pageLanguage: 'en'}, 'google_translate_element');
 }
 document.getElementById('translate-button').addEventListener('click', function() {
   var el = document.getElementById('google_translate_element');
-  el.style.display = el.style.display === 'none' ? 'block' : 'none';
+  var current = window.getComputedStyle(el).display;
+  el.style.display = current === 'none' ? 'block' : 'none';
 });
 </script>
 <script src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>


### PR DESCRIPTION
## Summary
- Enable a sticky Google Translate widget on the privacy page that reveals language options beneath the logo button.
- Adjust pants product listings so info overlays cover the full product area, matching the red outline height.

## Testing
- `npm test` *(fails: package.json missing)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a25d66328883218cd3afc3cca7c694