### PR TITLE
Restrict product image sliders to selected color

### DIFF
--- a/product.js
+++ b/product.js
@@ -4,8 +4,9 @@
 
 function initSliders() {
   document.querySelectorAll('.image-slider').forEach(slider => {
-    const images = slider.dataset.images ? slider.dataset.images.split(',') : [];
-    if (images.length === 0) return;
+    const allImages = slider.dataset.images ? slider.dataset.images.split(',') : [];
+    if (allImages.length === 0) return;
+    let images = [...allImages];
     let index = 0;
     const img = slider.querySelector('img');
     if (img) {
@@ -37,13 +38,14 @@ function initSliders() {
     const product = slider.closest('.product-item');
     product?.querySelectorAll('.color-option').forEach((opt) => {
       opt.addEventListener('click', () => {
+        const color = opt.dataset.color || '';
+        images = color ? allImages.filter(src => src.includes(color)) : [...allImages];
+        if (images.length === 0) images = [opt.dataset.image];
         const idx = images.indexOf(opt.dataset.image);
-        if (idx !== -1) {
-          index = idx;
-          img.src = images[index];
-        }
+        index = idx !== -1 ? idx : 0;
+        img.src = images[index];
         if (product) {
-          product.dataset.selectedColor = opt.dataset.color || '';
+          product.dataset.selectedColor = color;
           product.querySelectorAll('.color-option').forEach(o => o.classList.remove('selected'));
           opt.classList.add('selected');
         }


### PR DESCRIPTION
## Summary
- Filter product page image sliders so arrow navigation only cycles through images of the chosen color
- Update selected color handling for backpack, trucker hat and other multi-color products

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a501a79a5883219133ac98ce6c0786