### PR TITLE
Fix category navigation overlay and enable page scrolling

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -77,6 +77,7 @@
             display: block;
             width: 100%;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -113,6 +114,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -148,7 +150,8 @@
             flex-direction: column;
             align-items: center;
             gap: 20px;
-            margin-top: 160px;
+            margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .product-item {
@@ -269,9 +272,6 @@
 
         .full-site-link {
             text-align: center;
-            margin-top: 20px;
-        }
-        .product-grid {
             margin-top: 20px;
         }
         .product-info {

--- a/all.html
+++ b/all.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -77,6 +77,7 @@
             display: block;
             width: 100%;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -113,6 +114,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -148,7 +150,8 @@
             flex-direction: column;
             align-items: center;
             gap: 20px;
-            margin-top: 160px;
+            margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .product-item {
@@ -269,9 +272,6 @@
 
         .full-site-link {
             text-align: center;
-            margin-top: 20px;
-        }
-        .product-grid {
             margin-top: 20px;
         }
         .product-info {

--- a/bags.html
+++ b/bags.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -77,6 +77,7 @@
             display: block;
             width: 100%;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -113,6 +114,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -148,7 +150,8 @@
             flex-direction: column;
             align-items: center;
             gap: 20px;
-            margin-top: 160px;
+            margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .product-item {
@@ -269,9 +272,6 @@
 
         .full-site-link {
             text-align: center;
-            margin-top: 20px;
-        }
-        .product-grid {
             margin-top: 20px;
         }
         .product-info {

--- a/category_template.html
+++ b/category_template.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -77,6 +77,7 @@
             display: block;
             width: 100%;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -113,6 +114,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -148,7 +150,8 @@
             flex-direction: column;
             align-items: center;
             gap: 20px;
-            margin-top: 160px;
+            margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .product-item {
@@ -269,9 +272,6 @@
 
         .full-site-link {
             text-align: center;
-            margin-top: 20px;
-        }
-        .product-grid {
             margin-top: 20px;
         }
         .product-info {

--- a/gym.html
+++ b/gym.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -77,6 +77,7 @@
             display: block;
             width: 100%;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -113,6 +114,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -148,7 +150,8 @@
             flex-direction: column;
             align-items: center;
             gap: 20px;
-            margin-top: 160px;
+            margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .product-item {
@@ -269,9 +272,6 @@
 
         .full-site-link {
             text-align: center;
-            margin-top: 20px;
-        }
-        .product-grid {
             margin-top: 20px;
         }
         .product-info {

--- a/hats.html
+++ b/hats.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -77,6 +77,7 @@
             display: block;
             width: 100%;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -113,6 +114,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -148,7 +150,8 @@
             flex-direction: column;
             align-items: center;
             gap: 20px;
-            margin-top: 160px;
+            margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .product-item {
@@ -269,9 +272,6 @@
 
         .full-site-link {
             text-align: center;
-            margin-top: 20px;
-        }
-        .product-grid {
             margin-top: 20px;
         }
         .product-info {

--- a/jackets.html
+++ b/jackets.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -77,6 +77,7 @@
             display: block;
             width: 100%;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -113,6 +114,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -148,7 +150,8 @@
             flex-direction: column;
             align-items: center;
             gap: 20px;
-            margin-top: 160px;
+            margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .product-item {
@@ -269,9 +272,6 @@
 
         .full-site-link {
             text-align: center;
-            margin-top: 20px;
-        }
-        .product-grid {
             margin-top: 20px;
         }
         .product-info {

--- a/new.html
+++ b/new.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -77,6 +77,7 @@
             display: block;
             width: 100%;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -113,6 +114,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -148,7 +150,8 @@
             flex-direction: column;
             align-items: center;
             gap: 20px;
-            margin-top: 160px;
+            margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .product-item {
@@ -269,9 +272,6 @@
 
         .full-site-link {
             text-align: center;
-            margin-top: 20px;
-        }
-        .product-grid {
             margin-top: 20px;
         }
         .product-info {

--- a/pants.html
+++ b/pants.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -77,6 +77,7 @@
             display: block;
             width: 100%;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -113,6 +114,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -148,7 +150,8 @@
             flex-direction: column;
             align-items: center;
             gap: 20px;
-            margin-top: 160px;
+            margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .product-item {
@@ -269,9 +272,6 @@
 
         .full-site-link {
             text-align: center;
-            margin-top: 20px;
-        }
-        .product-grid {
             margin-top: 20px;
         }
         .product-info {

--- a/shirts.html
+++ b/shirts.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -77,6 +77,7 @@
             display: block;
             width: 100%;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -113,6 +114,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -148,7 +150,8 @@
             flex-direction: column;
             align-items: center;
             gap: 20px;
-            margin-top: 160px;
+            margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .product-item {
@@ -269,9 +272,6 @@
 
         .full-site-link {
             text-align: center;
-            margin-top: 20px;
-        }
-        .product-grid {
             margin-top: 20px;
         }
         .product-info {

--- a/shoes.html
+++ b/shoes.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -77,6 +77,7 @@
             display: block;
             width: 100%;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -113,6 +114,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -148,7 +150,8 @@
             flex-direction: column;
             align-items: center;
             gap: 20px;
-            margin-top: 160px;
+            margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .product-item {
@@ -269,9 +272,6 @@
 
         .full-site-link {
             text-align: center;
-            margin-top: 20px;
-        }
-        .product-grid {
             margin-top: 20px;
         }
         .product-info {

--- a/shop.html
+++ b/shop.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7; /* Off-white background color */
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -85,6 +85,7 @@
             display: block;
             width: 100%;
             margin-top: 20px; /* Ensure spacing between time and the first nav link */
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -126,6 +127,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -341,6 +343,7 @@
         }
         .mobile-nav {
             margin-top: 20px;
+            flex-shrink: 0;
         }
         .product-info {
             pointer-events: none;

--- a/skate.html
+++ b/skate.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -77,6 +77,7 @@
             display: block;
             width: 100%;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -113,6 +114,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -148,7 +150,8 @@
             flex-direction: column;
             align-items: center;
             gap: 20px;
-            margin-top: 160px;
+            margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .product-item {
@@ -269,9 +272,6 @@
 
         .full-site-link {
             text-align: center;
-            margin-top: 20px;
-        }
-        .product-grid {
             margin-top: 20px;
         }
         .product-info {

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -77,6 +77,7 @@
             display: block;
             width: 100%;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -113,6 +114,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -148,7 +150,8 @@
             flex-direction: column;
             align-items: center;
             gap: 20px;
-            margin-top: 160px;
+            margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .product-item {
@@ -269,9 +272,6 @@
 
         .full-site-link {
             text-align: center;
-            margin-top: 20px;
-        }
-        .product-grid {
             margin-top: 20px;
         }
         .product-info {

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -77,6 +77,7 @@
             display: block;
             width: 100%;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -113,6 +114,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -148,7 +150,8 @@
             flex-direction: column;
             align-items: center;
             gap: 20px;
-            margin-top: 160px;
+            margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .product-item {
@@ -269,9 +272,6 @@
 
         .full-site-link {
             text-align: center;
-            margin-top: 20px;
-        }
-        .product-grid {
             margin-top: 20px;
         }
         .product-info {

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -13,7 +13,7 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -77,6 +77,7 @@
             display: block;
             width: 100%;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         nav.mobile-nav ul {
@@ -113,6 +114,7 @@
             width: 100%;
             text-align: center;
             margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .desktop-nav ul {
@@ -148,7 +150,8 @@
             flex-direction: column;
             align-items: center;
             gap: 20px;
-            margin-top: 160px;
+            margin-top: 20px;
+            flex-shrink: 0;
         }
 
         .product-item {
@@ -269,9 +272,6 @@
 
         .full-site-link {
             text-align: center;
-            margin-top: 20px;
-        }
-        .product-grid {
             margin-top: 20px;
         }
         .product-info {


### PR DESCRIPTION
## Summary
- Prevent navigation menus and product grids from shrinking over product images
- Allow pages to grow beyond viewport height to keep scrolling functional

## Testing
- `python3 generate_category_pages.py`
- `python3 -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a26c8cbce883218d8b7929c1c033b0