### PR TITLE
Ensure header line and cart counter remain within sticky header

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -1245,13 +1245,13 @@ function ensureCartCounter() {
                 headerLine = document.createElement('div');
                 headerLine.className = 'header-line';
             }
-            header.insertAdjacentElement('afterend', headerLine);
+            if (headerLine.parentElement !== header) {
+                header.appendChild(headerLine);
+            }
             headerLine.style.marginTop = '5px';
-        }
-        if (headerLine) {
-            headerLine.insertAdjacentElement('afterend', counter);
-        } else if (header) {
-            header.insertAdjacentElement('afterend', counter);
+            if (counter.parentElement !== headerLine.parentElement) {
+                headerLine.insertAdjacentElement('afterend', counter);
+            }
         }
     }
     counter.style.marginTop = '5px';

--- a/product.js
+++ b/product.js
@@ -77,18 +77,19 @@ document.addEventListener('DOMContentLoaded', () => {
   const headerLine = document.querySelector('.header-line');
   const cartCounter = document.querySelector('.cart-counter');
   if (header && headerLine) {
-    header.insertAdjacentElement('afterend', headerLine);
-  }
-  if (headerLine && cartCounter) {
-    headerLine.insertAdjacentElement('afterend', cartCounter);
-  }
-  if (headerLine) {
+    if (headerLine.parentElement !== header) {
+      header.appendChild(headerLine);
+    }
     headerLine.style.borderTop = '1px solid #000';
     headerLine.style.marginTop = '5px';
     headerLine.style.width = '100%';
-  }
-  if (cartCounter) {
-    cartCounter.style.marginTop = '5px';
+    if (cartCounter) {
+      if (cartCounter.parentElement !== header) {
+        header.appendChild(cartCounter);
+      }
+      headerLine.insertAdjacentElement('afterend', cartCounter);
+      cartCounter.style.marginTop = '5px';
+    }
   }
 
   const productItem = document.querySelector('.product-item');


### PR DESCRIPTION
## Summary
- Keep header line inside sticky header and append cart counter beneath it.
- Adjust product page script to maintain header line and cart counter placement within sticky header.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3957a686483218b360f76e30ce874