### PR TITLE
Initialize checkout clock after DOM load

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -728,7 +728,7 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
             }
         }
 
-        (function ensureClock() {
+        function ensureClock() {
             const header = document.querySelector('.header-container');
             let clock = document.getElementById('current-time');
             if (!clock && header) {
@@ -742,10 +742,13 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
                     header.appendChild(clock);
                 }
             }
-        })();
+        }
 
-        updateChicagoTime();
-        setInterval(updateChicagoTime, 1000);
+        document.addEventListener('DOMContentLoaded', () => {
+            ensureClock();
+            updateChicagoTime();
+            setInterval(updateChicagoTime, 1000);
+        });
 
         const fullSiteLink = document.getElementById('full-site-link');
         if (window.top !== window.self && fullSiteLink) {


### PR DESCRIPTION
## Summary
- Ensure checkout clock exists and updates after DOM content loads to guarantee visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e3cf96ec8321a5cab23a4286d843