### PR TITLE
Make secondary page headers sticky and adjust layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -25,7 +25,11 @@
         @media (min-width:769px) { footer { position:fixed; bottom:0; width:100%; text-align:center; background-color:#f7f7f7; padding:20px 0; } .footer-links { padding-bottom:30px; } }
         @media (max-width:768px) { footer .footer-links { justify-content:center; padding-bottom:25px; margin-top:40px; } }
         .full-site-link { text-align:center; }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -34,9 +38,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-</header>
 <div class="header-line"></div>
-
+</header>
 <main>
     <h1>about</h1>
     <p>Maybe Not began in 2016 on the North Side of Chicago. We create everyday apparel and objects, vertically integrating our design and production with locally sourced materials and manufacturing. Our commitment to high performance and comfort supports our mission toward a fully eco-sustainable planet. We've been grinding since day one with multiple collections and shows along the way, and we're grateful to continue creating.</p>

--- a/accessibility.html
+++ b/accessibility.html
@@ -25,7 +25,11 @@
         .full-site-link { text-align:center; margin-top:20px; }
         @media (min-width:769px) { footer { position:fixed; bottom:0; width:100%; text-align:center; background-color:#f7f7f7; padding:20px 0; } .footer-links { padding-bottom:30px; } }
         @media (max-width:768px) { footer .footer-links { justify-content:center; padding-bottom:25px; margin-top:40px; } }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -34,8 +38,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-</header>
 <div class="header-line"></div>
+</header>
 <div class="translate-container">
     <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
     <div id="google_translate_element"></div>

--- a/accessories.html
+++ b/accessories.html
@@ -299,7 +299,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -309,13 +313,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
 
+</header>
 <section class="product-section">
     <div class="product-grid">
         <div class="coming-soon">Coming Soon..</div>

--- a/all.html
+++ b/all.html
@@ -299,7 +299,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -309,13 +313,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
 
+</header>
 <section class="product-section">
     <div class="product-grid">
         

--- a/americandenim.html
+++ b/americandenim.html
@@ -186,7 +186,11 @@
             cursor: pointer;
             display: inline-block;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -195,12 +199,12 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
+</header>
 <div class="product-item" data-product="american-denim" data-price="90" data-selected-color="" data-size="">
     <div class="image-slider" data-images="blackjeans.png,bluejeans.png">
         <button class="prev">&#10094;</button>

--- a/bags.html
+++ b/bags.html
@@ -299,7 +299,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -309,13 +313,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
 
+</header>
 <section class="product-section">
     <div class="product-grid">
         <div class="coming-soon">Coming Soon..</div>

--- a/cart.html
+++ b/cart.html
@@ -513,7 +513,11 @@
                 width: 100%;
             }
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -522,11 +526,11 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-</header>
 <div class="header-line"></div>
 <div class="cart-counter">
     <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 </div>
+</header>
 <div id="cart-page" class="cart-page">
     <h2>Cart</h2>
     <div class="item-count"></div>

--- a/category_template.html
+++ b/category_template.html
@@ -299,7 +299,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -309,13 +313,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
 
+</header>
 <section class="product-section">
     <div class="product-grid">
         {{ITEMS}}

--- a/checkout.html
+++ b/checkout.html
@@ -512,7 +512,11 @@
                 width: 100%;
             }
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
     <header class="header-container">
@@ -521,9 +525,9 @@
             <div class="logo-overlay"></div>
         </div>
         <div class="time" id="current-time"></div>
-    </header>
     <div class="header-line"></div>
-    <div id="final-checkout">
+</header>
+<div id="final-checkout">
         <form id="final-form">
             <h2 class="checkout-domain">maybenot.com</h2>
             <div class="order-summary-bar">

--- a/contact.html
+++ b/contact.html
@@ -30,7 +30,11 @@
         @media (min-width:769px) { footer { position:fixed; bottom:0; width:100%; text-align:center; background-color:#f7f7f7; padding:20px 0; } .footer-links { padding-bottom:30px; } }
         @media (max-width:768px) { footer .footer-links { justify-content:center; padding-bottom:25px; margin-top:40px; } }
         .full-site-link { text-align:center; }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -39,9 +43,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-</header>
 <div class="header-line"></div>
-
+</header>
 <main>
     <h1>contact</h1>
     <form id="contact-form">

--- a/faq.html
+++ b/faq.html
@@ -26,7 +26,11 @@
         .full-site-link { text-align:center; margin-top:20px; }
         @media (min-width:769px) { footer { position:fixed; bottom:0; width:100%; text-align:center; background-color:#f7f7f7; padding:20px 0; } .footer-links { padding-bottom:30px; } }
         @media (max-width:768px) { footer .footer-links { justify-content:center; padding-bottom:25px; margin-top:40px; } }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -35,8 +39,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-</header>
 <div class="header-line"></div>
+</header>
 <div class="translate-container">
     <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
     <div id="google_translate_element"></div>

--- a/gym.html
+++ b/gym.html
@@ -299,7 +299,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -309,13 +313,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
 
+</header>
 <section class="product-section">
     <div class="product-grid">
         <div class="coming-soon">Coming Soon..</div>

--- a/hat.html
+++ b/hat.html
@@ -160,7 +160,11 @@
             cursor: pointer;
             display: inline-block;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -169,12 +173,12 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
     
 </div>
+</header>
 <div class="product-item" data-product="hat" data-price="50" data-selected-color="" data-size="">
     <div class="image-slider" data-images="blackhat.png,whitehat.png">
         <button class="prev">&#10094;</button>

--- a/hats.html
+++ b/hats.html
@@ -299,7 +299,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -309,13 +313,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
 
+</header>
 <section class="product-section">
     <div class="product-grid">
         

--- a/hoodie.html
+++ b/hoodie.html
@@ -32,7 +32,11 @@
         .image-slider img { width:100%; height:100%; object-fit:contain; }
         .color-options { display:flex; gap:5px; margin:5px 0; }
         .color-option { width:15px; height:15px; cursor:pointer; display:inline-block; }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -41,12 +45,12 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
     
 </div>
+</header>
 <div class="product-item" data-product="hoodie" data-price="70" data-selected-color="" data-size="">
     <div class="image-slider" data-images="blackhoodie.png,whitehoodie.png">
         <button class="prev">&#10094;</button>

--- a/jackets.html
+++ b/jackets.html
@@ -299,7 +299,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -309,13 +313,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
 
+</header>
 <section class="product-section">
     <div class="product-grid">
         <div class="coming-soon">Coming Soon..</div>

--- a/joggers.html
+++ b/joggers.html
@@ -39,7 +39,11 @@
         .color-option.selected, .color-option:hover, .color-option:focus { border:2px solid red; }
         .product-item button { background:#000; color:#fff; border:2px solid #000; font-family:'Courier New', Courier, monospace; cursor:pointer; margin-top:5px; }
         .product-item button:hover, .product-item button:active, .product-item button:focus { background:#fff; color:red; border-color:red; }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -48,12 +52,12 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
     <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 </div>
 
+</header>
 <div class="product-item" data-product="joggers" data-price="60" data-selected-color="" data-size="">
     <div class="image-slider" data-images="blackjoggers.png,whitejoggers.png">
         <button class="prev">&#10094;</button>

--- a/mailinglist.html
+++ b/mailinglist.html
@@ -36,7 +36,11 @@
         @media (min-width:769px) { footer { position:fixed; bottom:0; width:100%; text-align:center; background-color:#f7f7f7; padding:20px 0; } .footer-links { padding-bottom:30px; } }
         @media (max-width:768px) { footer .footer-links { justify-content:center; padding-bottom:25px; margin-top:40px; } }
         .full-site-link { text-align:center; }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -45,9 +49,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-</header>
 <div class="header-line"></div>
-
+</header>
 <main>
     <h1>mailing list</h1>
     <p>Our webstore is currently closed and will reopen soon with our Fall/Winter 2025 collection.</p>

--- a/new.html
+++ b/new.html
@@ -299,7 +299,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -309,13 +313,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
 
+</header>
 <section class="product-section">
     <div class="product-grid">
         

--- a/news.html
+++ b/news.html
@@ -28,7 +28,11 @@
         @media (min-width:769px) { footer { position:fixed; bottom:0; width:100%; text-align:center; background-color:#f7f7f7; padding:20px 0; } .footer-links { padding-bottom:30px; } }
         @media (max-width:768px) { footer .footer-links { justify-content:center; padding-bottom:25px; margin-top:40px; } }
         .full-site-link { text-align:center; }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -37,9 +41,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-</header>
 <div class="header-line"></div>
-
+</header>
 <main>
     <h1>news</h1>
     <div class="news-item">

--- a/pants.html
+++ b/pants.html
@@ -299,7 +299,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -309,13 +313,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
 
+</header>
 <section class="product-section">
     <div class="product-grid">
         

--- a/privacy.html
+++ b/privacy.html
@@ -29,7 +29,11 @@
         .full-site-link { text-align:center; margin-top:20px; }
         @media (min-width:769px) { footer { position:fixed; bottom:0; width:100%; text-align:center; background-color:#f7f7f7; padding:20px 0; } .footer-links { padding-bottom:30px; } }
         @media (max-width:768px) { footer .footer-links { justify-content:center; padding-bottom:25px; margin-top:40px; } }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -38,8 +42,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-</header>
 <div class="header-line"></div>
+</header>
 <div class="translate-container">
     <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
     <div id="google_translate_element"></div>

--- a/random.html
+++ b/random.html
@@ -26,7 +26,11 @@
         @media (max-width:768px) { footer .footer-links { justify-content:center; padding-bottom:25px; margin-top:40px; } }
         .full-site-link { text-align:center; }
         .source-link { font-size:0.7rem; text-decoration:underline; color:#000; }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -35,9 +39,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-</header>
 <div class="header-line"></div>
-
+</header>
 <main>
     <h1>random</h1>
     <p>Feeling unpredictable? Refresh the page!</p>

--- a/shirt.html
+++ b/shirt.html
@@ -156,7 +156,11 @@
 
             display: inline-block;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -165,12 +169,12 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
     
 </div>
+</header>
 <div class="product-item" data-product="t-shirt" data-price="40" data-selected-color="" data-size="">
     <div class="image-slider" data-images="blackshirt.png,whiteshirt.png">
         <button class="prev">&#10094;</button>

--- a/shirts.html
+++ b/shirts.html
@@ -299,7 +299,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -309,13 +313,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
 
+</header>
 <section class="product-section">
     <div class="product-grid">
         

--- a/shoes.html
+++ b/shoes.html
@@ -299,7 +299,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -309,13 +313,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
 
+</header>
 <section class="product-section">
     <div class="product-grid">
         <div class="coming-soon">Coming Soon..</div>

--- a/shop.html
+++ b/shop.html
@@ -366,7 +366,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -376,13 +380,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
     
 </div>
 
+</header>
 <!-- Desktop Nav -->
 <nav class="desktop-nav">
     <ul>

--- a/shorts.html
+++ b/shorts.html
@@ -56,7 +56,11 @@
         .color-option.selected, .color-option:hover, .color-option:focus { border:2px solid red; }
         .product-item button { background:#000; color:#fff; border:2px solid #000; font-family:'Courier New', Courier, monospace; cursor:pointer; margin-top:5px; }
         .product-item button:hover, .product-item button:active, .product-item button:focus { background:#fff; color:red; border-color:red; }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -65,12 +69,12 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
     <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 </div>
 
+</header>
 <div class="product-item" data-product="shorts" data-price="50" data-selected-color="" data-size="">
     <div class="image-slider" data-images="blackshorts.png,whiteshorts.png">
         <button class="prev">&#10094;</button>

--- a/skate.html
+++ b/skate.html
@@ -299,7 +299,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -309,13 +313,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
 
+</header>
 <section class="product-section">
     <div class="product-grid">
         <div class="coming-soon">Coming Soon..</div>

--- a/soon.html
+++ b/soon.html
@@ -308,7 +308,11 @@
             text-align: center;
             font-size: 2rem;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -318,10 +322,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
-
-
+    <div class="header-line"></div>
+</header>
 <div class="coming-soon">coming soon..</div>
 
 

--- a/stores.html
+++ b/stores.html
@@ -26,7 +26,11 @@
         @media (min-width:769px) { footer { position:fixed; bottom:0; width:100%; text-align:center; background-color:#f7f7f7; padding:20px 0; } .footer-links { padding-bottom:30px; } }
         @media (max-width:768px) { footer .footer-links { justify-content:center; padding-bottom:25px; margin-top:40px; } }
         .full-site-link { text-align:center; }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -35,9 +39,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-</header>
 <div class="header-line"></div>
-
+</header>
 <main>
     <h1>stores</h1>
     <p>Visit us in person:</p>

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -299,7 +299,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -309,13 +313,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
 
+</header>
 <section class="product-section">
     <div class="product-grid">
         

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -299,7 +299,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -309,13 +313,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
 
+</header>
 <section class="product-section">
     <div class="product-grid">
         

--- a/terms.html
+++ b/terms.html
@@ -25,7 +25,11 @@
         .full-site-link { text-align:center; margin-top:20px; }
         @media (min-width:769px) { footer { position:fixed; bottom:0; width:100%; text-align:center; background-color:#f7f7f7; padding:20px 0; } .footer-links { padding-bottom:30px; } }
         @media (max-width:768px) { footer .footer-links { justify-content:center; padding-bottom:25px; margin-top:40px; } }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 <header class="header-container">
@@ -34,8 +38,8 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-</header>
 <div class="header-line"></div>
+</header>
 <div class="translate-container">
     <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
     <div id="google_translate_element"></div>

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -299,7 +299,11 @@
             background: red;
             color: #fff;
         }
-    </style>
+        .header-container { position: sticky; top: 0; z-index: 1000; }
+    .logo-container { height: 10vh; }
+    .time { margin-top: -5px; }
+    .cart-counter { margin-top: 5px; }
+</style>
 </head>
 <body>
 
@@ -309,13 +313,13 @@
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>
-    </header>
-<div class="header-line"></div>
+    <div class="header-line"></div>
 <div class="cart-counter">
         <span class="cart-icon">🛒</span><span id="cart-count">0</span>
 
 </div>
 
+</header>
 <section class="product-section">
     <div class="product-grid">
         <div class="coming-soon">Coming Soon..</div>


### PR DESCRIPTION
## Summary
- Move header line and cart inside header
- Add sticky header styling and adjust logo/clock spacing

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3916016d083219ac4e2b8bc52cd00