### PR TITLE
Improve Stripe checkout reliability by using relative endpoint defaults

### DIFF
--- a/STRIPE_CHECKOUT_SETUP.md
+++ b/STRIPE_CHECKOUT_SETUP.md
@@ -30,6 +30,12 @@ Optional overrides:
 - `STRIPE_SUCCESS_URL=https://your-site.example/success.html`
 - `STRIPE_CANCEL_URL=https://your-site.example/cart.html`
 
+## Endpoint configuration tips
+
+- In production, point `checkoutEndpoint` to an HTTPS URL on the same origin as your storefront (for example `/api/stripe/create-checkout-session`).
+- Avoid `http://localhost:4242/...` in production `stripe-config.json`; that causes browser network errors like `TypeError: Failed to fetch` for real users.
+- If frontend and API are on different origins, allow the storefront origin with CORS on your checkout-session API route.
+
 ## Run
 
 ```bash

--- a/cart.js
+++ b/cart.js
@@ -289,17 +289,23 @@ function buildStripeLineItems() {
 }
 
 async function startServerCheckout(method, lineItems) {
-    const response = await fetch(stripeSettings.checkoutEndpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            method,
-            lineItems,
-            cart,
-            successUrl: stripeSettings.successUrl,
-            cancelUrl: stripeSettings.cancelUrl
-        })
-    });
+    let response;
+    try {
+        response = await fetch(stripeSettings.checkoutEndpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                method,
+                lineItems,
+                cart,
+                successUrl: stripeSettings.successUrl,
+                cancelUrl: stripeSettings.cancelUrl
+            })
+        });
+    } catch (_) {
+        const endpoint = stripeSettings.checkoutEndpoint || '(missing endpoint)';
+        throw new Error(`Network error calling checkout endpoint (${endpoint}). Verify the endpoint is reachable from this site, uses HTTPS in production, and allows this origin (CORS).`);
+    }
 
     let payload = {};
     try {

--- a/stripe-config.json
+++ b/stripe-config.json
@@ -1,8 +1,8 @@
 {
   "publishableKey": "${STRIPE_PUBLISHABLE_KEY}",
-  "checkoutEndpoint": "http://localhost:4242/api/stripe/create-checkout-session",
-  "successUrl": "http://localhost:4242/success.html",
-  "cancelUrl": "http://localhost:4242/cart.html",
+  "checkoutEndpoint": "/api/stripe/create-checkout-session",
+  "successUrl": "/success.html",
+  "cancelUrl": "/cart.html",
   "priceLookup": {
     "t-shirt": "price_1TMrxb6vAbsTB4QVVI8wB6tb",
     "hoodie": "price_1TMrwq6vAbsTB4QVGhANJDBO",


### PR DESCRIPTION
### Motivation

- Browser clients were receiving generic `TypeError: Failed to fetch` when the frontend attempted to call a hardcoded `http://localhost:4242/...` checkout endpoint from non-localhost deployments.  
- Surface a clearer, actionable error when network/fetch fails so operators can diagnose unreachable endpoints, HTTPS mismatches, or CORS issues.  
- Add documentation guidance so deployers know to use same-origin or properly CORS-enabled HTTPS endpoints in production.  

### Description

- Changed `stripe-config.json` defaults from `http://localhost:4242/...` to same-origin relative paths (`/api/stripe/create-checkout-session`, `/success.html`, `/cart.html`).  
- Wrapped the `fetch()` in `startServerCheckout` (in `cart.js`) with a `try/catch` and throw a descriptive `Error` that explains likely causes: unreachable endpoint, HTTPS requirement in production, or missing CORS.  
- Added an "Endpoint configuration tips" section to `STRIPE_CHECKOUT_SETUP.md` explaining why localhost endpoints cause `Failed to fetch` in browsers and advising same-origin HTTPS or proper CORS.  

### Testing

- Ran `node --check cart.js` and it succeeded.  
- Ran `node --check stripe-checkout-server.mjs` and it succeeded.  
- Validated `stripe-config.json` with `python -m json.tool stripe-config.json` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e119dd19f88321be023cd3e105f5d1)