### PR TITLE
Normalize Stripe price lookup keys during checkout

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -76,6 +76,25 @@ function canonicalizeStripeProductKey(key) {
     return stripeLookupAliasMap[normalized] || '';
 }
 
+function normalizePriceLookupMap(config = {}) {
+    return Object.entries(config).reduce((lookup, [rawKey, value]) => {
+        if (typeof value !== 'string' || !value) return lookup;
+
+        const canonicalKey = canonicalizeStripeProductKey(rawKey);
+        if (canonicalKey) {
+            lookup[canonicalKey] = value;
+        }
+
+        const slugKey = toSlug(rawKey);
+        if (slugKey) {
+            lookup[slugKey] = value;
+            lookup[slugKey.replace(/-/g, '')] = value;
+        }
+
+        return lookup;
+    }, {});
+}
+
 function applyStripeSettings(overrides = {}) {
     if (overrides.publishableKey) {
         stripeSettings.publishableKey = overrides.publishableKey;
@@ -84,8 +103,8 @@ function applyStripeSettings(overrides = {}) {
     stripeSettings.cancelUrl = overrides.cancelUrl || stripeSettings.cancelUrl || defaultStripeSettings.cancelUrl;
     stripeSettings.priceLookup = {
         ...defaultPriceLookup,
-        ...(overrides.priceLookup || {}),
-        ...(window.STRIPE_PRICE_LOOKUP || {})
+        ...normalizePriceLookupMap(overrides.priceLookup || {}),
+        ...normalizePriceLookupMap(window.STRIPE_PRICE_LOOKUP || {})
     };
 }
 


### PR DESCRIPTION
### Motivation
- Checkout reported missing Stripe price IDs when `stripe-config.json` used variant keys (e.g. `t_shirt`, `tshirt`, `t-shirt`) that didn't match runtime lookup candidates, so price lookups needed normalization. 
- The intent is to accept common key variants and aliases so configured `price_...` IDs resolve reliably during checkout while still requiring real `price_...` values in configuration.

### Description
- Added `normalizePriceLookupMap` in `cart.js` to normalize keys from a config by canonicalizing to known product aliases, slug forms, and compact slugs. 
- Updated `applyStripeSettings` to merge normalized maps from `overrides.priceLookup` and `window.STRIPE_PRICE_LOOKUP` so lookups like `t_shirt`, `tshirt`, or `t-shirt` resolve to the same canonical product key. 
- Left existing `defaultPriceLookup` and alias logic intact so product aliases and explicit `data-price-id`/`stripePriceId` continue to work unchanged.

### Testing
- Ran a syntax check with `node --check cart.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e06611f86c832187b68671c300992b)