### PR TITLE
Restrict hyperlink recoloring to default blue links

### DIFF
--- a/footer-highlight.js
+++ b/footer-highlight.js
@@ -15,10 +15,17 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  const style = document.createElement('style');
-  style.innerHTML = `
-    a { color: red !important; }
-    a:visited { color: red !important; }
-  `;
-  document.head.appendChild(style);
+  // Recolor only links that still use the browser's default blue or purple
+  document.querySelectorAll('a').forEach(link => {
+    const color = getComputedStyle(link).color;
+    if (
+      color === 'rgb(0, 0, 238)' ||
+      color === 'rgb(0, 0, 255)' ||
+      color === 'blue' ||
+      color === 'rgb(85, 26, 139)' ||
+      color === 'purple'
+    ) {
+      link.style.color = 'red';
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Ensure only links using the browser's default blue or purple styling are recolored to red, leaving explicitly styled black links untouched.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a27e578b7c8321b2aad500d9615478