### PR TITLE
Add pagination for category pages

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -304,6 +304,24 @@
             background: red;
             color: #fff;
         }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .pagination a {
+            text-decoration: none;
+            color: #000;
+            border: 1px solid #000;
+            padding: 10px 20px;
+        }
+        .pagination a:hover,
+        .pagination a:focus,
+        .pagination a:active {
+            background-color: red;
+            color: #fff;
+        }
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
@@ -338,6 +356,7 @@
     </a>
 </div>
     </div>
+    
 </section>
 
 <!-- Desktop Nav -->

--- a/all-page2.html
+++ b/all-page2.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop Shirts">
-    <title>MaybeNot Shop - Shirts</title>
+    <meta name="description" content="MaybeNot Shop All">
+    <title>MaybeNot Shop - All</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -347,16 +347,46 @@
     <div class="product-grid">
         
 <div class="product-item">
-    <a href="shirt.html">
-        <img src="whiteshirt.png" alt="T-Shirt">
+    <a href="socks.html">
+        <img src="blacksocks.png" alt="Socks">
         <div class="product-info">
-            <p>T-Shirt</p>
-            <p>$40</p>
+            <p>Socks</p>
+            <p>$20</p>
+        </div>
+    </a>
+</div>
+    
+<div class="product-item">
+    <a href="skateboard1.html">
+        <img src="skateboard3v2.png" alt="Skateboard 1">
+        <div class="product-info">
+            <p>Skateboard 1</p>
+            <p>$100</p>
+        </div>
+    </a>
+</div>
+    
+<div class="product-item">
+    <a href="skateboard2.html">
+        <img src="skateboard4.png" alt="Skateboard 2">
+        <div class="product-info">
+            <p>Skateboard 2</p>
+            <p>$100</p>
+        </div>
+    </a>
+</div>
+    
+<div class="product-item">
+    <a href="skateboard3.html">
+        <img src="skateboard1.png" alt="Skateboard 3">
+        <div class="product-info">
+            <p>Skateboard 3</p>
+            <p>$100</p>
         </div>
     </a>
 </div>
     </div>
-    
+    <div class="pagination"><a href="all.html" class="pagination-button">Previous Page</a></div>
 </section>
 
 <!-- Desktop Nav -->

--- a/all.html
+++ b/all.html
@@ -304,6 +304,24 @@
             background: red;
             color: #fff;
         }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .pagination a {
+            text-decoration: none;
+            color: #000;
+            border: 1px solid #000;
+            padding: 10px 20px;
+        }
+        .pagination a:hover,
+        .pagination a:focus,
+        .pagination a:active {
+            background-color: red;
+            color: #fff;
+        }
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
@@ -417,47 +435,8 @@
         </div>
     </a>
 </div>
-    
-<div class="product-item">
-    <a href="socks.html">
-        <img src="blacksocks.png" alt="Socks">
-        <div class="product-info">
-            <p>Socks</p>
-            <p>$20</p>
-        </div>
-    </a>
-</div>
-    
-<div class="product-item">
-    <a href="skateboard1.html">
-        <img src="skateboard3v2.png" alt="Skateboard 1">
-        <div class="product-info">
-            <p>Skateboard 1</p>
-            <p>$100</p>
-        </div>
-    </a>
-</div>
-    
-<div class="product-item">
-    <a href="skateboard2.html">
-        <img src="skateboard4.png" alt="Skateboard 2">
-        <div class="product-info">
-            <p>Skateboard 2</p>
-            <p>$100</p>
-        </div>
-    </a>
-</div>
-    
-<div class="product-item">
-    <a href="skateboard3.html">
-        <img src="skateboard1.png" alt="Skateboard 3">
-        <div class="product-info">
-            <p>Skateboard 3</p>
-            <p>$100</p>
-        </div>
-    </a>
-</div>
     </div>
+    <div class="pagination"><a href="all-page2.html" class="pagination-button">Next Page</a></div>
 </section>
 
 <!-- Desktop Nav -->

--- a/bags.html
+++ b/bags.html
@@ -304,6 +304,24 @@
             background: red;
             color: #fff;
         }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .pagination a {
+            text-decoration: none;
+            color: #000;
+            border: 1px solid #000;
+            padding: 10px 20px;
+        }
+        .pagination a:hover,
+        .pagination a:focus,
+        .pagination a:active {
+            background-color: red;
+            color: #fff;
+        }
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
@@ -348,6 +366,7 @@
     </a>
 </div>
     </div>
+    
 </section>
 
 <!-- Desktop Nav -->

--- a/category_template.html
+++ b/category_template.html
@@ -304,6 +304,24 @@
             background: red;
             color: #fff;
         }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .pagination a {
+            text-decoration: none;
+            color: #000;
+            border: 1px solid #000;
+            padding: 10px 20px;
+        }
+        .pagination a:hover,
+        .pagination a:focus,
+        .pagination a:active {
+            background-color: red;
+            color: #fff;
+        }
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
@@ -329,6 +347,7 @@
     <div class="product-grid">
         {{ITEMS}}
     </div>
+    {{PAGINATION}}
 </section>
 
 <!-- Desktop Nav -->

--- a/generate_category_pages.py
+++ b/generate_category_pages.py
@@ -4,6 +4,8 @@ import os
 with open('category_template.html') as f:
     template = f.read()
 
+ITEMS_PER_PAGE = 9
+
 categories = [
     ("new", "New"),
     ("jackets", "Jackets"),
@@ -128,16 +130,35 @@ item_template = """
 </div>"""
 
 for slug, title in categories:
-    items = []
-    for product in products:
-        if slug in product["categories"]:
-            items.append(item_template.format(**product))
-    if not items:
-        items_content = '<div class="coming-soon">Coming Soon..</div>'
-    else:
-        items_content = "\n    ".join(items)
-    page = template.replace("{{TITLE}}", title).replace("{{ITEMS}}", items_content)
-    filename = f"{slug}.html"
-    with open(filename, "w") as f:
-        f.write(page)
-    print(f"Wrote {filename}")
+    category_products = [p for p in products if slug in p["categories"]]
+    total_pages = max(1, (len(category_products) + ITEMS_PER_PAGE - 1) // ITEMS_PER_PAGE)
+    for page_num in range(1, total_pages + 1):
+        start = (page_num - 1) * ITEMS_PER_PAGE
+        end = start + ITEMS_PER_PAGE
+        page_products = category_products[start:end]
+        if not page_products:
+            items_content = '<div class="coming-soon">Coming Soon..</div>'
+        else:
+            items = [item_template.format(**prod) for prod in page_products]
+            items_content = "\n    ".join(items)
+
+        pagination_links = []
+        if page_num > 1:
+            prev_file = f"{slug}.html" if page_num == 2 else f"{slug}-page{page_num - 1}.html"
+            pagination_links.append(f'<a href="{prev_file}" class="pagination-button">Previous Page</a>')
+        if page_num < total_pages:
+            next_file = f"{slug}-page{page_num + 1}.html"
+            pagination_links.append(f'<a href="{next_file}" class="pagination-button">Next Page</a>')
+        if pagination_links:
+            pagination_html = '<div class="pagination">' + "\n        ".join(pagination_links) + '</div>'
+        else:
+            pagination_html = ''
+
+        page = (template.replace("{{TITLE}}", title)
+                         .replace("{{ITEMS}}", items_content)
+                         .replace("{{PAGINATION}}", pagination_html))
+
+        filename = f"{slug}.html" if page_num == 1 else f"{slug}-page{page_num}.html"
+        with open(filename, "w") as f:
+            f.write(page)
+        print(f"Wrote {filename}")

--- a/gym.html
+++ b/gym.html
@@ -304,6 +304,24 @@
             background: red;
             color: #fff;
         }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .pagination a {
+            text-decoration: none;
+            color: #000;
+            border: 1px solid #000;
+            padding: 10px 20px;
+        }
+        .pagination a:hover,
+        .pagination a:focus,
+        .pagination a:active {
+            background-color: red;
+            color: #fff;
+        }
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
@@ -329,6 +347,7 @@
     <div class="product-grid">
         <div class="coming-soon">Coming Soon..</div>
     </div>
+    
 </section>
 
 <!-- Desktop Nav -->

--- a/hats.html
+++ b/hats.html
@@ -304,6 +304,24 @@
             background: red;
             color: #fff;
         }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .pagination a {
+            text-decoration: none;
+            color: #000;
+            border: 1px solid #000;
+            padding: 10px 20px;
+        }
+        .pagination a:hover,
+        .pagination a:focus,
+        .pagination a:active {
+            background-color: red;
+            color: #fff;
+        }
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
@@ -348,6 +366,7 @@
     </a>
 </div>
     </div>
+    
 </section>
 
 <!-- Desktop Nav -->

--- a/jackets.html
+++ b/jackets.html
@@ -304,6 +304,24 @@
             background: red;
             color: #fff;
         }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .pagination a {
+            text-decoration: none;
+            color: #000;
+            border: 1px solid #000;
+            padding: 10px 20px;
+        }
+        .pagination a:hover,
+        .pagination a:focus,
+        .pagination a:active {
+            background-color: red;
+            color: #fff;
+        }
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
@@ -329,6 +347,7 @@
     <div class="product-grid">
         <div class="coming-soon">Coming Soon..</div>
     </div>
+    
 </section>
 
 <!-- Desktop Nav -->

--- a/new-page2.html
+++ b/new-page2.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop Shirts">
-    <title>MaybeNot Shop - Shirts</title>
+    <meta name="description" content="MaybeNot Shop New">
+    <title>MaybeNot Shop - New</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -347,16 +347,46 @@
     <div class="product-grid">
         
 <div class="product-item">
-    <a href="shirt.html">
-        <img src="whiteshirt.png" alt="T-Shirt">
+    <a href="socks.html">
+        <img src="blacksocks.png" alt="Socks">
         <div class="product-info">
-            <p>T-Shirt</p>
-            <p>$40</p>
+            <p>Socks</p>
+            <p>$20</p>
+        </div>
+    </a>
+</div>
+    
+<div class="product-item">
+    <a href="skateboard1.html">
+        <img src="skateboard3v2.png" alt="Skateboard 1">
+        <div class="product-info">
+            <p>Skateboard 1</p>
+            <p>$100</p>
+        </div>
+    </a>
+</div>
+    
+<div class="product-item">
+    <a href="skateboard2.html">
+        <img src="skateboard4.png" alt="Skateboard 2">
+        <div class="product-info">
+            <p>Skateboard 2</p>
+            <p>$100</p>
+        </div>
+    </a>
+</div>
+    
+<div class="product-item">
+    <a href="skateboard3.html">
+        <img src="skateboard1.png" alt="Skateboard 3">
+        <div class="product-info">
+            <p>Skateboard 3</p>
+            <p>$100</p>
         </div>
     </a>
 </div>
     </div>
-    
+    <div class="pagination"><a href="new.html" class="pagination-button">Previous Page</a></div>
 </section>
 
 <!-- Desktop Nav -->

--- a/new.html
+++ b/new.html
@@ -304,6 +304,24 @@
             background: red;
             color: #fff;
         }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .pagination a {
+            text-decoration: none;
+            color: #000;
+            border: 1px solid #000;
+            padding: 10px 20px;
+        }
+        .pagination a:hover,
+        .pagination a:focus,
+        .pagination a:active {
+            background-color: red;
+            color: #fff;
+        }
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
@@ -417,47 +435,8 @@
         </div>
     </a>
 </div>
-    
-<div class="product-item">
-    <a href="socks.html">
-        <img src="blacksocks.png" alt="Socks">
-        <div class="product-info">
-            <p>Socks</p>
-            <p>$20</p>
-        </div>
-    </a>
-</div>
-    
-<div class="product-item">
-    <a href="skateboard1.html">
-        <img src="skateboard3v2.png" alt="Skateboard 1">
-        <div class="product-info">
-            <p>Skateboard 1</p>
-            <p>$100</p>
-        </div>
-    </a>
-</div>
-    
-<div class="product-item">
-    <a href="skateboard2.html">
-        <img src="skateboard4.png" alt="Skateboard 2">
-        <div class="product-info">
-            <p>Skateboard 2</p>
-            <p>$100</p>
-        </div>
-    </a>
-</div>
-    
-<div class="product-item">
-    <a href="skateboard3.html">
-        <img src="skateboard1.png" alt="Skateboard 3">
-        <div class="product-info">
-            <p>Skateboard 3</p>
-            <p>$100</p>
-        </div>
-    </a>
-</div>
     </div>
+    <div class="pagination"><a href="new-page2.html" class="pagination-button">Next Page</a></div>
 </section>
 
 <!-- Desktop Nav -->

--- a/pants.html
+++ b/pants.html
@@ -304,6 +304,24 @@
             background: red;
             color: #fff;
         }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .pagination a {
+            text-decoration: none;
+            color: #000;
+            border: 1px solid #000;
+            padding: 10px 20px;
+        }
+        .pagination a:hover,
+        .pagination a:focus,
+        .pagination a:active {
+            background-color: red;
+            color: #fff;
+        }
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
@@ -358,6 +376,7 @@
     </a>
 </div>
     </div>
+    
 </section>
 
 <!-- Desktop Nav -->

--- a/shoes.html
+++ b/shoes.html
@@ -304,6 +304,24 @@
             background: red;
             color: #fff;
         }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .pagination a {
+            text-decoration: none;
+            color: #000;
+            border: 1px solid #000;
+            padding: 10px 20px;
+        }
+        .pagination a:hover,
+        .pagination a:focus,
+        .pagination a:active {
+            background-color: red;
+            color: #fff;
+        }
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
@@ -329,6 +347,7 @@
     <div class="product-grid">
         <div class="coming-soon">Coming Soon..</div>
     </div>
+    
 </section>
 
 <!-- Desktop Nav -->

--- a/skate.html
+++ b/skate.html
@@ -304,6 +304,24 @@
             background: red;
             color: #fff;
         }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .pagination a {
+            text-decoration: none;
+            color: #000;
+            border: 1px solid #000;
+            padding: 10px 20px;
+        }
+        .pagination a:hover,
+        .pagination a:focus,
+        .pagination a:active {
+            background-color: red;
+            color: #fff;
+        }
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
@@ -358,6 +376,7 @@
     </a>
 </div>
     </div>
+    
 </section>
 
 <!-- Desktop Nav -->

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -304,6 +304,24 @@
             background: red;
             color: #fff;
         }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .pagination a {
+            text-decoration: none;
+            color: #000;
+            border: 1px solid #000;
+            padding: 10px 20px;
+        }
+        .pagination a:hover,
+        .pagination a:focus,
+        .pagination a:active {
+            background-color: red;
+            color: #fff;
+        }
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
@@ -338,6 +356,7 @@
     </a>
 </div>
     </div>
+    
 </section>
 
 <!-- Desktop Nav -->

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -304,6 +304,24 @@
             background: red;
             color: #fff;
         }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .pagination a {
+            text-decoration: none;
+            color: #000;
+            border: 1px solid #000;
+            padding: 10px 20px;
+        }
+        .pagination a:hover,
+        .pagination a:focus,
+        .pagination a:active {
+            background-color: red;
+            color: #fff;
+        }
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
@@ -338,6 +356,7 @@
     </a>
 </div>
     </div>
+    
 </section>
 
 <!-- Desktop Nav -->

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -304,6 +304,24 @@
             background: red;
             color: #fff;
         }
+        .pagination {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .pagination a {
+            text-decoration: none;
+            color: #000;
+            border: 1px solid #000;
+            padding: 10px 20px;
+        }
+        .pagination a:hover,
+        .pagination a:focus,
+        .pagination a:active {
+            background-color: red;
+            color: #fff;
+        }
         .header-container { position: sticky; top: 0; z-index: 1000; }
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
@@ -329,6 +347,7 @@
     <div class="product-grid">
         <div class="coming-soon">Coming Soon..</div>
     </div>
+    
 </section>
 
 <!-- Desktop Nav -->


### PR DESCRIPTION
## Summary
- limit category pages to 9 products per page
- add centered previous/next navigation buttons
- regenerate category pages with pagination

## Testing
- `python generate_category_pages.py`
- `python -m py_compile generate_category_pages.py`


------
https://chatgpt.com/codex/tasks/task_e_68a75b501a748321a372ba20cc37c043