### PR TITLE
Improve Stripe catalog matching for checkout price sync

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -45,11 +45,12 @@ const defaultStripeSettings = {
 
 const stripeSettings = { ...defaultStripeSettings };
 const stripeProductAliases = {
-    hat: ['baseball-cap', 'baseballcap', 'hats', 'cap'],
+    hat: ['baseball-cap', 'baseballcap', 'hat-baseball-cap', 'hats', 'cap'],
     truckerhat: ['trucker-hat', 'trucker'],
     't-shirt': ['tshirt', 'tee', 'shirt'],
     'american-denim': ['americandenim', 'denim', 'jeans'],
-    dufflebag: ['duffle-bag', 'duffelbag', 'duffel-bag']
+    dufflebag: ['duffle-bag', 'duffelbag', 'duffel-bag'],
+    skateboard2: ['stakeboard2', 'stakeboard-2']
 };
 
 function buildStripeLookupAliasMap() {

--- a/sync-stripe-prices.mjs
+++ b/sync-stripe-prices.mjs
@@ -10,19 +10,19 @@ if (!stripeSecretKey) {
 const configPath = process.env.STRIPE_CONFIG_PATH || 'stripe-config.json';
 
 const catalog = [
-  { key: 't-shirt', name: 'T-Shirt', unitAmount: 3000 },
-  { key: 'hoodie', name: 'Hoodie', unitAmount: 7000 },
-  { key: 'shorts', name: 'Shorts', unitAmount: 5000 },
-  { key: 'joggers', name: 'Joggers', unitAmount: 6000 },
-  { key: 'hat', name: 'Hat', unitAmount: 4000 },
-  { key: 'truckerhat', name: 'Trucker Hat', unitAmount: 5000 },
-  { key: 'socks', name: 'Socks', unitAmount: 2000 },
-  { key: 'backpack', name: 'Backpack', unitAmount: 6000 },
-  { key: 'dufflebag', name: 'Duffle Bag', unitAmount: 8000 },
-  { key: 'american-denim', name: 'American Denim', unitAmount: 9000 },
-  { key: 'skateboard1', name: 'Skateboard 1', unitAmount: 10000 },
-  { key: 'skateboard2', name: 'Skateboard 2', unitAmount: 10000 },
-  { key: 'skateboard3', name: 'Skateboard 3', unitAmount: 10000 }
+  { key: 't-shirt', name: 'T-Shirt', unitAmount: 3000, aliases: ['T Shirt', 'Tee'] },
+  { key: 'hoodie', name: 'Hoodie', unitAmount: 7000, aliases: [] },
+  { key: 'shorts', name: 'Shorts', unitAmount: 5000, aliases: [] },
+  { key: 'joggers', name: 'Joggers', unitAmount: 7000, aliases: [] },
+  { key: 'hat', name: 'Hat -Baseball Cap', unitAmount: 4000, aliases: ['Baseball Cap', 'Hat'] },
+  { key: 'truckerhat', name: 'Trucker Hat', unitAmount: 5000, aliases: ['Trucker'] },
+  { key: 'socks', name: 'Socks', unitAmount: 2000, aliases: [] },
+  { key: 'backpack', name: 'Backpack', unitAmount: 6000, aliases: [] },
+  { key: 'dufflebag', name: 'Duffle Bag', unitAmount: 8000, aliases: ['Duffel Bag'] },
+  { key: 'american-denim', name: 'American Denim Jeans', unitAmount: 9000, aliases: ['American Denim', 'Jeans'] },
+  { key: 'skateboard1', name: 'Skateboard 1', unitAmount: 10000, aliases: [] },
+  { key: 'skateboard2', name: 'Skateboard 2', unitAmount: 10000, aliases: ['Stakeboard 2'] },
+  { key: 'skateboard3', name: 'Skateboard 3', unitAmount: 10000, aliases: [] }
 ];
 
 function formBody(data) {
@@ -72,12 +72,23 @@ function normalizeName(value) {
     .replace(/[^a-z0-9]/g, '');
 }
 
+function findByAliases(aliases, productsByName) {
+  for (const alias of aliases || []) {
+    const match = productsByName.get(normalizeName(alias));
+    if (match) return match;
+  }
+  return null;
+}
+
 async function ensureProduct(item, productsByKey, productsByName) {
   const byKey = productsByKey.get(item.key);
   if (byKey) return byKey;
 
   const byName = productsByName.get(normalizeName(item.name));
   if (byName) return byName;
+
+  const byAlias = findByAliases(item.aliases, productsByName);
+  if (byAlias) return byAlias;
 
   const created = await stripeRequest('/products', {
     method: 'POST',


### PR DESCRIPTION
### Motivation
- Ensure client checkout maps to live Stripe `price_...` IDs and reuses existing Stripe products instead of creating duplicates when product names vary or contain typos. 
- Align the local catalog with the actual product names and pricing (e.g. Joggers at $70, American Denim Jeans) so `stripe-config.json` can be populated reliably. 

### Description
- Extended the catalog entries in `sync-stripe-prices.mjs` to include `aliases` and updated product names and `unitAmount` values to match the live catalog (notably `joggers` -> 7000 and `american-denim` -> "American Denim Jeans").
- Added `findByAliases` and reused alias matching inside `ensureProduct` in `sync-stripe-prices.mjs` so existing Stripe products with alternate names are matched instead of recreated. 
- Expanded client-side alias mapping in `cart.js` (added `hat` variants and `skateboard2` typo aliases) so the checkout price lookup resolves common naming variants. 

### Testing
- Ran `node --check cart.js` which succeeded. 
- Ran `node --check sync-stripe-prices.mjs` which succeeded. 
- Attempted to run the full sync (`STRIPE_SECRET_KEY=<key> node sync-stripe-prices.mjs`) in this environment and it failed due to blocked outbound connectivity (`fetch` / network 403), so live Stripe sync was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e106d747e88321937040269e5c66f2)