### PR TITLE
Fix checkout header clock visibility

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -42,7 +42,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 5px;
+            margin-top: -5px;
             font-weight: 600;
         }
         iframe {


### PR DESCRIPTION
## Summary
- ensure sticky header clock appears below logo on checkout page by adjusting style

## Testing
- `npm test` *(fails: could not read package.json)*
- `python -m pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a17dedb88321b61c5c8927cdc8c2