### PR TITLE
Avoid duplicate empty cart notice on cart page

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -1165,6 +1165,9 @@ function setupCartPage() {
 function setupCheckoutPage() {
     const finalPage = document.getElementById('final-checkout');
     if (!finalPage) return;
+    if (document.getElementById('cart-page') && cart.length === 0) {
+        return;
+    }
     if (cart.length === 0) {
         finalPage.innerHTML = '';
         finalPage.style.display = 'flex';


### PR DESCRIPTION
## Summary
- Prevent duplicate "Your cart is empty." message when visiting cart.html by skipping checkout setup on an empty cart page

## Testing
- `node --check cart.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3b4b916348321a16fd668b55f32c1