### PR TITLE
Ensure checkout clock is always visible

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -23,7 +23,7 @@
             align-items: center;
             position: sticky;
             top: 0;
-            z-index: 1000;
+            z-index: 10000;
         }
         .logo-container {
             position: relative;
@@ -45,7 +45,7 @@
             margin-top: -5px;
             font-weight: 600;
             position: relative;
-            z-index: 1001;
+            z-index: 10001;
             display: block;
             width: 100%;
         }
@@ -727,8 +727,24 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
                 clock.textContent = currentTime + " CHICAGO";
             }
         }
-        updateChicagoTime();
-        setInterval(updateChicagoTime, 1000);
+
+        document.addEventListener('DOMContentLoaded', () => {
+            const header = document.querySelector('.header-container');
+            let clock = document.getElementById('current-time');
+            if (!clock && header) {
+                clock = document.createElement('div');
+                clock.id = 'current-time';
+                clock.className = 'time';
+                const headerLine = header.querySelector('.header-line');
+                if (headerLine) {
+                    header.insertBefore(clock, headerLine);
+                } else {
+                    header.appendChild(clock);
+                }
+            }
+            updateChicagoTime();
+            setInterval(updateChicagoTime, 1000);
+        });
 
         const fullSiteLink = document.getElementById('full-site-link');
         if (window.top !== window.self && fullSiteLink) {


### PR DESCRIPTION
## Summary
- raise header z-index and clock z-index so checkout clock stays above page content
- add DOMContentLoaded hook to insert and update the Chicago clock on checkout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3dcb1196883218139ded3953d12ce