### PR TITLE
Fix link colors in checkout pop-up

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -703,7 +703,7 @@
                 </div>
             </div>
             <button id="final-order-submit" type="submit">Pay now</button>
-            <p id="remember-message" style="display:none;">Your info will be saved to a Shop account. By continuing, you agree to Shop’s Terms of Service and acknowledge the Privacy Policy.</p>
+            <p id="remember-message" style="display:none;">Your info will be saved to a Shop account. By continuing, you agree to Shop’s <a href="https://shop.app/terms-of-service" target="_blank" style="color:red;">Terms of Service</a> and acknowledge the <a href="https://www.shopify.com/legal/privacy/consumers" target="_blank" style="color:red;">Privacy Policy</a>.</p>
         </form>
     </div>
 </div>

--- a/cart.js
+++ b/cart.js
@@ -423,7 +423,7 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
                         </div>
                     </div>
                     <button id="final-order-submit" type="submit">Pay now</button>
-                    <p id="remember-message" style="display:none;">Your info will be saved to a Shop account. By continuing, you agree to Shop’s <a href="https://shop.app/terms-of-service" target="_blank">Terms of Service</a> and acknowledge the <a href="https://www.shopify.com/legal/privacy/consumers" target="_blank">Privacy Policy</a>.</p>
+                    <p id="remember-message" style="display:none;">Your info will be saved to a Shop account. By continuing, you agree to Shop’s <a href="https://shop.app/terms-of-service" target="_blank" style="color:red;">Terms of Service</a> and acknowledge the <a href="https://www.shopify.com/legal/privacy/consumers" target="_blank" style="color:red;">Privacy Policy</a>.</p>
                 </form>
             </div>
             <footer>
@@ -439,8 +439,8 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
                 <div class="cart-footer" style="display:none;">
                     <a href="#">refund policy</a> |
                     <a href="#">shipping</a> |
-                    <a href="privacy.html" style="color: red;">privacy policy</a> |
-                    <a href="terms.html" style="color: red;">terms of service</a> |
+                    <a href="privacy.html">privacy policy</a> |
+                    <a href="terms.html">terms of service</a> |
                     <a href="#">cookies</a>
                 </div>
             </footer>

--- a/checkout.html
+++ b/checkout.html
@@ -677,7 +677,7 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
                 </div>
             </div>
             <button id="final-order-submit" type="submit">Pay now</button>
-            <p id="remember-message" style="display:none;">Your info will be saved to a Shop account. By continuing, you agree to Shop’s <a href="https://shop.app/terms-of-service" target="_blank">Terms of Service</a> and acknowledge the <a href="https://www.shopify.com/legal/privacy/consumers" target="_blank">Privacy Policy</a>.</p>
+            <p id="remember-message" style="display:none;">Your info will be saved to a Shop account. By continuing, you agree to Shop’s <a href="https://shop.app/terms-of-service" target="_blank" style="color:red;">Terms of Service</a> and acknowledge the <a href="https://www.shopify.com/legal/privacy/consumers" target="_blank" style="color:red;">Privacy Policy</a>.</p>
         </form>
     </div>
 <footer>
@@ -693,8 +693,8 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
     <div class="cart-footer">
         <a href="#">refund policy</a> |
         <a href="#">shipping</a> |
-        <a href="privacy.html" style="color: red;">privacy policy</a> |
-        <a href="terms.html" style="color: red;">terms of service</a> |
+        <a href="privacy.html">privacy policy</a> |
+        <a href="terms.html">terms of service</a> |
         <a href="#">cookies</a>
     </div>
     <div class="full-site-link" id="full-site-link">


### PR DESCRIPTION
## Summary
- Highlight Terms of Service and Privacy Policy in checkout consent notice
- Restore footer Privacy Policy and Terms of Service links to default black

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a381cd24788321a5e02e61fa938944