### PR TITLE
Fix cart outline width on soon page

### DIFF
--- a/soon.html
+++ b/soon.html
@@ -59,11 +59,15 @@
             border: none;
         }
 
-                .time {
+        .time {
             font-size: 0.7rem;
             text-align: center;
             margin-top: -15px;
             font-weight: 600;
+        }
+
+        body .cart-counter {
+            align-self: center;
         }
 
         /* Coming Soon Styling */


### PR DESCRIPTION
## Summary
- prevent cart counter highlight from spanning full width on `soon.html`

## Testing
- `python -m py_compile generate_category_pages.py`
- `node --check cart.js`


------
https://chatgpt.com/codex/tasks/task_e_68a321bb1f88832188cef5ea687ab4ae