### PR TITLE
Fix sticky header across shop/product pages

### DIFF
--- a/footer-highlight.js
+++ b/footer-highlight.js
@@ -4,6 +4,23 @@ document.addEventListener('DOMContentLoaded', () => {
     current === 'shop.html' ||
     document.querySelector('.product-item') ||
     document.querySelector('.product-grid');
+
+  // Ensure all shop and product pages use a sticky header like the t-shirt page
+  const header = document.querySelector('.header-container');
+  if (header) {
+    header.style.position = 'sticky';
+    header.style.top = '0';
+    header.style.zIndex = '1000';
+  }
+
+  const { documentElement: html, body } = document;
+  [html, body].forEach(el => {
+    el.style.display = 'block';
+    el.style.minHeight = '100%';
+  });
+  body.style.flexDirection = '';
+  body.style.alignItems = '';
+
   document.querySelectorAll('footer a').forEach(link => {
     const href = link.getAttribute('href');
     if (href === current || (isShopPage && href === 'shop.html')) {


### PR DESCRIPTION
## Summary
- Ensure sticky header styles apply across all shop and product pages via shared script
- Normalize body layout to allow header stickiness

## Testing
- `node --check footer-highlight.js && echo "Syntax OK"`
- `python -m py_compile generate_category_pages.py && echo "py ok"`


------
https://chatgpt.com/codex/tasks/task_e_68a47a713d148321a4a2d8a34af8710e