### PR TITLE
Highlight shop navigation and show full-site link on desktop

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -411,14 +411,16 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/all.html
+++ b/all.html
@@ -174,7 +174,6 @@
             align-items: center;
         }
 
-
         .product-item a {
             display: block;
             text-decoration: none;
@@ -471,14 +470,16 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/bags.html
+++ b/bags.html
@@ -411,14 +411,16 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/cart.html
+++ b/cart.html
@@ -27,6 +27,15 @@
             width: 20vw;
             height: 15vh;
         }
+        .logo-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            cursor: pointer;
+            z-index: 10;
+        }
         .time {
             font-size: 0.7rem;
             text-align: center;

--- a/category_template.html
+++ b/category_template.html
@@ -411,14 +411,16 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/checkout.html
+++ b/checkout.html
@@ -27,6 +27,15 @@
             width: 20vw;
             height: 15vh;
         }
+        .logo-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            cursor: pointer;
+            z-index: 10;
+        }
         .time {
             font-size: 0.7rem;
             text-align: center;

--- a/footer-highlight.js
+++ b/footer-highlight.js
@@ -1,6 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
   const current = window.location.pathname.split('/').pop() || 'index.html';
-  const isShopPage = current === 'shop.html' || document.querySelector('.product-item');
+  const isShopPage =
+    current === 'shop.html' ||
+    document.querySelector('.product-item') ||
+    document.querySelector('.product-grid');
   document.querySelectorAll('footer a').forEach(link => {
     const href = link.getAttribute('href');
     if (href === current || (isShopPage && href === 'shop.html')) {

--- a/gym.html
+++ b/gym.html
@@ -411,14 +411,16 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/hats.html
+++ b/hats.html
@@ -420,14 +420,16 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/jackets.html
+++ b/jackets.html
@@ -411,14 +411,16 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/new.html
+++ b/new.html
@@ -174,7 +174,6 @@
             align-items: center;
         }
 
-
         .product-item a {
             display: block;
             text-decoration: none;
@@ -471,14 +470,16 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/pants.html
+++ b/pants.html
@@ -174,7 +174,6 @@
             align-items: center;
         }
 
-
         .product-item a {
             display: block;
             text-decoration: none;
@@ -441,14 +440,16 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/product.js
+++ b/product.js
@@ -198,14 +198,16 @@ document.addEventListener('DOMContentLoaded', () => {
     `;
   document.head.appendChild(style);
 
-  window.addEventListener('scroll', function() {
+  function toggleFullSiteLink() {
     var fullSiteLink = document.getElementById('full-site-link');
     if (fullSiteLink) {
-      if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+      if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
         fullSiteLink.style.display = 'block';
       } else {
         fullSiteLink.style.display = 'none';
       }
     }
-  });
+  }
+  window.addEventListener('scroll', toggleFullSiteLink);
+  toggleFullSiteLink();
 });

--- a/shirts.html
+++ b/shirts.html
@@ -420,14 +420,16 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/shoes.html
+++ b/shoes.html
@@ -411,14 +411,16 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/shop.html
+++ b/shop.html
@@ -243,7 +243,7 @@
             }
 
             .full-site-link {
-                display: block; /* Ensure it's visible only on mobile */
+                display: block;
                 width: 100%;
                 text-align: center;
                 padding: 10px;
@@ -308,7 +308,12 @@
             }
 
             .full-site-link {
-                display: none !important; /* Ensure full-site link doesn't show on desktop */
+                display: block;
+                width: 100%;
+                text-align: center;
+                padding: 10px;
+                background-color: #f7f7f7;
+                color: #000;
             }
         }
             /* Header and overlay fixes */
@@ -475,15 +480,17 @@
         }
     });
 
-    // Show the full-site link only when the user scrolls to the bottom on mobile
-    window.addEventListener('scroll', function() {
+    // Show the full-site link only when the user scrolls to the bottom
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/skate.html
+++ b/skate.html
@@ -411,14 +411,16 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/soon.html
+++ b/soon.html
@@ -228,7 +228,12 @@
             }
 
             .full-site-link {
-                display: none !important;
+                display: block;
+                width: 100%;
+                text-align: center;
+                padding: 10px;
+                background-color: #f7f7f7;
+                color: #000;
             }
 
             .coming-soon {
@@ -366,15 +371,17 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    // Show the full-site link only when the user scrolls to the bottom on mobile
-    window.addEventListener('scroll', function() {
+    // Show the full-site link only when the user scrolls to the bottom
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -420,14 +420,16 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -420,14 +420,16 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -411,14 +411,16 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    window.addEventListener('scroll', function() {
+    function toggleFullSiteLink() {
         var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight && window.innerWidth <= 768) {
+        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
             fullSiteLink.style.display = 'block';
         } else {
             fullSiteLink.style.display = 'none';
         }
-    });
+    }
+    window.addEventListener('scroll', toggleFullSiteLink);
+    toggleFullSiteLink();
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {


### PR DESCRIPTION
## Summary
- Ensure footer "shop" link stays highlighted on category pages without products
- Restore long-press logo navigation on cart and checkout pages
- Display "full site" link on desktop versions of shop, category, and product pages

## Testing
- `python generate_category_pages.py`
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a31f1ecb788321b55e4519e4d2f330