### PR TITLE
Remove desktop whitespace before recommendations

### DIFF
--- a/product.js
+++ b/product.js
@@ -375,7 +375,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .size-select select { background:#000; color:#fff; border:1px solid #000; padding:5px; }
     .size-select select:hover, .size-select select:focus, .size-select select:active { border:2px solid red; }
     .product-item { margin-bottom:0; padding-bottom:0; }
-    .recommend-section { width:100%; margin:30px auto; text-align:center; }
+    .recommend-section { width:100%; margin:0 auto; text-align:center; }
     .recommend-section h2 { margin:0 0 10px; }
     .recommend-container { position:relative; max-width:800px; margin:0 auto; }
     .recommend-track { display:flex; overflow-x:auto; scroll-behavior:smooth; scrollbar-width:none; }
@@ -387,10 +387,13 @@ document.addEventListener('DOMContentLoaded', () => {
     .recommend-container button:hover, .recommend-container button:focus, .recommend-container button:active { background:white; border:2px solid red; }
     .recommend-container .prev { left:0; }
     .recommend-container .next { right:0; }
+    @media (max-width:767px) {
+      .recommend-section { margin:30px auto; }
+    }
     @media (min-width:768px) {
       .recommend-item { flex:0 0 calc(100% / 4); }
       .product-item { margin-bottom:0; padding-bottom:0; }
-      .recommend-section { margin:0 auto; }
+      .recommend-section { margin-top:0; padding-top:0; }
     }
     `;
   document.head.appendChild(footerStyle);


### PR DESCRIPTION
## Summary
- tighten `.recommend-section` styles to remove extra whitespace on desktop product pages
- keep spacing on small screens via mobile-specific media query

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a55266513c83219311987f9d79e7b6