### PR TITLE
Ensure pants overlays span image height

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -166,6 +166,9 @@
             display: block;
             text-decoration: none;
             color: inherit;
+            width: 100%;
+            height: 100%;
+            position: relative;
         }
 
         .product-item img {
@@ -217,6 +220,7 @@
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
+            z-index: 1;
         }
 
         .product-item:hover .product-info,

--- a/all.html
+++ b/all.html
@@ -166,6 +166,9 @@
             display: block;
             text-decoration: none;
             color: inherit;
+            width: 100%;
+            height: 100%;
+            position: relative;
         }
 
         .product-item img {
@@ -217,6 +220,7 @@
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
+            z-index: 1;
         }
 
         .product-item:hover .product-info,

--- a/bags.html
+++ b/bags.html
@@ -166,6 +166,9 @@
             display: block;
             text-decoration: none;
             color: inherit;
+            width: 100%;
+            height: 100%;
+            position: relative;
         }
 
         .product-item img {
@@ -217,6 +220,7 @@
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
+            z-index: 1;
         }
 
         .product-item:hover .product-info,

--- a/category_template.html
+++ b/category_template.html
@@ -166,6 +166,9 @@
             display: block;
             text-decoration: none;
             color: inherit;
+            width: 100%;
+            height: 100%;
+            position: relative;
         }
 
         .product-item img {
@@ -217,6 +220,7 @@
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
+            z-index: 1;
         }
 
         .product-item:hover .product-info,

--- a/gym.html
+++ b/gym.html
@@ -166,6 +166,9 @@
             display: block;
             text-decoration: none;
             color: inherit;
+            width: 100%;
+            height: 100%;
+            position: relative;
         }
 
         .product-item img {
@@ -217,6 +220,7 @@
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
+            z-index: 1;
         }
 
         .product-item:hover .product-info,

--- a/hats.html
+++ b/hats.html
@@ -166,6 +166,9 @@
             display: block;
             text-decoration: none;
             color: inherit;
+            width: 100%;
+            height: 100%;
+            position: relative;
         }
 
         .product-item img {
@@ -217,6 +220,7 @@
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
+            z-index: 1;
         }
 
         .product-item:hover .product-info,

--- a/jackets.html
+++ b/jackets.html
@@ -166,6 +166,9 @@
             display: block;
             text-decoration: none;
             color: inherit;
+            width: 100%;
+            height: 100%;
+            position: relative;
         }
 
         .product-item img {
@@ -217,6 +220,7 @@
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
+            z-index: 1;
         }
 
         .product-item:hover .product-info,

--- a/new.html
+++ b/new.html
@@ -166,6 +166,9 @@
             display: block;
             text-decoration: none;
             color: inherit;
+            width: 100%;
+            height: 100%;
+            position: relative;
         }
 
         .product-item img {
@@ -217,6 +220,7 @@
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
+            z-index: 1;
         }
 
         .product-item:hover .product-info,

--- a/pants.html
+++ b/pants.html
@@ -168,6 +168,7 @@
             color: inherit;
             width: 100%;
             height: 100%;
+            position: relative;
         }
 
         .product-item img {
@@ -219,10 +220,11 @@
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
+            z-index: 1;
         }
 
         .product-item:hover .product-info,
-        .product-item:focus-within .product-info {
+        .product-item:focus .product-info {
             opacity: 1;
         }
 
@@ -310,31 +312,31 @@
 <div class="product-item">
     <a href="joggers.html">
         <img src="blackjoggers.png" alt="Joggers">
+        <div class="product-info">
+            <p>Joggers</p>
+            <p>$60</p>
+        </div>
     </a>
-    <div class="product-info">
-        <p>Joggers</p>
-        <p>$60</p>
-    </div>
 </div>
-
+    
 <div class="product-item">
     <a href="shorts.html">
         <img src="blackshorts.png" alt="Shorts">
+        <div class="product-info">
+            <p>Shorts</p>
+            <p>$50</p>
+        </div>
     </a>
-    <div class="product-info">
-        <p>Shorts</p>
-        <p>$50</p>
-    </div>
 </div>
-
+    
 <div class="product-item">
     <a href="americandenim.html">
         <img src="bluejeans.png" alt="American Denim">
+        <div class="product-info">
+            <p>American Denim</p>
+            <p>$90</p>
+        </div>
     </a>
-    <div class="product-info">
-        <p>American Denim</p>
-        <p>$90</p>
-    </div>
 </div>
 </div>
 

--- a/shirts.html
+++ b/shirts.html
@@ -166,6 +166,9 @@
             display: block;
             text-decoration: none;
             color: inherit;
+            width: 100%;
+            height: 100%;
+            position: relative;
         }
 
         .product-item img {
@@ -217,6 +220,7 @@
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
+            z-index: 1;
         }
 
         .product-item:hover .product-info,

--- a/shoes.html
+++ b/shoes.html
@@ -166,6 +166,9 @@
             display: block;
             text-decoration: none;
             color: inherit;
+            width: 100%;
+            height: 100%;
+            position: relative;
         }
 
         .product-item img {
@@ -217,6 +220,7 @@
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
+            z-index: 1;
         }
 
         .product-item:hover .product-info,

--- a/skate.html
+++ b/skate.html
@@ -166,6 +166,9 @@
             display: block;
             text-decoration: none;
             color: inherit;
+            width: 100%;
+            height: 100%;
+            position: relative;
         }
 
         .product-item img {
@@ -217,6 +220,7 @@
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
+            z-index: 1;
         }
 
         .product-item:hover .product-info,

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -166,6 +166,9 @@
             display: block;
             text-decoration: none;
             color: inherit;
+            width: 100%;
+            height: 100%;
+            position: relative;
         }
 
         .product-item img {
@@ -217,6 +220,7 @@
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
+            z-index: 1;
         }
 
         .product-item:hover .product-info,

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -166,6 +166,9 @@
             display: block;
             text-decoration: none;
             color: inherit;
+            width: 100%;
+            height: 100%;
+            position: relative;
         }
 
         .product-item img {
@@ -217,6 +220,7 @@
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
+            z-index: 1;
         }
 
         .product-item:hover .product-info,

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -166,6 +166,9 @@
             display: block;
             text-decoration: none;
             color: inherit;
+            width: 100%;
+            height: 100%;
+            position: relative;
         }
 
         .product-item img {
@@ -217,6 +220,7 @@
             align-items: center;
             opacity: 0;
             transition: opacity 0.3s ease;
+            z-index: 1;
         }
 
         .product-item:hover .product-info,


### PR DESCRIPTION
## Summary
- Ensure product overlay anchors fill their containers and establish positioning
- Add z-index to product info overlay so it appears above images but below red outline
- Regenerate category pages so overlays for pants items match image height

## Testing
- `python generate_category_pages.py`
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a268b564dc8321a8e3b49ea1d1d015