### PR TITLE
Add Stripe catalog sync script and clarify missing-price checkout message

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -190,7 +190,7 @@ async function startStripeCheckout(method = 'Stripe') {
 
     const { lineItems, missing } = buildStripeLineItems();
     if (missing.length) {
-        alert(`Stripe price IDs missing for: ${missing.join(', ')}. Please configure STRIPE_PRICE_LOOKUP.`);
+        alert(`Stripe price IDs missing for: ${missing.join(', ')}. Checkout requires real price_... IDs in stripe-config.json (or data-price-id on cart items).`);
         return;
     }
     if (!lineItems.length) {

--- a/sync-stripe-prices.mjs
+++ b/sync-stripe-prices.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+if (!stripeSecretKey) {
+  console.error('Missing STRIPE_SECRET_KEY environment variable.');
+  process.exit(1);
+}
+
+const configPath = process.env.STRIPE_CONFIG_PATH || 'stripe-config.json';
+
+const catalog = [
+  { key: 't-shirt', name: 'T-Shirt', unitAmount: 3000 },
+  { key: 'hoodie', name: 'Hoodie', unitAmount: 7000 },
+  { key: 'shorts', name: 'Shorts', unitAmount: 5000 },
+  { key: 'joggers', name: 'Joggers', unitAmount: 6000 },
+  { key: 'hat', name: 'Hat', unitAmount: 4000 },
+  { key: 'truckerhat', name: 'Trucker Hat', unitAmount: 5000 },
+  { key: 'socks', name: 'Socks', unitAmount: 2000 },
+  { key: 'backpack', name: 'Backpack', unitAmount: 6000 },
+  { key: 'dufflebag', name: 'Duffle Bag', unitAmount: 8000 },
+  { key: 'american-denim', name: 'American Denim', unitAmount: 9000 },
+  { key: 'skateboard1', name: 'Skateboard 1', unitAmount: 10000 },
+  { key: 'skateboard2', name: 'Skateboard 2', unitAmount: 10000 },
+  { key: 'skateboard3', name: 'Skateboard 3', unitAmount: 10000 }
+];
+
+function formBody(data) {
+  return new URLSearchParams(data).toString();
+}
+
+async function stripeRequest(path, { method = 'GET', body } = {}) {
+  const response = await fetch(`https://api.stripe.com/v1${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${stripeSecretKey}`,
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: body ? formBody(body) : undefined
+  });
+
+  const json = await response.json();
+  if (!response.ok) {
+    const message = json?.error?.message || `Stripe API request failed (${response.status})`;
+    throw new Error(message);
+  }
+
+  return json;
+}
+
+async function listAll(path) {
+  let hasMore = true;
+  let startingAfter = null;
+  const data = [];
+
+  while (hasMore) {
+    const query = new URLSearchParams({ limit: '100' });
+    if (startingAfter) query.set('starting_after', startingAfter);
+
+    const page = await stripeRequest(`${path}?${query.toString()}`);
+    data.push(...(page.data || []));
+    hasMore = !!page.has_more;
+    startingAfter = hasMore && page.data.length ? page.data[page.data.length - 1].id : null;
+  }
+
+  return data;
+}
+
+function normalizeName(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+async function ensureProduct(item, productsByKey, productsByName) {
+  const byKey = productsByKey.get(item.key);
+  if (byKey) return byKey;
+
+  const byName = productsByName.get(normalizeName(item.name));
+  if (byName) return byName;
+
+  const created = await stripeRequest('/products', {
+    method: 'POST',
+    body: {
+      name: item.name,
+      'metadata[store_key]': item.key
+    }
+  });
+
+  productsByKey.set(item.key, created);
+  productsByName.set(normalizeName(item.name), created);
+  return created;
+}
+
+async function ensurePrice(productId, unitAmount, pricesByProduct) {
+  const existing = (pricesByProduct.get(productId) || []).find(
+    (price) =>
+      price.active &&
+      price.currency === 'usd' &&
+      price.type === 'one_time' &&
+      price.unit_amount === unitAmount
+  );
+
+  if (existing) return existing;
+
+  const created = await stripeRequest('/prices', {
+    method: 'POST',
+    body: {
+      product: productId,
+      currency: 'usd',
+      unit_amount: String(unitAmount)
+    }
+  });
+
+  const list = pricesByProduct.get(productId) || [];
+  list.push(created);
+  pricesByProduct.set(productId, list);
+  return created;
+}
+
+async function loadConfig() {
+  try {
+    const raw = await fs.readFile(configPath, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+async function main() {
+  const [products, prices, existingConfig] = await Promise.all([
+    listAll('/products'),
+    listAll('/prices'),
+    loadConfig()
+  ]);
+
+  const productsByKey = new Map();
+  const productsByName = new Map();
+
+  for (const product of products) {
+    const storeKey = product?.metadata?.store_key;
+    if (storeKey) productsByKey.set(storeKey, product);
+    productsByName.set(normalizeName(product.name), product);
+  }
+
+  const pricesByProduct = new Map();
+  for (const price of prices) {
+    const list = pricesByProduct.get(price.product) || [];
+    list.push(price);
+    pricesByProduct.set(price.product, list);
+  }
+
+  const priceLookup = {};
+  for (const item of catalog) {
+    const product = await ensureProduct(item, productsByKey, productsByName);
+    const price = await ensurePrice(product.id, item.unitAmount, pricesByProduct);
+    priceLookup[item.key] = price.id;
+  }
+
+  const nextConfig = {
+    publishableKey:
+      process.env.STRIPE_PUBLISHABLE_KEY ||
+      existingConfig.publishableKey ||
+      'pk_test_REPLACE_WITH_YOUR_PUBLISHABLE_KEY',
+    successUrl: existingConfig.successUrl || '/success.html',
+    cancelUrl: existingConfig.cancelUrl || '/cart.html',
+    priceLookup
+  };
+
+  await fs.writeFile(configPath, `${JSON.stringify(nextConfig, null, 2)}\n`, 'utf8');
+  console.log(`Updated ${configPath} with ${Object.keys(priceLookup).length} Stripe price IDs.`);
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Provide a safe, repeatable way to create Stripe products/prices for the current storefront catalog and populate `stripe-config.json` with real `price_...` IDs so Checkout can complete.
- Make the cart checkout feedback clearer so integrators know they must supply real Stripe `price_...` IDs (either in `stripe-config.json` or via item `data-price-id`).

### Description
- Added `sync-stripe-prices.mjs`, a Node script that uses the Stripe REST API to list existing products/prices, create missing products (setting `metadata.store_key`) and one-time USD prices, and write a full `priceLookup` back to `stripe-config.json` using the catalog defined in the script.
- The sync script requires `STRIPE_SECRET_KEY` (and optionally reads `STRIPE_PUBLISHABLE_KEY` and `STRIPE_CONFIG_PATH`) and implements helper functions `listAll`, `ensureProduct`, and `ensurePrice` to safely reconcile the storefront catalog with Stripe.
- Updated `cart.js` to improve the missing-price alert to: `Stripe price IDs missing for: ... Checkout requires real price_... IDs in stripe-config.json (or data-price-id on cart items).` so integrators understand what is required to complete Checkout.

### Testing
- Ran `node --check cart.js`, which succeeded and verified the modified `cart.js` parses correctly.
- Ran `node --check sync-stripe-prices.mjs`, which succeeded and verified the new script parses correctly.
- Executed `node sync-stripe-prices.mjs`, which failed as expected with a clear error because the environment did not provide `STRIPE_SECRET_KEY` (this is intentional to avoid running live Stripe changes in the test environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0388b9a288321b41c2f03bf1e9166)