### PR TITLE
Integrate cart payment buttons with Stripe Checkout

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -96,14 +96,20 @@ async function loadStripeConfig() {
     return stripeConfigPromise;
 }
 
+const unsupportedMethodNotices = {
+    'Shop Pay': 'Shop Pay is not directly supported in this checkout. Opening Stripe Checkout with available payment methods.',
+    PayPal: 'PayPal is not directly supported in this checkout. Opening Stripe Checkout with available payment methods.',
+    Venmo: 'Venmo is not directly supported in this checkout. Opening Stripe Checkout with available payment methods.'
+};
+
 const paymentHandlers = {
-    'Shop Pay': () => alert('Shop Pay integration pending.'),
-    'Apple Pay': () => alert('Apple Pay integration pending.'),
-    'PayPal': () => alert('PayPal integration pending.'),
-    'Google Pay': () => alert('Google Pay integration pending.'),
-    'Klarna': () => alert('Klarna integration pending.'),
-    'Venmo': () => alert('Venmo integration pending.'),
-    Stripe: () => startStripeCheckout()
+    'Shop Pay': () => startStripeCheckout('Shop Pay'),
+    'Apple Pay': () => startStripeCheckout('Apple Pay'),
+    'PayPal': () => startStripeCheckout('PayPal'),
+    'Google Pay': () => startStripeCheckout('Google Pay'),
+    'Klarna': () => startStripeCheckout('Klarna'),
+    'Venmo': () => startStripeCheckout('Venmo'),
+    Stripe: () => startStripeCheckout('Stripe')
 };
 
 async function handlePayment(method) {
@@ -169,10 +175,15 @@ function buildStripeLineItems() {
     return { lineItems, missing };
 }
 
-async function startStripeCheckout() {
+async function startStripeCheckout(method = 'Stripe') {
     if (!cart.length) {
         alert('Your cart is empty.');
         return;
+    }
+
+    const unsupportedMessage = unsupportedMethodNotices[method];
+    if (unsupportedMessage) {
+        alert(unsupportedMessage);
     }
 
     await loadStripeConfig();

--- a/stripe-config.json
+++ b/stripe-config.json
@@ -1,5 +1,5 @@
 {
-  "publishableKey": "pk_live_REPLACE_WITH_PUBLISHABLE_KEY",
+  "publishableKey": "pk_live_51TMeEa6vAbsTB4QVTasJRtaEMgTI683GLL2rPYlW8rlJpq6f2YtReDI339OBuwgbSiEDNieWPzYiIkunzjeD4sJb006WwAL9eH",
   "successUrl": "/success.html",
   "cancelUrl": "/cart.html",
   "priceLookup": {


### PR DESCRIPTION
### Motivation
- Replace placeholder alerts on cart and shop popup payment buttons with a working checkout flow so customers can complete purchases. 
- Ensure a single, consistent client-side path (Stripe Checkout) is used from the cart page, popup modal, and checkout form.

### Description
- Wired all express payment buttons (cart page, popup, and checkout final form) to call `startStripeCheckout(...)` via the `paymentHandlers` map so button clicks initiate the Stripe Checkout flow. 
- Added `unsupportedMethodNotices` and updated `startStripeCheckout(method)` to show a brief notice for methods not directly supported (e.g., Shop Pay, PayPal, Venmo) before redirecting to Stripe Checkout. 
- Updated `stripe-config.json` to set the provided publishable key so the front-end can load Stripe with the configured key while leaving secret keys out of client code. 

### Testing
- Ran `node --check cart.js` to validate the modified JavaScript for syntax errors and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0374d7a208321be3de6af00028897)