### PR TITLE
Ensure sticky header across product pages

### DIFF
--- a/americandenim.html
+++ b/americandenim.html
@@ -13,10 +13,8 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
+            /* Allow normal document flow so the header can stick */
+            min-height: 100%;
         }
         .header-container {
             width: 100%;
@@ -25,45 +23,16 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-        }
-        .logo-container {
-            position: relative;
-            width: 20vw;
-            height: 15vh;
-            margin-top: 0;
-        }
-        .logo-overlay {
-            position: absolute;
+            position: sticky;
             top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            cursor: pointer;
-            z-index: 10;
+            z-index: 1000;
         }
-        iframe {
-            width: 100%;
-            height: 100%;
-            border: none;
-        }
-        .time {
-            font-size: 0.7rem;
-            text-align: center;
-            margin-top: -15px;
-            font-weight: 600;
-        }
-        .header-line {
-            border-top: 1px solid #000;
-            margin-top:5px;
-            width: 100%;
-        }
-
-        .cart-counter {
-            margin-top:5px;
-            font-size:0.7rem;
-            text-align:center;
-            font-weight:600;
-        }
+        .logo-container { position: relative; width: 20vw; height: 10vh; margin-top: 0; }
+        .logo-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; cursor: pointer; z-index: 10; }
+        iframe { width: 100%; height: 100%; border: none; }
+        .time { font-size: 0.7rem; text-align: center; margin-top: -5px; font-weight: 600; }
+        .header-line { border-top: 1px solid #000; margin-top:5px; width: 100%; }
+        .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
         /* Mobile Navigation */
         .mobile-nav {
             display: block;
@@ -186,10 +155,6 @@
             cursor: pointer;
             display: inline-block;
         }
-        .header-container { position: sticky; top: 0; z-index: 1000; }
-    .logo-container { height: 10vh; }
-    .time { margin-top: -5px; }
-    .cart-counter { margin-top: 5px; }
 </style>
 </head>
 <body>

--- a/hat.html
+++ b/hat.html
@@ -13,10 +13,8 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
+            /* Allow normal document flow so the header can stick */
+            min-height: 100%;
         }
         .header-container {
             width: 100%;
@@ -25,45 +23,16 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-        }
-        .logo-container {
-            position: relative;
-            width: 20vw;
-            height: 15vh;
-            margin-top: 0;
-        }
-        .logo-overlay {
-            position: absolute;
+            position: sticky;
             top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            cursor: pointer;
-            z-index: 10;
+            z-index: 1000;
         }
-        iframe {
-            width: 100%;
-            height: 100%;
-            border: none;
-        }
-        .time {
-            font-size: 0.7rem;
-            text-align: center;
-            margin-top: -15px;
-            font-weight: 600;
-        }
-        .header-line {
-            border-top: 1px solid #000;
-            margin-top:5px;
-            width: 100%;
-        }
-
-        .cart-counter {
-            margin-top:5px;
-            font-size:0.7rem;
-            text-align:center;
-            font-weight:600;
-        }
+        .logo-container { position: relative; width: 20vw; height: 10vh; margin-top: 0; }
+        .logo-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; cursor: pointer; z-index: 10; }
+        iframe { width: 100%; height: 100%; border: none; }
+        .time { font-size: 0.7rem; text-align: center; margin-top: -5px; font-weight: 600; }
+        .header-line { border-top: 1px solid #000; margin-top:5px; width: 100%; }
+        .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
 
         /* Mobile Navigation */
         .mobile-nav {
@@ -160,10 +129,6 @@
             cursor: pointer;
             display: inline-block;
         }
-        .header-container { position: sticky; top: 0; z-index: 1000; }
-    .logo-container { height: 10vh; }
-    .time { margin-top: -5px; }
-    .cart-counter { margin-top: 5px; }
 </style>
 </head>
 <body>

--- a/hoodie.html
+++ b/hoodie.html
@@ -7,14 +7,32 @@
     <title>Hoodie - MaybeNot Shop</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
-        body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; height:100%; display:flex; flex-direction:column; align-items:center; }
-        .header-container { width:100%; padding: 0 10px 10px; background-color:#f7f7f7; display:flex; flex-direction:column; align-items:center; }
-        .logo-container { position:static; width:20vw; height:20vh; margin-top:0; }
-        .logo-overlay { position:absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
-        iframe { width:100%; height:100%; border:none; }
-        .time { font-size:0.7rem; text-align:center; margin-top: -15px; font-weight:600; }
-        .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
+        body, html {
+            margin: 0;
+            padding: 0;
+            font-family: 'Courier New', Courier, monospace;
+            background-color: #f7f7f7;
+            color: #000;
+            /* Allow normal document flow so the header can stick */
+            min-height: 100%;
+        }
+        .header-container {
+            width: 100%;
+            padding: 0 10px 10px;
+            background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+        }
+        .logo-container { position: relative; width: 20vw; height: 10vh; margin-top: 0; }
+        .logo-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; cursor: pointer; z-index: 10; }
+        iframe { width: 100%; height: 100%; border: none; }
+        .time { font-size: 0.7rem; text-align: center; margin-top: -5px; font-weight: 600; }
+        .header-line { border-top: 1px solid #000; margin-top: 5px; width: 100%; }
+        .cart-counter { margin-top: 5px; font-size: 0.7rem; text-align: center; font-weight: 600; }
         /* Mobile Navigation */
         .mobile-nav { display:block; width:100%; margin-top:20px; }
         nav.mobile-nav ul { list-style-type:none; padding:0; margin:0; width:100%; }
@@ -32,10 +50,6 @@
         .image-slider img { width:100%; height:100%; object-fit:contain; }
         .color-options { display:flex; gap:5px; margin:5px 0; }
         .color-option { width:15px; height:15px; cursor:pointer; display:inline-block; }
-        .header-container { position: sticky; top: 0; z-index: 1000; }
-    .logo-container { height: 10vh; }
-    .time { margin-top: -5px; }
-    .cart-counter { margin-top: 5px; }
 </style>
 </head>
 <body>

--- a/joggers.html
+++ b/joggers.html
@@ -7,14 +7,32 @@
     <title>Joggers - MaybeNot Shop</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
-        body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; height:100%; display:flex; flex-direction:column; align-items:center; }
-        .header-container { width:100%; padding: 0 10px 10px; background-color:#f7f7f7; display:flex; flex-direction:column; align-items:center; }
-        .logo-container { position:static; width:20vw; height:20vh; margin-top:0; }
-        .logo-overlay { position:absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
-        iframe { width:100%; height:100%; border:none; }
-        .time { font-size:0.7rem; text-align:center; margin-top: -15px; font-weight:600; }
-        .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
-        .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
+        body, html {
+            margin: 0;
+            padding: 0;
+            font-family: 'Courier New', Courier, monospace;
+            background-color: #f7f7f7;
+            color: #000;
+            /* Allow normal document flow so the header can stick */
+            min-height: 100%;
+        }
+        .header-container {
+            width: 100%;
+            padding: 0 10px 10px;
+            background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+        }
+        .logo-container { position: relative; width: 20vw; height: 10vh; margin-top: 0; }
+        .logo-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; cursor: pointer; z-index: 10; }
+        iframe { width: 100%; height: 100%; border: none; }
+        .time { font-size: 0.7rem; text-align: center; margin-top: -5px; font-weight: 600; }
+        .header-line { border-top: 1px solid #000; margin-top: 5px; width: 100%; }
+        .cart-counter { margin-top: 5px; font-size: 0.7rem; text-align: center; font-weight: 600; }
         /* Mobile Navigation */
         .mobile-nav { display:block; width:100%; margin-top:20px; }
         nav.mobile-nav ul { list-style-type:none; padding:0; margin:0; width:100%; }
@@ -39,10 +57,6 @@
         .color-option.selected, .color-option:hover, .color-option:focus { border:2px solid red; }
         .product-item button { background:#000; color:#fff; border:2px solid #000; font-family:'Courier New', Courier, monospace; cursor:pointer; margin-top:5px; }
         .product-item button:hover, .product-item button:active, .product-item button:focus { background:#fff; color:red; border-color:red; }
-        .header-container { position: sticky; top: 0; z-index: 1000; }
-    .logo-container { height: 10vh; }
-    .time { margin-top: -5px; }
-    .cart-counter { margin-top: 5px; }
 </style>
 </head>
 <body>

--- a/shorts.html
+++ b/shorts.html
@@ -13,10 +13,8 @@
             font-family: 'Courier New', Courier, monospace;
             background-color: #f7f7f7;
             color: #000;
-            height: 100%;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
+            /* Allow normal document flow so the header can stick */
+            min-height: 100%;
         }
         .header-container {
             width: 100%;
@@ -25,11 +23,14 @@
             display: flex;
             flex-direction: column;
             align-items: center;
+            position: sticky;
+            top: 0;
+            z-index: 1000;
         }
-        .logo-container { position: relative; width: 20vw; height: 15vh; margin-top: 0; }
+        .logo-container { position: relative; width: 20vw; height: 10vh; margin-top: 0; }
         .logo-overlay { position: absolute; top:0; left:0; width:100%; height:100%; cursor:pointer; z-index:10; }
         iframe { width:100%; height:100%; border:none; }
-        .time { font-size:0.7rem; text-align:center; margin-top: -15px; font-weight:600; }
+        .time { font-size:0.7rem; text-align:center; margin-top: -5px; font-weight:600; }
         .header-line { border-top:1px solid #000; margin-top:5px; width:100%; }
         .cart-counter { margin-top:5px; font-size:0.7rem; text-align:center; font-weight:600; }
         /* Mobile Navigation */
@@ -56,10 +57,6 @@
         .color-option.selected, .color-option:hover, .color-option:focus { border:2px solid red; }
         .product-item button { background:#000; color:#fff; border:2px solid #000; font-family:'Courier New', Courier, monospace; cursor:pointer; margin-top:5px; }
         .product-item button:hover, .product-item button:active, .product-item button:focus { background:#fff; color:red; border-color:red; }
-        .header-container { position: sticky; top: 0; z-index: 1000; }
-    .logo-container { height: 10vh; }
-    .time { margin-top: -5px; }
-    .cart-counter { margin-top: 5px; }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Standardize product page layout to match t-shirt page
- Make header sticky and consistent on hoodie, joggers, hat, shorts, and American denim pages

## Testing
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a47e5865748321a708fdf195e92d43