### PR TITLE
Fix pagination controls and socks image reference

### DIFF
--- a/all.html
+++ b/all.html
@@ -304,7 +304,7 @@
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
-        .pagination { text-align: center; margin-top: 20px; }
+        .pagination { display: flex; justify-content: center; gap: 10px; margin-top: 20px; }
         .pagination button { font-family: 'Courier New', Courier, monospace; background: #fff; color: #000; border: 1px solid #000; cursor: pointer; }
         .pagination button:hover { background: red; color: #fff; }
 </style>
@@ -385,6 +385,7 @@
             <p>$90</p>
         </div>
     </a>
+    </div>
 
 <div class="product-item">
     <a href="dufflebag.html">
@@ -451,6 +452,7 @@
 </div>
     </div>
     <div class="pagination">
+        <button id="prev-page">previous page</button>
         <button id="next-page">next page</button>
     </div>
 </section>
@@ -549,20 +551,44 @@
     let currentPage = 0;
     const totalPages = Math.ceil(items.length / itemsPerPage);
     const nextBtn = document.getElementById('next-page');
+    const prevBtn = document.getElementById('prev-page');
 
     function showPage(page) {
         items.forEach((item, index) => {
             item.style.display = Math.floor(index / itemsPerPage) === page ? 'block' : 'none';
         });
         if (nextBtn) {
-            nextBtn.style.display = page < totalPages - 1 ? 'block' : 'none';
+            nextBtn.style.display = page < totalPages - 1 ? 'inline-block' : 'none';
+        }
+        if (prevBtn) {
+            prevBtn.style.display = page > 0 ? 'inline-block' : 'none';
+        }
+    }
+
+    function scrollToFirst(page) {
+        const first = items[page * itemsPerPage];
+        if (first) {
+            first.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
     }
 
     if (nextBtn) {
         nextBtn.addEventListener('click', () => {
-            currentPage++;
-            showPage(currentPage);
+            if (currentPage < totalPages - 1) {
+                currentPage++;
+                showPage(currentPage);
+                scrollToFirst(currentPage);
+            }
+        });
+    }
+
+    if (prevBtn) {
+        prevBtn.addEventListener('click', () => {
+            if (currentPage > 0) {
+                currentPage--;
+                showPage(currentPage);
+                scrollToFirst(currentPage);
+            }
         });
     }
 

--- a/new.html
+++ b/new.html
@@ -304,7 +304,7 @@
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
         .cart-counter { margin-top: 5px; }
-        .pagination { text-align: center; margin-top: 20px; }
+        .pagination { display: flex; justify-content: center; gap: 10px; margin-top: 20px; }
         .pagination button { font-family: 'Courier New', Courier, monospace; background: #fff; color: #000; border: 1px solid #000; cursor: pointer; }
         .pagination button:hover { background: red; color: #fff; }
 </style>
@@ -452,6 +452,7 @@
 </div>
     </div>
     <div class="pagination">
+        <button id="prev-page">previous page</button>
         <button id="next-page">next page</button>
     </div>
 </section>
@@ -550,20 +551,44 @@
     let currentPage = 0;
     const totalPages = Math.ceil(items.length / itemsPerPage);
     const nextBtn = document.getElementById('next-page');
+    const prevBtn = document.getElementById('prev-page');
 
     function showPage(page) {
         items.forEach((item, index) => {
             item.style.display = Math.floor(index / itemsPerPage) === page ? 'block' : 'none';
         });
         if (nextBtn) {
-            nextBtn.style.display = page < totalPages - 1 ? 'block' : 'none';
+            nextBtn.style.display = page < totalPages - 1 ? 'inline-block' : 'none';
+        }
+        if (prevBtn) {
+            prevBtn.style.display = page > 0 ? 'inline-block' : 'none';
+        }
+    }
+
+    function scrollToFirst(page) {
+        const first = items[page * itemsPerPage];
+        if (first) {
+            first.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
     }
 
     if (nextBtn) {
         nextBtn.addEventListener('click', () => {
-            currentPage++;
-            showPage(currentPage);
+            if (currentPage < totalPages - 1) {
+                currentPage++;
+                showPage(currentPage);
+                scrollToFirst(currentPage);
+            }
+        });
+    }
+
+    if (prevBtn) {
+        prevBtn.addEventListener('click', () => {
+            if (currentPage > 0) {
+                currentPage--;
+                showPage(currentPage);
+                scrollToFirst(currentPage);
+            }
         });
     }
 

--- a/socks.html
+++ b/socks.html
@@ -134,7 +134,7 @@
 </div>
 </header>
 <div class="product-item" data-product="socks" data-price="20" data-selected-color="" data-size="">
-    <div class="image-slider" data-images="blacksocks.png,blacksocks2.png">
+    <div class="image-slider" data-images="blacksocks.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="blacksocks.png" alt="Socks">
         <button class="next">&#10095;</button>


### PR DESCRIPTION
## Summary
- Add centered previous/next pagination controls that scroll to the first product on each page
- Correct socks page to use the `blacksocks.png` image
- Fix unclosed product markup on all category page to prevent navigation overlap

## Testing
- `node --check product.js`
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4f28cada083219acd9005b5716f1a