### PR TITLE
Fix clock visibility on checkout page

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -787,7 +787,6 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
         const rememberWarning = document.querySelector('.remember-warning');
         const emailInput = document.querySelector('input[name="contact_email"]');
         const emailWarning = document.querySelector('.email-warning');
-        const creditRadio = document.getElementById('pay-credit');
         const cardInputs = document.querySelectorAll('.credit-card-fields input');
         const cardWarning = document.querySelector('.card-warning');
         const addressInputs = document.querySelectorAll('input[name="first_name"], input[name="last_name"], input[name="address"], input[name="city"], input[name="state"], input[name="zip"]');


### PR DESCRIPTION
## Summary
- Ensure checkout script runs by removing duplicate `creditRadio` declaration, restoring sticky clock display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3eb4254808321a0322d5af8b49dfe