### PR TITLE
Canonicalize Stripe price lookup keys and support alias keys (fix t-shirt lookup)

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -52,6 +52,30 @@ const stripeProductAliases = {
     dufflebag: ['duffle-bag', 'duffelbag', 'duffel-bag']
 };
 
+function buildStripeLookupAliasMap() {
+    const aliasMap = {};
+    const register = (alias, canonical) => {
+        const normalized = toSlug(alias).replace(/-/g, '');
+        if (normalized) aliasMap[normalized] = canonical;
+    };
+
+    Object.keys(defaultPriceLookup).forEach(canonical => {
+        register(canonical, canonical);
+        const aliases = stripeProductAliases[canonical] || [];
+        aliases.forEach(alias => register(alias, canonical));
+    });
+
+    return aliasMap;
+}
+
+const stripeLookupAliasMap = buildStripeLookupAliasMap();
+
+function canonicalizeStripeProductKey(key) {
+    const normalized = toSlug(key).replace(/-/g, '');
+    if (!normalized) return '';
+    return stripeLookupAliasMap[normalized] || '';
+}
+
 function applyStripeSettings(overrides = {}) {
     if (overrides.publishableKey) {
         stripeSettings.publishableKey = overrides.publishableKey;
@@ -66,12 +90,11 @@ function applyStripeSettings(overrides = {}) {
 }
 
 function readInlinePriceLookup(config = {}) {
-    const knownKeys = Object.keys(defaultPriceLookup);
-    return knownKeys.reduce((lookup, key) => {
-        const value = config[key];
-        if (typeof value === 'string' && value) {
-            lookup[key] = value;
-        }
+    return Object.entries(config).reduce((lookup, [rawKey, value]) => {
+        if (typeof value !== 'string' || !value) return lookup;
+        const canonicalKey = canonicalizeStripeProductKey(rawKey);
+        if (!canonicalKey) return lookup;
+        lookup[canonicalKey] = value;
         return lookup;
     }, {});
 }


### PR DESCRIPTION
### Motivation
- Checkout was reporting missing Stripe price IDs for `t-shirt` when a valid price ID was provided under an aliased key such as `tshirt`, `tee`, or `shirt` in `stripe-config.json`. 
- The intent is to normalize top-level price keys so inline/alias keys map to the canonical product keys used by the checkout logic.

### Description
- Added an alias map builder and canonicalization function (`buildStripeLookupAliasMap`, `canonicalizeStripeProductKey`) to normalize product keys and map aliases to canonical keys in `cart.js`.
- Updated `readInlinePriceLookup` to accept and normalize top-level keys from `stripe-config.json` so aliased entries (e.g. `tshirt`, `tee`, `shirt`) are merged under the canonical `t-shirt` key. 
- Kept `stripeSettings.priceLookup` canonical so `buildStripeLineItems` can reliably resolve `price_...` IDs and avoid false missing-ID alerts.

### Testing
- Ran `node --check cart.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0625632f88321b84313f6b1d322f2)