### PR TITLE
Separate category nav from product images

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -78,6 +78,8 @@
             width: 100%;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         nav.mobile-nav ul {
@@ -115,6 +117,8 @@
             text-align: center;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         .desktop-nav ul {
@@ -145,6 +149,11 @@
         }
 
         /* Product grid */
+        .product-section {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+
         .product-grid {
             display: flex;
             flex-direction: column;
@@ -307,9 +316,11 @@
 
 </div>
 
-<div class="product-grid">
-    <div class="coming-soon">Coming Soon..</div>
-</div>
+<section class="product-section">
+    <div class="product-grid">
+        <div class="coming-soon">Coming Soon..</div>
+    </div>
+</section>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">

--- a/all.html
+++ b/all.html
@@ -78,6 +78,8 @@
             width: 100%;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         nav.mobile-nav ul {
@@ -115,6 +117,8 @@
             text-align: center;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         .desktop-nav ul {
@@ -145,6 +149,11 @@
         }
 
         /* Product grid */
+        .product-section {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+
         .product-grid {
             display: flex;
             flex-direction: column;
@@ -307,8 +316,9 @@
 
 </div>
 
-<div class="product-grid">
-    
+<section class="product-section">
+    <div class="product-grid">
+        
 <div class="product-item">
     <a href="hat.html">
         <img src="blackhat.png" alt="Hat">
@@ -368,7 +378,8 @@
         </div>
     </a>
 </div>
-</div>
+    </div>
+</section>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">

--- a/bags.html
+++ b/bags.html
@@ -78,6 +78,8 @@
             width: 100%;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         nav.mobile-nav ul {
@@ -115,6 +117,8 @@
             text-align: center;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         .desktop-nav ul {
@@ -145,6 +149,11 @@
         }
 
         /* Product grid */
+        .product-section {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+
         .product-grid {
             display: flex;
             flex-direction: column;
@@ -307,9 +316,11 @@
 
 </div>
 
-<div class="product-grid">
-    <div class="coming-soon">Coming Soon..</div>
-</div>
+<section class="product-section">
+    <div class="product-grid">
+        <div class="coming-soon">Coming Soon..</div>
+    </div>
+</section>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">

--- a/category_template.html
+++ b/category_template.html
@@ -78,6 +78,8 @@
             width: 100%;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         nav.mobile-nav ul {
@@ -115,6 +117,8 @@
             text-align: center;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         .desktop-nav ul {
@@ -145,6 +149,11 @@
         }
 
         /* Product grid */
+        .product-section {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+
         .product-grid {
             display: flex;
             flex-direction: column;
@@ -307,9 +316,11 @@
 
 </div>
 
-<div class="product-grid">
-    {{ITEMS}}
-</div>
+<section class="product-section">
+    <div class="product-grid">
+        {{ITEMS}}
+    </div>
+</section>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">

--- a/gym.html
+++ b/gym.html
@@ -78,6 +78,8 @@
             width: 100%;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         nav.mobile-nav ul {
@@ -115,6 +117,8 @@
             text-align: center;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         .desktop-nav ul {
@@ -145,6 +149,11 @@
         }
 
         /* Product grid */
+        .product-section {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+
         .product-grid {
             display: flex;
             flex-direction: column;
@@ -307,9 +316,11 @@
 
 </div>
 
-<div class="product-grid">
-    <div class="coming-soon">Coming Soon..</div>
-</div>
+<section class="product-section">
+    <div class="product-grid">
+        <div class="coming-soon">Coming Soon..</div>
+    </div>
+</section>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">

--- a/hats.html
+++ b/hats.html
@@ -78,6 +78,8 @@
             width: 100%;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         nav.mobile-nav ul {
@@ -115,6 +117,8 @@
             text-align: center;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         .desktop-nav ul {
@@ -145,6 +149,11 @@
         }
 
         /* Product grid */
+        .product-section {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+
         .product-grid {
             display: flex;
             flex-direction: column;
@@ -307,8 +316,9 @@
 
 </div>
 
-<div class="product-grid">
-    
+<section class="product-section">
+    <div class="product-grid">
+        
 <div class="product-item">
     <a href="hat.html">
         <img src="blackhat.png" alt="Hat">
@@ -318,7 +328,8 @@
         </div>
     </a>
 </div>
-</div>
+    </div>
+</section>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">

--- a/jackets.html
+++ b/jackets.html
@@ -78,6 +78,8 @@
             width: 100%;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         nav.mobile-nav ul {
@@ -115,6 +117,8 @@
             text-align: center;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         .desktop-nav ul {
@@ -145,6 +149,11 @@
         }
 
         /* Product grid */
+        .product-section {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+
         .product-grid {
             display: flex;
             flex-direction: column;
@@ -307,9 +316,11 @@
 
 </div>
 
-<div class="product-grid">
-    <div class="coming-soon">Coming Soon..</div>
-</div>
+<section class="product-section">
+    <div class="product-grid">
+        <div class="coming-soon">Coming Soon..</div>
+    </div>
+</section>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">

--- a/new.html
+++ b/new.html
@@ -78,6 +78,8 @@
             width: 100%;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         nav.mobile-nav ul {
@@ -115,6 +117,8 @@
             text-align: center;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         .desktop-nav ul {
@@ -145,6 +149,11 @@
         }
 
         /* Product grid */
+        .product-section {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+
         .product-grid {
             display: flex;
             flex-direction: column;
@@ -307,8 +316,9 @@
 
 </div>
 
-<div class="product-grid">
-    
+<section class="product-section">
+    <div class="product-grid">
+        
 <div class="product-item">
     <a href="hat.html">
         <img src="blackhat.png" alt="Hat">
@@ -368,7 +378,8 @@
         </div>
     </a>
 </div>
-</div>
+    </div>
+</section>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">

--- a/pants.html
+++ b/pants.html
@@ -78,6 +78,8 @@
             width: 100%;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         nav.mobile-nav ul {
@@ -115,6 +117,8 @@
             text-align: center;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         .desktop-nav ul {
@@ -145,6 +149,11 @@
         }
 
         /* Product grid */
+        .product-section {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+
         .product-grid {
             display: flex;
             flex-direction: column;
@@ -307,8 +316,9 @@
 
 </div>
 
-<div class="product-grid">
-    
+<section class="product-section">
+    <div class="product-grid">
+        
 <div class="product-item">
     <a href="joggers.html">
         <img src="blackjoggers.png" alt="Joggers">
@@ -338,7 +348,8 @@
         </div>
     </a>
 </div>
-</div>
+    </div>
+</section>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">

--- a/shirts.html
+++ b/shirts.html
@@ -78,6 +78,8 @@
             width: 100%;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         nav.mobile-nav ul {
@@ -115,6 +117,8 @@
             text-align: center;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         .desktop-nav ul {
@@ -145,6 +149,11 @@
         }
 
         /* Product grid */
+        .product-section {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+
         .product-grid {
             display: flex;
             flex-direction: column;
@@ -307,8 +316,9 @@
 
 </div>
 
-<div class="product-grid">
-    
+<section class="product-section">
+    <div class="product-grid">
+        
 <div class="product-item">
     <a href="shirt.html">
         <img src="blackshirt.png" alt="T-Shirt">
@@ -318,7 +328,8 @@
         </div>
     </a>
 </div>
-</div>
+    </div>
+</section>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">

--- a/shoes.html
+++ b/shoes.html
@@ -78,6 +78,8 @@
             width: 100%;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         nav.mobile-nav ul {
@@ -115,6 +117,8 @@
             text-align: center;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         .desktop-nav ul {
@@ -145,6 +149,11 @@
         }
 
         /* Product grid */
+        .product-section {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+
         .product-grid {
             display: flex;
             flex-direction: column;
@@ -307,9 +316,11 @@
 
 </div>
 
-<div class="product-grid">
-    <div class="coming-soon">Coming Soon..</div>
-</div>
+<section class="product-section">
+    <div class="product-grid">
+        <div class="coming-soon">Coming Soon..</div>
+    </div>
+</section>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">

--- a/skate.html
+++ b/skate.html
@@ -78,6 +78,8 @@
             width: 100%;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         nav.mobile-nav ul {
@@ -115,6 +117,8 @@
             text-align: center;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         .desktop-nav ul {
@@ -145,6 +149,11 @@
         }
 
         /* Product grid */
+        .product-section {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+
         .product-grid {
             display: flex;
             flex-direction: column;
@@ -307,9 +316,11 @@
 
 </div>
 
-<div class="product-grid">
-    <div class="coming-soon">Coming Soon..</div>
-</div>
+<section class="product-section">
+    <div class="product-grid">
+        <div class="coming-soon">Coming Soon..</div>
+    </div>
+</section>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -78,6 +78,8 @@
             width: 100%;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         nav.mobile-nav ul {
@@ -115,6 +117,8 @@
             text-align: center;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         .desktop-nav ul {
@@ -145,6 +149,11 @@
         }
 
         /* Product grid */
+        .product-section {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+
         .product-grid {
             display: flex;
             flex-direction: column;
@@ -307,8 +316,9 @@
 
 </div>
 
-<div class="product-grid">
-    
+<section class="product-section">
+    <div class="product-grid">
+        
 <div class="product-item">
     <a href="hoodie.html">
         <img src="blackhoodie.png" alt="Hoodie">
@@ -318,7 +328,8 @@
         </div>
     </a>
 </div>
-</div>
+    </div>
+</section>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -78,6 +78,8 @@
             width: 100%;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         nav.mobile-nav ul {
@@ -115,6 +117,8 @@
             text-align: center;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         .desktop-nav ul {
@@ -145,6 +149,11 @@
         }
 
         /* Product grid */
+        .product-section {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+
         .product-grid {
             display: flex;
             flex-direction: column;
@@ -307,8 +316,9 @@
 
 </div>
 
-<div class="product-grid">
-    
+<section class="product-section">
+    <div class="product-grid">
+        
 <div class="product-item">
     <a href="shirt.html">
         <img src="blackshirt.png" alt="T-Shirt">
@@ -318,7 +328,8 @@
         </div>
     </a>
 </div>
-</div>
+    </div>
+</section>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -78,6 +78,8 @@
             width: 100%;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         nav.mobile-nav ul {
@@ -115,6 +117,8 @@
             text-align: center;
             margin-top: 20px;
             flex-shrink: 0;
+            position: static;
+            clear: both;
         }
 
         .desktop-nav ul {
@@ -145,6 +149,11 @@
         }
 
         /* Product grid */
+        .product-section {
+            width: 100%;
+            margin-bottom: 20px;
+        }
+
         .product-grid {
             display: flex;
             flex-direction: column;
@@ -307,9 +316,11 @@
 
 </div>
 
-<div class="product-grid">
-    <div class="coming-soon">Coming Soon..</div>
-</div>
+<section class="product-section">
+    <div class="product-grid">
+        <div class="coming-soon">Coming Soon..</div>
+    </div>
+</section>
 
 <!-- Desktop Nav -->
 <nav class="desktop-nav">


### PR DESCRIPTION
## Summary
- prevent category nav from overlapping product images
- wrap product grids in their own section and regenerate category pages

## Testing
- `python generate_category_pages.py`
- `python -m py_compile generate_category_pages.py`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2706dc86c8321a84d8db2a5c181b2