### PR TITLE
feat: set checkout policy links red

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -439,8 +439,8 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
                 <div class="cart-footer" style="display:none;">
                     <a href="#">refund policy</a> |
                     <a href="#">shipping</a> |
-                    <a href="privacy.html">privacy policy</a> |
-                    <a href="terms.html">terms of service</a> |
+                    <a href="privacy.html" style="color: red;">privacy policy</a> |
+                    <a href="terms.html" style="color: red;">terms of service</a> |
                     <a href="#">cookies</a>
                 </div>
             </footer>

--- a/checkout.html
+++ b/checkout.html
@@ -693,8 +693,8 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
     <div class="cart-footer">
         <a href="#">refund policy</a> |
         <a href="#">shipping</a> |
-        <a href="privacy.html">privacy policy</a> |
-        <a href="terms.html">terms of service</a> |
+        <a href="privacy.html" style="color: red;">privacy policy</a> |
+        <a href="terms.html" style="color: red;">terms of service</a> |
         <a href="#">cookies</a>
     </div>
     <div class="full-site-link" id="full-site-link">


### PR DESCRIPTION
## Summary
- make privacy and terms links red in checkout modal
- color policy links red on standalone checkout page

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a36293a8dc83218547ebce41f041e8