### PR TITLE
Ensure translate widget and cart sit within sticky header

### DIFF
--- a/accessibility.html
+++ b/accessibility.html
@@ -13,7 +13,7 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        .translate-container { text-align:center; position:sticky; top:0; background:#f7f7f7; z-index:1000; }
+        .translate-container { text-align:center; background:#f7f7f7; }
         .translate-button { margin-top:10px; padding:0; border:none; background:transparent; cursor:pointer; }
         .translate-button img { width:24px; height:auto; }
         #google_translate_element { display:none; margin-top:5px; }
@@ -39,11 +39,11 @@
     </div>
     <div class="time" id="current-time"></div>
 <div class="header-line"></div>
+    <div class="translate-container">
+        <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
+        <div id="google_translate_element"></div>
+    </div>
 </header>
-<div class="translate-container">
-    <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
-    <div id="google_translate_element"></div>
-</div>
 <main>
     <h1>accessibility</h1>
     <p>MaybeNot is committed to providing a website that is accessible to all visitors and aims to comply with the World Wide Web Consortium's Web Content Accessibility Guidelines&nbsp;2.1 up to level AA. We follow best practices and regularly review our site to improve usability.</p>

--- a/faq.html
+++ b/faq.html
@@ -13,7 +13,7 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        .translate-container { text-align:center; position:sticky; top:0; background:#f7f7f7; z-index:1000; }
+        .translate-container { text-align:center; background:#f7f7f7; }
         .translate-button { margin-top:10px; padding:0; border:none; background:transparent; cursor:pointer; }
         .translate-button img { width:24px; height:auto; }
         #google_translate_element { display:none; margin-top:5px; }
@@ -40,11 +40,11 @@
     </div>
     <div class="time" id="current-time"></div>
 <div class="header-line"></div>
+    <div class="translate-container">
+        <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
+        <div id="google_translate_element"></div>
+    </div>
 </header>
-<div class="translate-container">
-    <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
-    <div id="google_translate_element"></div>
-</div>
 <main>
     <h1>f.a.q.</h1>
     <h2>when do new items release?</h2>

--- a/privacy.html
+++ b/privacy.html
@@ -13,7 +13,7 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        .translate-container { text-align:center; position:sticky; top:0; background:#f7f7f7; z-index:1000; }
+        .translate-container { text-align:center; background:#f7f7f7; }
         .translate-button { margin-top:10px; padding:0; border:none; background:transparent; cursor:pointer; }
         .translate-button img { width:24px; height:auto; }
         #google_translate_element { display:none; margin-top:5px; }
@@ -43,11 +43,11 @@
     </div>
     <div class="time" id="current-time"></div>
 <div class="header-line"></div>
+    <div class="translate-container">
+        <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
+        <div id="google_translate_element"></div>
+    </div>
 </header>
-<div class="translate-container">
-    <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
-    <div id="google_translate_element"></div>
-</div>
 <main>
     <h1>Consumer Privacy Policy Settlement</h1>
     <p>At Maybe Not, we understand that you care how information about you is collected, used, and shared. This Privacy Statement describes information we may collect about you directly or indirectly, how and why we may collect, use and share your information, and the choices you have regarding your information. As more fully described below, we collect, use and share your information to better serve you and to improve our own business processes. By using our websites, mobile applications, or facilities, buying our products, participating in our promotions and events, or by providing your information to us in other ways, you agree to this Privacy Statement.</p>

--- a/terms.html
+++ b/terms.html
@@ -13,7 +13,7 @@
         iframe { width:100%; height:100%; border:none; }
         .time { font-size:0.7rem; text-align:center; margin-top:-15px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        .translate-container { text-align:center; position:sticky; top:0; background:#f7f7f7; z-index:1000; }
+        .translate-container { text-align:center; background:#f7f7f7; }
         .translate-button { margin-top:10px; padding:0; border:none; background:transparent; cursor:pointer; }
         .translate-button img { width:24px; height:auto; }
         #google_translate_element { display:none; margin-top:5px; }
@@ -39,11 +39,11 @@
     </div>
     <div class="time" id="current-time"></div>
 <div class="header-line"></div>
+    <div class="translate-container">
+        <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
+        <div id="google_translate_element"></div>
+    </div>
 </header>
-<div class="translate-container">
-    <button id="translate-button" class="translate-button"><img src="IMG_1870.png" alt="Translate"></button>
-    <div id="google_translate_element"></div>
-</div>
 <main>
     <h1>Terms</h1>
     <p><em>Effective August 17, 2025</em></p>


### PR DESCRIPTION
## Summary
- Move Google Translate button inside the sticky header beneath the top border across policy pages
- Remove standalone sticky behavior from the translate widget so it follows the header

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a393955a948321963c6bd974346b3b