### PR TITLE
Ensure navigation highlights persist across paginated pages

### DIFF
--- a/footer-highlight.js
+++ b/footer-highlight.js
@@ -30,7 +30,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Bold the current category in navigation lists
   document.querySelectorAll('.desktop-nav a, .mobile-nav a').forEach(link => {
-    if (link.getAttribute('href') === current) {
+    const href = link.getAttribute('href');
+    const base = href.replace('.html', '');
+    if (
+      href === current ||
+      current.startsWith(`${base}-`) ||
+      (isShopPage && href === 'shop.html')
+    ) {
       link.style.fontWeight = 'bold';
     }
   });


### PR DESCRIPTION
## Summary
- Keep category navigation bold when visiting paginated pages like `*-page2.html`
- Maintain bold "shop" link within nav when browsing product or category pages

## Testing
- `node --check footer-highlight.js`
- `python -m py_compile generate_category_pages.py`

------
https://chatgpt.com/codex/tasks/task_e_68a762e78e2083218275ee9f6502c73b