### PR TITLE
Reduce whitespace above category navigation on product pages

### DIFF
--- a/product.js
+++ b/product.js
@@ -377,9 +377,9 @@ document.addEventListener('DOMContentLoaded', () => {
     .size-select { margin-top:10px; display:flex; justify-content:center; }
     .size-select select { background:#000; color:#fff; border:1px solid #000; padding:5px; }
     .size-select select:hover, .size-select select:focus, .size-select select:active { border:2px solid red; }
-    .product-item { margin-bottom:0; padding-bottom:0; }
-    .recommend-section { width:100%; margin:0 auto; text-align:center; margin-bottom:0; padding-bottom:0; }
-    .desktop-nav { margin-top:0; }
+    .product-item { margin-bottom:0 !important; padding-bottom:0 !important; }
+    .recommend-section { width:100%; margin:0 auto; text-align:center; margin-bottom:0 !important; padding-bottom:0 !important; }
+    .desktop-nav { margin-top:0 !important; padding-top:0 !important; }
     .recommend-section h2 { margin:0 0 10px; }
     .recommend-container { position:relative; max-width:800px; margin:0 auto; }
     .recommend-track { display:flex; overflow-x:auto; scroll-behavior:smooth; scrollbar-width:none; }
@@ -396,8 +396,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     @media (min-width:768px) {
       .recommend-item { flex:0 0 calc(100% / 4); }
-      .product-item { margin-bottom:0; padding-bottom:0; }
-      .recommend-section { margin-top:20px; padding-top:20px; margin-bottom:0; padding-bottom:0; }
+      .product-item { margin-bottom:0 !important; padding-bottom:0 !important; }
+      .recommend-section { margin-top:20px; padding-top:20px; margin-bottom:0 !important; padding-bottom:0 !important; }
     }
     `;
   document.head.appendChild(footerStyle);


### PR DESCRIPTION
## Summary
- Force product and recommendation blocks to remove bottom spacing
- Ensure desktop category navigation sits directly beneath product info

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a55c94242883219b51cb5fb090d34b