### PR TITLE
Fix checkout sticky header clock visibility

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -21,11 +21,14 @@
             display: flex;
             flex-direction: column;
             align-items: center;
+            position: sticky;
+            top: 0;
+            z-index: 1000;
         }
         .logo-container {
             position: relative;
             width: 20vw;
-            height: 15vh;
+            height: 10vh;
         }
         .logo-overlay {
             position: absolute;
@@ -39,8 +42,12 @@
         .time {
             font-size: 0.7rem;
             text-align: center;
-            margin-top: 0;
+            margin-top: -5px;
             font-weight: 600;
+            position: relative;
+            z-index: 1001;
+            display: block;
+            width: 100%;
         }
         iframe {
             width: 100%;
@@ -51,6 +58,8 @@
             border-top: 1px solid #000;
             width: 100%;
             margin-top: 5px;
+            position: relative;
+            z-index: 1001;
         }
         .cart-buttons {
             display: flex;
@@ -511,17 +520,6 @@
                 position: static;
                 width: 100%;
             }
-        }
-        .header-container { position: sticky; top: 0; z-index: 1000; }
-        .logo-container { height: 10vh; }
-        .time {
-            margin-top: 0;
-            position: relative;
-            z-index: 1001;
-        }
-        .header-line {
-            position: relative;
-            z-index: 1001;
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- Ensure sticky checkout header includes logo, clock, and separator line
- Make time element always visible with sticky positioning and high z-index

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d862d9dc832181ffe2491c566d8f