### PR TITLE
Add responsive latest purchases ticker

### DIFF
--- a/footer-highlight.js
+++ b/footer-highlight.js
@@ -49,6 +49,91 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  // Inject the "Latest Purchases" ticker
+  const purchases = [
+    'olivia in los angeles bought a tote bag',
+    'liam in new york bought a hoodie',
+    'emma in chicago bought socks',
+    'noah in toronto bought a skateboard'
+  ];
+
+  const ticker = document.createElement('div');
+  ticker.className = 'purchase-ticker';
+
+  const label = document.createElement('div');
+  label.className = 'ticker-label';
+  label.textContent = 'LATEST PURCHASES';
+  ticker.appendChild(label);
+
+  const track = document.createElement('div');
+  track.className = 'ticker-track';
+  const content = purchases.join(' \u00A0\u00A0\u2022\u00A0\u00A0 ');
+  track.innerHTML = content + ' \u00A0\u00A0\u2022\u00A0\u00A0 ' + content;
+  ticker.appendChild(track);
+
+  const banner = document.getElementById('cookie-banner');
+  if (banner && banner.parentNode) {
+    banner.parentNode.insertBefore(ticker, banner.nextSibling);
+  } else {
+    document.body.insertBefore(ticker, document.body.firstChild);
+  }
+
+  const labelWidth = label.offsetWidth;
+  ticker.style.setProperty('--label-width', labelWidth + 'px');
+  window.addEventListener('resize', () => {
+    ticker.style.setProperty('--label-width', label.offsetWidth + 'px');
+  });
+
+  const style = document.createElement('style');
+  style.textContent = `
+    .purchase-ticker {
+      position: relative;
+      overflow: hidden;
+      background: #f2f2f2;
+      color: #000;
+      font-family: 'Courier New', Courier, monospace;
+      font-size: 0.8rem;
+      padding: 5px 0 5px calc(var(--label-width) + 20px);
+      width: 100%;
+      box-sizing: border-box;
+    }
+    .purchase-ticker .ticker-label {
+      position: absolute;
+      left: 0;
+      top: 0;
+      font-weight: bold;
+      padding: 5px 10px;
+      background: #f2f2f2;
+      z-index: 2;
+    }
+    .purchase-ticker .ticker-track {
+      display: inline-block;
+      white-space: nowrap;
+      animation: ticker-scroll 25s linear infinite;
+    }
+    .purchase-ticker::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: calc(var(--label-width) + 20px);
+      height: 100%;
+      background: linear-gradient(to right, #f2f2f2 0%, rgba(242, 242, 242, 0) 100%);
+      z-index: 1;
+      pointer-events: none;
+    }
+    @keyframes ticker-scroll {
+      0% { transform: translateX(0); }
+      100% { transform: translateX(-50%); }
+    }
+    @media (max-width: 768px) {
+      .purchase-ticker, .purchase-ticker .ticker-label {
+        font-size: 0.6rem;
+      }
+    }
+  `;
+  document.head.appendChild(style);
+
   // Allow long press on the logo to return to the homepage
   const logoOverlay = document.querySelector('.logo-overlay');
   if (logoOverlay) {


### PR DESCRIPTION
## Summary
- add site-wide "Latest Purchases" ticker with repeated messages and continuous scroll
- include gradient fade and label overlay so text fades before reaching label
- adjust font sizes so ticker works on desktop and mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a629a60d1483218e70d3f68d2758d5