### PR TITLE
Show full site link on checkout page

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -489,7 +489,7 @@
         }
 
         .full-site-link {
-            display: none;
+            display: block;
             width: 100%;
             text-align: center;
             padding: 10px;
@@ -709,16 +709,10 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
         updateChicagoTime();
         setInterval(updateChicagoTime, 1000);
 
-        function toggleFullSiteLink() {
-            var fullSiteLink = document.getElementById('full-site-link');
-            if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-                fullSiteLink.style.display = 'block';
-            } else {
-                fullSiteLink.style.display = 'none';
-            }
+        const fullSiteLink = document.getElementById('full-site-link');
+        if (window.top !== window.self && fullSiteLink) {
+            fullSiteLink.style.display = 'none';
         }
-        window.addEventListener('scroll', toggleFullSiteLink);
-        toggleFullSiteLink();
         const logoOverlay = document.querySelector(".logo-overlay");
         if (logoOverlay) {
             let pressTimer;


### PR DESCRIPTION
## Summary
- Ensure checkout page footer always shows "view full site"
- Hide full site link when checkout is embedded in a popup

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2814ec8ac8321b4f9091c52f23876