### PR TITLE
Ensure red hyperlinks and full site link on checkout

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -689,7 +689,7 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
         <a href="#">cookies</a>
     </div>
     <div class="full-site-link" id="full-site-link">
-        <a href="index.html">full site</a>
+        <a href="index.html">view full site</a>
     </div>
 </footer>
 <script src="cart.js"></script>

--- a/footer-highlight.js
+++ b/footer-highlight.js
@@ -15,7 +15,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  document.querySelectorAll('.full-site-link a').forEach(link => {
-    link.style.color = 'red';
-  });
+  const style = document.createElement('style');
+  style.innerHTML = `
+    a { color: red !important; }
+    a:visited { color: red !important; }
+  `;
+  document.head.appendChild(style);
 });


### PR DESCRIPTION
## Summary
- Add "view full site" link at bottom of checkout page
- Make all hyperlinks render in red across the site

## Testing
- `node --check footer-highlight.js`
- `npx htmlhint checkout.html` *(fails: 403 Forbidden when fetching package)*
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a27c15213483218c7d5d2b9493f669