### PR TITLE
Always show full site link on shop and category pages

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -411,16 +411,7 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is always visible; scroll handler removed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/all.html
+++ b/all.html
@@ -470,16 +470,7 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is always visible; scroll handler removed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/bags.html
+++ b/bags.html
@@ -411,16 +411,7 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is always visible; scroll handler removed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/category_template.html
+++ b/category_template.html
@@ -411,16 +411,7 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is always visible; scroll handler removed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/gym.html
+++ b/gym.html
@@ -411,16 +411,7 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is always visible; scroll handler removed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/hats.html
+++ b/hats.html
@@ -420,16 +420,7 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is always visible; scroll handler removed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/jackets.html
+++ b/jackets.html
@@ -411,16 +411,7 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is always visible; scroll handler removed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/new.html
+++ b/new.html
@@ -470,16 +470,7 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is always visible; scroll handler removed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/pants.html
+++ b/pants.html
@@ -440,16 +440,7 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is always visible; scroll handler removed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/shirts.html
+++ b/shirts.html
@@ -420,16 +420,7 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is always visible; scroll handler removed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/shoes.html
+++ b/shoes.html
@@ -411,16 +411,7 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is always visible; scroll handler removed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/shop.html
+++ b/shop.html
@@ -480,17 +480,7 @@
         }
     });
 
-    // Show the full-site link only when the user scrolls to the bottom
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is now always visible; no scroll handler needed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/skate.html
+++ b/skate.html
@@ -411,16 +411,7 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is always visible; scroll handler removed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -420,16 +420,7 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is always visible; scroll handler removed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -420,16 +420,7 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is always visible; scroll handler removed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -411,16 +411,7 @@
 
     setInterval(updateChicagoTime, 1000);
 
-    function toggleFullSiteLink() {
-        var fullSiteLink = document.getElementById('full-site-link');
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
-            fullSiteLink.style.display = 'block';
-        } else {
-            fullSiteLink.style.display = 'none';
-        }
-    }
-    window.addEventListener('scroll', toggleFullSiteLink);
-    toggleFullSiteLink();
+    // Full-site link is always visible; scroll handler removed
 
                 const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {


### PR DESCRIPTION
## Summary
- Remove scroll-based logic so the full site link stays visible on the shop page footer.
- Update category template with the same always-visible link and regenerate category pages.

## Testing
- `python generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a323460a0c8321b4f94abf8abfb125