### PR TITLE
Ensure checkout clock displays

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -728,7 +728,7 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
             }
         }
 
-        document.addEventListener('DOMContentLoaded', () => {
+        (function ensureClock() {
             const header = document.querySelector('.header-container');
             let clock = document.getElementById('current-time');
             if (!clock && header) {
@@ -742,9 +742,10 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
                     header.appendChild(clock);
                 }
             }
-            updateChicagoTime();
-            setInterval(updateChicagoTime, 1000);
-        });
+        })();
+
+        updateChicagoTime();
+        setInterval(updateChicagoTime, 1000);
 
         const fullSiteLink = document.getElementById('full-site-link');
         if (window.top !== window.self && fullSiteLink) {


### PR DESCRIPTION
## Summary
- Guarantee clock element exists and show Chicago time on checkout page

## Testing
- `npm test` *(fails: could not read package.json)*
- `python -m py_compile generate_category_pages.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3dfeb4be483218fbedaa5e976dd18