### PR TITLE
Tighten product page spacing on desktop

### DIFF
--- a/product.js
+++ b/product.js
@@ -234,7 +234,10 @@ document.addEventListener('DOMContentLoaded', () => {
         <button class="next">&#10095;</button>
       </div>
     `;
-    productEl.insertAdjacentElement('afterend', section);
+    // Append recommendations directly inside the product container to avoid
+    // extra whitespace on desktop between the product details and
+    // recommendations.
+    productEl.appendChild(section);
 
     const track = section.querySelector('.recommend-track');
 


### PR DESCRIPTION
## Summary
- Append "You May Also Like" recommendations directly inside each product container to eliminate desktop-only white space

## Testing
- `node --check product.js`


------
https://chatgpt.com/codex/tasks/task_e_68a554d737148321ad1f52f143de5407