### PR TITLE
Add pagination and clean up single-color products

### DIFF
--- a/all.html
+++ b/all.html
@@ -304,6 +304,9 @@
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
+        .pagination { text-align: center; margin-top: 20px; }
+        .pagination button { font-family: 'Courier New', Courier, monospace; background: #fff; color: #000; border: 1px solid #000; cursor: pointer; }
+        .pagination button:hover { background: red; color: #fff; }
 </style>
 </head>
 <body>
@@ -447,6 +450,9 @@
     </a>
 </div>
     </div>
+    <div class="pagination">
+        <button id="next-page">next page</button>
+    </div>
 </section>
 
 <!-- Desktop Nav -->
@@ -537,6 +543,30 @@
     }
 
     setInterval(updateChicagoTime, 1000);
+
+    const items = Array.from(document.querySelectorAll('.product-item'));
+    const itemsPerPage = 9;
+    let currentPage = 0;
+    const totalPages = Math.ceil(items.length / itemsPerPage);
+    const nextBtn = document.getElementById('next-page');
+
+    function showPage(page) {
+        items.forEach((item, index) => {
+            item.style.display = Math.floor(index / itemsPerPage) === page ? 'block' : 'none';
+        });
+        if (nextBtn) {
+            nextBtn.style.display = page < totalPages - 1 ? 'block' : 'none';
+        }
+    }
+
+    if (nextBtn) {
+        nextBtn.addEventListener('click', () => {
+            currentPage++;
+            showPage(currentPage);
+        });
+    }
+
+    showPage(currentPage);
 
     // Full-site link is always visible; scroll handler removed
 

--- a/dufflebag.html
+++ b/dufflebag.html
@@ -118,17 +118,6 @@
         }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
-        .color-options {
-            display: flex;
-            gap: 5px;
-            margin: 5px 0;
-        }
-        .color-option {
-            width: 15px;
-            height: 15px;
-            cursor: pointer;
-            display: inline-block;
-        }
 </style>
 </head>
 <body>
@@ -152,9 +141,6 @@
     </div>
     <h1>Duffle Bag</h1>
     <p>$80</p>
-    <div class="color-options">
-        <span class="color-option" data-color="black" data-image="dufflebag1.png" style="background:#000;"></span>
-    </div>
     <div class="size-select">
         <select>
             <option value="">Select Size</option>

--- a/new.html
+++ b/new.html
@@ -303,7 +303,10 @@
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
-    .cart-counter { margin-top: 5px; }
+        .cart-counter { margin-top: 5px; }
+        .pagination { text-align: center; margin-top: 20px; }
+        .pagination button { font-family: 'Courier New', Courier, monospace; background: #fff; color: #000; border: 1px solid #000; cursor: pointer; }
+        .pagination button:hover { background: red; color: #fff; }
 </style>
 </head>
 <body>
@@ -323,7 +326,7 @@
 </header>
 <section class="product-section">
     <div class="product-grid">
-        
+
 <div class="product-item">
     <a href="hat.html">
         <img src="whitehat.png" alt="Hat">
@@ -333,7 +336,7 @@
         </div>
     </a>
 </div>
-    
+
 <div class="product-item">
     <a href="hoodie.html">
         <img src="blackhoodie.png" alt="Hoodie">
@@ -343,7 +346,7 @@
         </div>
     </a>
 </div>
-    
+
 <div class="product-item">
     <a href="shirt.html">
         <img src="whiteshirt.png" alt="T-Shirt">
@@ -353,7 +356,7 @@
         </div>
     </a>
 </div>
-    
+
 <div class="product-item">
     <a href="joggers.html">
         <img src="blackjoggers.png" alt="Joggers">
@@ -363,7 +366,7 @@
         </div>
     </a>
 </div>
-    
+
 <div class="product-item">
     <a href="shorts.html">
         <img src="whiteshorts.png" alt="Shorts">
@@ -373,7 +376,7 @@
         </div>
     </a>
 </div>
-    
+
 <div class="product-item">
     <a href="americandenim.html">
         <img src="bluejeans.png" alt="American Denim">
@@ -383,6 +386,73 @@
         </div>
     </a>
 </div>
+
+<div class="product-item">
+    <a href="dufflebag.html">
+        <img src="dufflebag1.png" alt="Duffle Bag">
+        <div class="product-info">
+            <p>Duffle Bag</p>
+            <p>$80</p>
+        </div>
+    </a>
+</div>
+<div class="product-item">
+    <a href="backpack.html">
+        <img src="backpackblack.png" alt="Backpack">
+        <div class="product-info">
+            <p>Backpack</p>
+            <p>$70</p>
+        </div>
+    </a>
+</div>
+<div class="product-item">
+    <a href="truckerhat.html">
+        <img src="truckerwhitefront.png" alt="Trucker Hat">
+        <div class="product-info">
+            <p>Trucker Hat</p>
+            <p>$40</p>
+        </div>
+    </a>
+</div>
+<div class="product-item">
+    <a href="socks.html">
+        <img src="blacksocks.png" alt="Socks">
+        <div class="product-info">
+            <p>Socks</p>
+            <p>$20</p>
+        </div>
+    </a>
+</div>
+<div class="product-item">
+    <a href="skateboard1.html">
+        <img src="skateboard3v2.png" alt="Skateboard 1">
+        <div class="product-info">
+            <p>Skateboard 1</p>
+            <p>$70</p>
+        </div>
+    </a>
+</div>
+<div class="product-item">
+    <a href="skateboard2.html">
+        <img src="skateboard4.png" alt="Skateboard 2">
+        <div class="product-info">
+            <p>Skateboard 2</p>
+            <p>$70</p>
+        </div>
+    </a>
+</div>
+<div class="product-item">
+    <a href="skateboard3.html">
+        <img src="skateboard1.png" alt="Skateboard 3">
+        <div class="product-info">
+            <p>Skateboard 3</p>
+            <p>$70</p>
+        </div>
+    </a>
+</div>
+    </div>
+    <div class="pagination">
+        <button id="next-page">next page</button>
     </div>
 </section>
 
@@ -474,6 +544,30 @@
     }
 
     setInterval(updateChicagoTime, 1000);
+
+    const items = Array.from(document.querySelectorAll('.product-item'));
+    const itemsPerPage = 9;
+    let currentPage = 0;
+    const totalPages = Math.ceil(items.length / itemsPerPage);
+    const nextBtn = document.getElementById('next-page');
+
+    function showPage(page) {
+        items.forEach((item, index) => {
+            item.style.display = Math.floor(index / itemsPerPage) === page ? 'block' : 'none';
+        });
+        if (nextBtn) {
+            nextBtn.style.display = page < totalPages - 1 ? 'block' : 'none';
+        }
+    }
+
+    if (nextBtn) {
+        nextBtn.addEventListener('click', () => {
+            currentPage++;
+            showPage(currentPage);
+        });
+    }
+
+    showPage(currentPage);
 
     // Full-site link is always visible; scroll handler removed
 

--- a/skateboard1.html
+++ b/skateboard1.html
@@ -118,17 +118,6 @@
         }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
-        .color-options {
-            display: flex;
-            gap: 5px;
-            margin: 5px 0;
-        }
-        .color-option {
-            width: 15px;
-            height: 15px;
-            cursor: pointer;
-            display: inline-block;
-        }
 </style>
 </head>
 <body>
@@ -152,9 +141,6 @@
     </div>
     <h1>Skateboard 1</h1>
     <p>$70</p>
-    <div class="color-options">
-        <span class="color-option" data-color="natural" data-image="skateboard3v2.png" style="background:#ccc;"></span>
-    </div>
     <div class="size-select">
         <select>
             <option value="">Select Size</option>

--- a/skateboard2.html
+++ b/skateboard2.html
@@ -118,17 +118,6 @@
         }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
-        .color-options {
-            display: flex;
-            gap: 5px;
-            margin: 5px 0;
-        }
-        .color-option {
-            width: 15px;
-            height: 15px;
-            cursor: pointer;
-            display: inline-block;
-        }
 </style>
 </head>
 <body>
@@ -152,9 +141,6 @@
     </div>
     <h1>Skateboard 2</h1>
     <p>$70</p>
-    <div class="color-options">
-        <span class="color-option" data-color="natural" data-image="skateboard4.png" style="background:#ccc;"></span>
-    </div>
     <div class="size-select">
         <select>
             <option value="">Select Size</option>

--- a/skateboard3.html
+++ b/skateboard3.html
@@ -118,17 +118,6 @@
         }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
-        .color-options {
-            display: flex;
-            gap: 5px;
-            margin: 5px 0;
-        }
-        .color-option {
-            width: 15px;
-            height: 15px;
-            cursor: pointer;
-            display: inline-block;
-        }
 </style>
 </head>
 <body>
@@ -152,9 +141,6 @@
     </div>
     <h1>Skateboard 3</h1>
     <p>$70</p>
-    <div class="color-options">
-        <span class="color-option" data-color="natural" data-image="skateboard1.png" style="background:#ccc;"></span>
-    </div>
     <div class="size-select">
         <select>
             <option value="">Select Size</option>

--- a/socks.html
+++ b/socks.html
@@ -118,17 +118,6 @@
         }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
-        .color-options {
-            display: flex;
-            gap: 5px;
-            margin: 5px 0;
-        }
-        .color-option {
-            width: 15px;
-            height: 15px;
-            cursor: pointer;
-            display: inline-block;
-        }
 </style>
 </head>
 <body>
@@ -145,16 +134,13 @@
 </div>
 </header>
 <div class="product-item" data-product="socks" data-price="20" data-selected-color="" data-size="">
-    <div class="image-slider" data-images="blacksocks.png">
+    <div class="image-slider" data-images="blacksocks.png,blacksocks2.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="blacksocks.png" alt="Socks">
         <button class="next">&#10095;</button>
     </div>
     <h1>Socks</h1>
     <p>$20</p>
-    <div class="color-options">
-        <span class="color-option" data-color="black" data-image="blacksocks.png" style="background:#fff;border:1px solid #000;"></span>
-    </div>
     <div class="size-select">
         <select>
             <option value="">Select Size</option>


### PR DESCRIPTION
## Summary
- paginate all and new category pages with 9 items per view and a Next Page button
- include socks and other new products on the new page
- drop color selectors for single-color items and ensure socks use blacksocks.png/blacksocks2.png

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4eb8bcc0c832185e0111e26b67eee