### PR TITLE
Fix checkout header clock visibility

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -514,7 +514,15 @@
         }
         .header-container { position: sticky; top: 0; z-index: 1000; }
         .logo-container { height: 10vh; }
-        .time { margin-top: -5px; display: block; }
+        .time {
+            margin-top: -5px;
+            position: relative;
+            z-index: 1001;
+        }
+        .header-line {
+            position: relative;
+            z-index: 1001;
+        }
     </style>
 </head>
 <body>
@@ -716,10 +724,15 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
                 day: '2-digit',
             };
             const currentTime = new Intl.DateTimeFormat('en-US', options).format(new Date()).replace(",", "");
-            document.getElementById('current-time').textContent = currentTime + " CHICAGO";
+            const clock = document.getElementById('current-time');
+            if (clock) {
+                clock.textContent = currentTime + " CHICAGO";
+            }
         }
-        updateChicagoTime();
-        setInterval(updateChicagoTime, 1000);
+        document.addEventListener('DOMContentLoaded', () => {
+            updateChicagoTime();
+            setInterval(updateChicagoTime, 1000);
+        });
 
         const fullSiteLink = document.getElementById('full-site-link');
         if (window.top !== window.self && fullSiteLink) {


### PR DESCRIPTION
## Summary
- Ensure checkout sticky header clock and divider render above other content
- Update clock script to initialize after DOM load for consistent display

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3d01c77bc8321bb5478338168bdf6