### PR TITLE
Trim desktop whitespace before product recommendations

### DIFF
--- a/product.js
+++ b/product.js
@@ -374,6 +374,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .size-select { margin-top:10px; display:flex; justify-content:center; }
     .size-select select { background:#000; color:#fff; border:1px solid #000; padding:5px; }
     .size-select select:hover, .size-select select:focus, .size-select select:active { border:2px solid red; }
+    .product-item { margin-bottom:0; padding-bottom:0; }
     .recommend-section { width:100%; margin:30px auto; text-align:center; }
     .recommend-section h2 { margin:0 0 10px; }
     .recommend-container { position:relative; max-width:800px; margin:0 auto; }
@@ -386,7 +387,11 @@ document.addEventListener('DOMContentLoaded', () => {
     .recommend-container button:hover, .recommend-container button:focus, .recommend-container button:active { background:white; border:2px solid red; }
     .recommend-container .prev { left:0; }
     .recommend-container .next { right:0; }
-    @media (min-width:768px) { .recommend-item { flex:0 0 calc(100% / 4); } .recommend-section { margin-top:0; } }
+    @media (min-width:768px) {
+      .recommend-item { flex:0 0 calc(100% / 4); }
+      .product-item { margin-bottom:0; padding-bottom:0; }
+      .recommend-section { margin:0 auto; }
+    }
     `;
   document.head.appendChild(footerStyle);
 


### PR DESCRIPTION
## Summary
- Remove bottom spacing from product sections
- Zero out top margin of "You May Also Like" on desktop to eliminate gap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a550db19e08321816c36198c3ab2a8