### PR TITLE
Hide cart icon on cart/checkout and fix checkout header clock

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -52,9 +52,6 @@
             width: 100%;
             margin-top: 5px;
         }
-        .cart-counter {
-            display: none;
-        }
         .cart-page {
             max-width: 400px;
             margin: 0 auto;
@@ -519,7 +516,6 @@
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
-    .cart-counter { margin-top: 5px; }
 </style>
 </head>
 <body>
@@ -530,9 +526,6 @@
     </div>
     <div class="time" id="current-time"></div>
 <div class="header-line"></div>
-<div class="cart-counter">
-    <span class="cart-icon">🛒</span><span id="cart-count">0</span>
-</div>
 </header>
 <div id="cart-page" class="cart-page">
     <h2>Cart</h2>

--- a/cart.js
+++ b/cart.js
@@ -1269,7 +1269,10 @@ function ensureCartCounter() {
 
 document.addEventListener('DOMContentLoaded', () => {
     initCart();
-    ensureCartCounter();
+    const page = window.location.pathname.split('/').pop();
+    if (page !== 'cart.html' && page !== 'checkout.html') {
+        ensureCartCounter();
+    }
     document.querySelectorAll('button:not(.pay-btn)').forEach(btn => {
         btn.style.background = '#000';
         btn.style.color = '#fff';

--- a/checkout.html
+++ b/checkout.html
@@ -28,7 +28,7 @@
         .logo-container {
             position: relative;
             width: 20vw;
-            height: 15vh;
+            height: 10vh;
         }
         .logo-overlay {
             position: absolute;
@@ -42,7 +42,7 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: -15px;
+            margin-top: -5px;
             font-weight: 600;
         }
         iframe {
@@ -54,9 +54,6 @@
             border-top: 1px solid #000;
             width: 100%;
             margin-top: 5px;
-        }
-        .cart-counter {
-            display: none;
         }
         .cart-buttons {
             display: flex;


### PR DESCRIPTION
## Summary
- Make cart counter injection conditional so cart and checkout pages hide the icon
- Adjust checkout header styles so clock shows beneath the logo
- Remove leftover cart-counter markup from cart page header

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a73ecb9c83219848221892868f73