### PR TITLE
Replace Stripe placeholder prices with live price IDs

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -21,19 +21,18 @@ const stateTaxRates = {
 const defaultTaxRate = stateTaxRates['IL'];
 
 const defaultPriceLookup = {
-    't-shirt': 'price_REPLACE_TSHIRT',
-    hoodie: 'price_REPLACE_HOODIE',
-    shorts: 'price_REPLACE_SHORTS',
-    joggers: 'price_REPLACE_JOGGERS',
-    hat: 'price_REPLACE_HAT',
-    truckerhat: 'price_REPLACE_TRUCKER_HAT',
-    socks: 'price_REPLACE_SOCKS',
-    backpack: 'price_REPLACE_BACKPACK',
-    dufflebag: 'price_REPLACE_DUFFLEBAG',
-    'american-denim': 'price_REPLACE_AMERICAN_DENIM',
-    skateboard1: 'price_REPLACE_SKATEBOARD1',
-    skateboard2: 'price_REPLACE_SKATEBOARD2',
-    skateboard3: 'price_REPLACE_SKATEBOARD3'
+    't-shirt': 'price_1TMrxb6vAbsTB4QVVI8wB6tb',
+    hoodie: 'price_1TMrwq6vAbsTB4QVGhANJDBO',
+    shorts: 'price_1TMs0e6vAbsTB4QV0IU5JIPS',
+    joggers: 'price_1TMryV6vAbsTB4QVd9G1WVH1',
+    hat: 'price_1TMrw26vAbsTB4QVfnxBgAmB',
+    truckerhat: 'price_1TMs6P6vAbsTB4QVIB0j7b7k',
+    socks: 'price_1TMs9R6vAbsTB4QVRn8SawXZ',
+    dufflebag: 'price_1TMs4N6vAbsTB4QV2N9UmUs1',
+    'american-denim': 'price_1TMs366vAbsTB4QVlEHmGj1A',
+    skateboard1: 'price_1TMsAJ6vAbsTB4QVof4P9O6J',
+    skateboard2: 'price_1TMsB66vAbsTB4QVgdK0paRD',
+    skateboard3: 'price_1TMsBv6vAbsTB4QVwwDsrvmn'
 };
 
 const defaultStripeSettings = {

--- a/stripe-config.json
+++ b/stripe-config.json
@@ -3,18 +3,17 @@
   "successUrl": "/success.html",
   "cancelUrl": "/cart.html",
   "priceLookup": {
-    "t-shirt": "price_REPLACE_TSHIRT",
-    "hoodie": "price_REPLACE_HOODIE",
-    "shorts": "price_REPLACE_SHORTS",
-    "joggers": "price_REPLACE_JOGGERS",
-    "hat": "price_REPLACE_HAT",
-    "truckerhat": "price_REPLACE_TRUCKER_HAT",
-    "socks": "price_REPLACE_SOCKS",
-    "backpack": "price_REPLACE_BACKPACK",
-    "dufflebag": "price_REPLACE_DUFFLEBAG",
-    "american-denim": "price_REPLACE_AMERICAN_DENIM",
-    "skateboard1": "price_REPLACE_SKATEBOARD1",
-    "skateboard2": "price_REPLACE_SKATEBOARD2",
-    "skateboard3": "price_REPLACE_SKATEBOARD3"
+    "t-shirt": "price_1TMrxb6vAbsTB4QVVI8wB6tb",
+    "hoodie": "price_1TMrwq6vAbsTB4QVGhANJDBO",
+    "shorts": "price_1TMs0e6vAbsTB4QV0IU5JIPS",
+    "joggers": "price_1TMryV6vAbsTB4QVd9G1WVH1",
+    "hat": "price_1TMrw26vAbsTB4QVfnxBgAmB",
+    "truckerhat": "price_1TMs6P6vAbsTB4QVIB0j7b7k",
+    "socks": "price_1TMs9R6vAbsTB4QVRn8SawXZ",
+    "dufflebag": "price_1TMs4N6vAbsTB4QV2N9UmUs1",
+    "american-denim": "price_1TMs366vAbsTB4QVlEHmGj1A",
+    "skateboard1": "price_1TMsAJ6vAbsTB4QVof4P9O6J",
+    "skateboard2": "price_1TMsB66vAbsTB4QVgdK0paRD",
+    "skateboard3": "price_1TMsBv6vAbsTB4QVwwDsrvmn"
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure Stripe Checkout uses real price IDs instead of placeholders so checkout sessions charge correctly.
- Provide a working default price lookup in the client (`cart.js`) so mapping works before remote config is fetched.
- Remove stale placeholder entries to avoid failing line-item resolution at runtime.

### Description
- Replaced placeholder `price_REPLACE_*` entries with real Stripe `price_1...` IDs in `stripe-config.json` under `priceLookup`.
- Updated the `defaultPriceLookup` map in `cart.js` to use the same live price IDs so client-side line-item building works out of the box.
- Removed the unresolved `backpack` placeholder mapping from the lookup maps to prevent accidental use of a `REPLACE` value.
- Left existing canonical keys and alias logic intact so product-to-price resolution continues to follow the current normalization rules.

### Testing
- Ran `node --check cart.js` which completed successfully.
- Validated JSON with `python -m json.tool stripe-config.json >/dev/null` which completed successfully.
- Confirmed no syntax errors and that the default price lookup is present in `cart.js` after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e109a8b73083218b6a62f58354be58)