### PR TITLE
Normalize Stripe Checkout success/cancel URLs to absolute http/https

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -70,6 +70,19 @@ function buildStripeLookupAliasMap() {
 
 const stripeLookupAliasMap = buildStripeLookupAliasMap();
 
+function normalizeCheckoutUrl(url, fallback) {
+    if (typeof url !== 'string' || !url.trim()) return fallback;
+    try {
+        const resolvedUrl = new URL(url, window.location.origin);
+        if (resolvedUrl.protocol === 'http:' || resolvedUrl.protocol === 'https:') {
+            return resolvedUrl.toString();
+        }
+    } catch (_) {
+        // Fall through to fallback when URL parsing fails
+    }
+    return fallback;
+}
+
 function canonicalizeStripeProductKey(key) {
     const normalized = toSlug(key).replace(/-/g, '');
     if (!normalized) return '';
@@ -99,8 +112,14 @@ function applyStripeSettings(overrides = {}) {
     if (overrides.publishableKey) {
         stripeSettings.publishableKey = overrides.publishableKey;
     }
-    stripeSettings.successUrl = overrides.successUrl || stripeSettings.successUrl || defaultStripeSettings.successUrl;
-    stripeSettings.cancelUrl = overrides.cancelUrl || stripeSettings.cancelUrl || defaultStripeSettings.cancelUrl;
+    stripeSettings.successUrl = normalizeCheckoutUrl(
+        overrides.successUrl || stripeSettings.successUrl || defaultStripeSettings.successUrl,
+        defaultStripeSettings.successUrl
+    );
+    stripeSettings.cancelUrl = normalizeCheckoutUrl(
+        overrides.cancelUrl || stripeSettings.cancelUrl || defaultStripeSettings.cancelUrl,
+        defaultStripeSettings.cancelUrl
+    );
     stripeSettings.priceLookup = {
         ...defaultPriceLookup,
         ...normalizePriceLookupMap(overrides.priceLookup || {}),


### PR DESCRIPTION
### Motivation
- Stripe Checkout requires `successUrl` and `cancelUrl` to be absolute URLs starting with `http://` or `https://`, and relative values (e.g. `/success.html`) caused `stripe.redirectToCheckout` validation errors during flows like Apple Pay. 
- The change ensures configured URLs are normalized and validated before being passed to Stripe to avoid those runtime failures.

### Description
- Added `normalizeCheckoutUrl(url, fallback)` in `cart.js` which resolves relative paths against `window.location.origin`, validates the `http`/`https` protocol, and returns a fallback when invalid. 
- Updated `applyStripeSettings` to run both `successUrl` and `cancelUrl` through `normalizeCheckoutUrl` so only valid absolute `http`/`https` URLs are used. 
- Defaults are preserved by passing `defaultStripeSettings.successUrl` / `defaultStripeSettings.cancelUrl` as fallbacks when normalization fails. 
- All changes are contained in `cart.js`.

### Testing
- Ran static syntax check with `node --check cart.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10b7c16948321a1cd8e819c2617fc)