### PR TITLE
Restore new products and fix category hover outline

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -241,7 +241,8 @@
         .product-item:focus .product-info,
         .product-item:active .product-info {
             opacity: 1;
-            border: 2px solid red;
+            outline: 2px solid red;
+            outline-offset: -2px;
         }
 
         /* Footer Links styling */
@@ -325,8 +326,8 @@
 
 </header>
 <section class="product-section">
-    
-<div class="product-grid">
+    <div class="product-grid">
+        
 <div class="product-item">
     <a href="socks.html">
         <img src="blacksocks.png" alt="Socks">

--- a/all.html
+++ b/all.html
@@ -241,7 +241,8 @@
         .product-item:focus .product-info,
         .product-item:active .product-info {
             opacity: 1;
-            border: 2px solid red;
+            outline: 2px solid red;
+            outline-offset: -2px;
         }
 
         /* Footer Links styling */
@@ -307,9 +308,6 @@
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
-        .pagination { display: flex; justify-content: center; gap: 10px; margin-top: 20px; }
-        .pagination button { font-family: 'Courier New', Courier, monospace; background: #fff; color: #000; border: 1px solid #000; cursor: pointer; }
-        .pagination button:hover { background: red; color: #fff; }
 </style>
 </head>
 <body>
@@ -332,10 +330,10 @@
         
 <div class="product-item">
     <a href="hat.html">
-        <img src="whitehat.png" alt="Baseball Cap">
+        <img src="whitehat.png" alt="Hat">
         <div class="product-info">
-            <p>Baseball Cap</p>
-            <p>$40</p>
+            <p>Hat</p>
+            <p>$50</p>
         </div>
     </a>
 </div>
@@ -355,7 +353,7 @@
         <img src="whiteshirt.png" alt="T-Shirt">
         <div class="product-info">
             <p>T-Shirt</p>
-            <p>$30</p>
+            <p>$40</p>
         </div>
     </a>
 </div>
@@ -388,8 +386,8 @@
             <p>$90</p>
         </div>
     </a>
-    </div>
-
+</div>
+    
 <div class="product-item">
     <a href="dufflebag.html">
         <img src="dufflebag1.png" alt="Duffle Bag">
@@ -399,6 +397,7 @@
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="backpack.html">
         <img src="backpackblack.png" alt="Backpack">
@@ -408,6 +407,7 @@
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="truckerhat.html">
         <img src="truckerwhitefront.png" alt="Trucker Hat">
@@ -417,6 +417,7 @@
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="socks.html">
         <img src="blacksocks.png" alt="Socks">
@@ -426,6 +427,7 @@
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="skateboard1.html">
         <img src="skateboard3v2.png" alt="Skateboard 1">
@@ -435,6 +437,7 @@
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="skateboard2.html">
         <img src="skateboard4.png" alt="Skateboard 2">
@@ -444,6 +447,7 @@
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="skateboard3.html">
         <img src="skateboard1.png" alt="Skateboard 3">
@@ -453,10 +457,6 @@
         </div>
     </a>
 </div>
-    </div>
-    <div class="pagination">
-        <button id="prev-page">previous page</button>
-        <button id="next-page">next page</button>
     </div>
 </section>
 
@@ -548,54 +548,6 @@
     }
 
     setInterval(updateChicagoTime, 1000);
-
-    const items = Array.from(document.querySelectorAll('.product-item'));
-    const itemsPerPage = 9;
-    let currentPage = 0;
-    const totalPages = Math.ceil(items.length / itemsPerPage);
-    const nextBtn = document.getElementById('next-page');
-    const prevBtn = document.getElementById('prev-page');
-
-    function showPage(page) {
-        items.forEach((item, index) => {
-            item.style.display = Math.floor(index / itemsPerPage) === page ? 'block' : 'none';
-        });
-        if (nextBtn) {
-            nextBtn.style.display = page < totalPages - 1 ? 'inline-block' : 'none';
-        }
-        if (prevBtn) {
-            prevBtn.style.display = page > 0 ? 'inline-block' : 'none';
-        }
-    }
-
-    function scrollToFirst(page) {
-        const first = items[page * itemsPerPage];
-        if (first) {
-            first.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
-    }
-
-    if (nextBtn) {
-        nextBtn.addEventListener('click', () => {
-            if (currentPage < totalPages - 1) {
-                currentPage++;
-                showPage(currentPage);
-                scrollToFirst(currentPage);
-            }
-        });
-    }
-
-    if (prevBtn) {
-        prevBtn.addEventListener('click', () => {
-            if (currentPage > 0) {
-                currentPage--;
-                showPage(currentPage);
-                scrollToFirst(currentPage);
-            }
-        });
-    }
-
-    showPage(currentPage);
 
     // Full-site link is always visible; scroll handler removed
 

--- a/bags.html
+++ b/bags.html
@@ -241,7 +241,8 @@
         .product-item:focus .product-info,
         .product-item:active .product-info {
             opacity: 1;
-            border: 2px solid red;
+            outline: 2px solid red;
+            outline-offset: -2px;
         }
 
         /* Footer Links styling */
@@ -325,8 +326,8 @@
 
 </header>
 <section class="product-section">
-    
-<div class="product-grid">
+    <div class="product-grid">
+        
 <div class="product-item">
     <a href="dufflebag.html">
         <img src="dufflebag1.png" alt="Duffle Bag">
@@ -336,6 +337,7 @@
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="backpack.html">
         <img src="backpackblack.png" alt="Backpack">

--- a/category_template.html
+++ b/category_template.html
@@ -241,7 +241,8 @@
         .product-item:focus .product-info,
         .product-item:active .product-info {
             opacity: 1;
-            border: 2px solid red;
+            outline: 2px solid red;
+            outline-offset: -2px;
         }
 
         /* Footer Links styling */

--- a/generate_category_pages.py
+++ b/generate_category_pages.py
@@ -65,6 +65,55 @@ products = [
         "link": "americandenim.html",
         "categories": ["pants", "new", "all"],
     },
+    {
+        "name": "Duffle Bag",
+        "price": 80,
+        "image": "dufflebag1.png",
+        "link": "dufflebag.html",
+        "categories": ["bags", "new", "all"],
+    },
+    {
+        "name": "Backpack",
+        "price": 60,
+        "image": "backpackblack.png",
+        "link": "backpack.html",
+        "categories": ["bags", "new", "all"],
+    },
+    {
+        "name": "Trucker Hat",
+        "price": 50,
+        "image": "truckerwhitefront.png",
+        "link": "truckerhat.html",
+        "categories": ["hats", "new", "all"],
+    },
+    {
+        "name": "Socks",
+        "price": 20,
+        "image": "blacksocks.png",
+        "link": "socks.html",
+        "categories": ["accessories", "new", "all"],
+    },
+    {
+        "name": "Skateboard 1",
+        "price": 100,
+        "image": "skateboard3v2.png",
+        "link": "skateboard1.html",
+        "categories": ["skate", "new", "all"],
+    },
+    {
+        "name": "Skateboard 2",
+        "price": 100,
+        "image": "skateboard4.png",
+        "link": "skateboard2.html",
+        "categories": ["skate", "new", "all"],
+    },
+    {
+        "name": "Skateboard 3",
+        "price": 100,
+        "image": "skateboard1.png",
+        "link": "skateboard3.html",
+        "categories": ["skate", "new", "all"],
+    },
 ]
 
 item_template = """

--- a/gym.html
+++ b/gym.html
@@ -241,7 +241,8 @@
         .product-item:focus .product-info,
         .product-item:active .product-info {
             opacity: 1;
-            border: 2px solid red;
+            outline: 2px solid red;
+            outline-offset: -2px;
         }
 
         /* Footer Links styling */

--- a/hats.html
+++ b/hats.html
@@ -241,7 +241,8 @@
         .product-item:focus .product-info,
         .product-item:active .product-info {
             opacity: 1;
-            border: 2px solid red;
+            outline: 2px solid red;
+            outline-offset: -2px;
         }
 
         /* Footer Links styling */
@@ -329,13 +330,14 @@
         
 <div class="product-item">
     <a href="hat.html">
-        <img src="whitehat.png" alt="Baseball Cap">
+        <img src="whitehat.png" alt="Hat">
         <div class="product-info">
-            <p>Baseball Cap</p>
-            <p>$40</p>
+            <p>Hat</p>
+            <p>$50</p>
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="truckerhat.html">
         <img src="truckerwhitefront.png" alt="Trucker Hat">

--- a/jackets.html
+++ b/jackets.html
@@ -241,7 +241,8 @@
         .product-item:focus .product-info,
         .product-item:active .product-info {
             opacity: 1;
-            border: 2px solid red;
+            outline: 2px solid red;
+            outline-offset: -2px;
         }
 
         /* Footer Links styling */

--- a/new.html
+++ b/new.html
@@ -241,7 +241,8 @@
         .product-item:focus .product-info,
         .product-item:active .product-info {
             opacity: 1;
-            border: 2px solid red;
+            outline: 2px solid red;
+            outline-offset: -2px;
         }
 
         /* Footer Links styling */
@@ -306,10 +307,7 @@
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
-        .cart-counter { margin-top: 5px; }
-        .pagination { display: flex; justify-content: center; gap: 10px; margin-top: 20px; }
-        .pagination button { font-family: 'Courier New', Courier, monospace; background: #fff; color: #000; border: 1px solid #000; cursor: pointer; }
-        .pagination button:hover { background: red; color: #fff; }
+    .cart-counter { margin-top: 5px; }
 </style>
 </head>
 <body>
@@ -329,17 +327,17 @@
 </header>
 <section class="product-section">
     <div class="product-grid">
-
+        
 <div class="product-item">
     <a href="hat.html">
-        <img src="whitehat.png" alt="Baseball Cap">
+        <img src="whitehat.png" alt="Hat">
         <div class="product-info">
-            <p>Baseball Cap</p>
-            <p>$40</p>
+            <p>Hat</p>
+            <p>$50</p>
         </div>
     </a>
 </div>
-
+    
 <div class="product-item">
     <a href="hoodie.html">
         <img src="blackhoodie.png" alt="Hoodie">
@@ -349,17 +347,17 @@
         </div>
     </a>
 </div>
-
+    
 <div class="product-item">
     <a href="shirt.html">
         <img src="whiteshirt.png" alt="T-Shirt">
         <div class="product-info">
             <p>T-Shirt</p>
-            <p>$30</p>
+            <p>$40</p>
         </div>
     </a>
 </div>
-
+    
 <div class="product-item">
     <a href="joggers.html">
         <img src="blackjoggers.png" alt="Joggers">
@@ -369,7 +367,7 @@
         </div>
     </a>
 </div>
-
+    
 <div class="product-item">
     <a href="shorts.html">
         <img src="whiteshorts.png" alt="Shorts">
@@ -379,7 +377,7 @@
         </div>
     </a>
 </div>
-
+    
 <div class="product-item">
     <a href="americandenim.html">
         <img src="bluejeans.png" alt="American Denim Jeans">
@@ -389,7 +387,7 @@
         </div>
     </a>
 </div>
-
+    
 <div class="product-item">
     <a href="dufflebag.html">
         <img src="dufflebag1.png" alt="Duffle Bag">
@@ -399,6 +397,7 @@
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="backpack.html">
         <img src="backpackblack.png" alt="Backpack">
@@ -408,6 +407,7 @@
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="truckerhat.html">
         <img src="truckerwhitefront.png" alt="Trucker Hat">
@@ -417,6 +417,7 @@
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="socks.html">
         <img src="blacksocks.png" alt="Socks">
@@ -426,6 +427,7 @@
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="skateboard1.html">
         <img src="skateboard3v2.png" alt="Skateboard 1">
@@ -435,6 +437,7 @@
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="skateboard2.html">
         <img src="skateboard4.png" alt="Skateboard 2">
@@ -444,6 +447,7 @@
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="skateboard3.html">
         <img src="skateboard1.png" alt="Skateboard 3">
@@ -453,10 +457,6 @@
         </div>
     </a>
 </div>
-    </div>
-    <div class="pagination">
-        <button id="prev-page">previous page</button>
-        <button id="next-page">next page</button>
     </div>
 </section>
 
@@ -548,54 +548,6 @@
     }
 
     setInterval(updateChicagoTime, 1000);
-
-    const items = Array.from(document.querySelectorAll('.product-item'));
-    const itemsPerPage = 9;
-    let currentPage = 0;
-    const totalPages = Math.ceil(items.length / itemsPerPage);
-    const nextBtn = document.getElementById('next-page');
-    const prevBtn = document.getElementById('prev-page');
-
-    function showPage(page) {
-        items.forEach((item, index) => {
-            item.style.display = Math.floor(index / itemsPerPage) === page ? 'block' : 'none';
-        });
-        if (nextBtn) {
-            nextBtn.style.display = page < totalPages - 1 ? 'inline-block' : 'none';
-        }
-        if (prevBtn) {
-            prevBtn.style.display = page > 0 ? 'inline-block' : 'none';
-        }
-    }
-
-    function scrollToFirst(page) {
-        const first = items[page * itemsPerPage];
-        if (first) {
-            first.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
-    }
-
-    if (nextBtn) {
-        nextBtn.addEventListener('click', () => {
-            if (currentPage < totalPages - 1) {
-                currentPage++;
-                showPage(currentPage);
-                scrollToFirst(currentPage);
-            }
-        });
-    }
-
-    if (prevBtn) {
-        prevBtn.addEventListener('click', () => {
-            if (currentPage > 0) {
-                currentPage--;
-                showPage(currentPage);
-                scrollToFirst(currentPage);
-            }
-        });
-    }
-
-    showPage(currentPage);
 
     // Full-site link is always visible; scroll handler removed
 

--- a/pants.html
+++ b/pants.html
@@ -241,7 +241,8 @@
         .product-item:focus .product-info,
         .product-item:active .product-info {
             opacity: 1;
-            border: 2px solid red;
+            outline: 2px solid red;
+            outline-offset: -2px;
         }
 
         /* Footer Links styling */

--- a/shirts.html
+++ b/shirts.html
@@ -241,7 +241,8 @@
         .product-item:focus .product-info,
         .product-item:active .product-info {
             opacity: 1;
-            border: 2px solid red;
+            outline: 2px solid red;
+            outline-offset: -2px;
         }
 
         /* Footer Links styling */
@@ -332,7 +333,7 @@
         <img src="whiteshirt.png" alt="T-Shirt">
         <div class="product-info">
             <p>T-Shirt</p>
-            <p>$30</p>
+            <p>$40</p>
         </div>
     </a>
 </div>

--- a/shoes.html
+++ b/shoes.html
@@ -241,7 +241,8 @@
         .product-item:focus .product-info,
         .product-item:active .product-info {
             opacity: 1;
-            border: 2px solid red;
+            outline: 2px solid red;
+            outline-offset: -2px;
         }
 
         /* Footer Links styling */

--- a/skate.html
+++ b/skate.html
@@ -241,7 +241,8 @@
         .product-item:focus .product-info,
         .product-item:active .product-info {
             opacity: 1;
-            border: 2px solid red;
+            outline: 2px solid red;
+            outline-offset: -2px;
         }
 
         /* Footer Links styling */
@@ -325,8 +326,8 @@
 
 </header>
 <section class="product-section">
-    
-<div class="product-grid">
+    <div class="product-grid">
+        
 <div class="product-item">
     <a href="skateboard1.html">
         <img src="skateboard3v2.png" alt="Skateboard 1">
@@ -336,6 +337,7 @@
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="skateboard2.html">
         <img src="skateboard4.png" alt="Skateboard 2">
@@ -345,6 +347,7 @@
         </div>
     </a>
 </div>
+    
 <div class="product-item">
     <a href="skateboard3.html">
         <img src="skateboard1.png" alt="Skateboard 3">

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -241,7 +241,8 @@
         .product-item:focus .product-info,
         .product-item:active .product-info {
             opacity: 1;
-            border: 2px solid red;
+            outline: 2px solid red;
+            outline-offset: -2px;
         }
 
         /* Footer Links styling */

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -241,7 +241,8 @@
         .product-item:focus .product-info,
         .product-item:active .product-info {
             opacity: 1;
-            border: 2px solid red;
+            outline: 2px solid red;
+            outline-offset: -2px;
         }
 
         /* Footer Links styling */
@@ -332,7 +333,7 @@
         <img src="whiteshirt.png" alt="T-Shirt">
         <div class="product-info">
             <p>T-Shirt</p>
-            <p>$30</p>
+            <p>$40</p>
         </div>
     </a>
 </div>

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -241,7 +241,8 @@
         .product-item:focus .product-info,
         .product-item:active .product-info {
             opacity: 1;
-            border: 2px solid red;
+            outline: 2px solid red;
+            outline-offset: -2px;
         }
 
         /* Footer Links styling */


### PR DESCRIPTION
## Summary
- Adjust category hover styling so the red outline matches the gray overlay
- Restore missing products (trucker hat, backpack, duffle bag, skateboards, etc.) in all categories
- Remove stray pagination buttons and regenerate category pages

## Testing
- `python generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a755892c3c8321937340592658a0e6