### PR TITLE
Improve Stripe checkout endpoint failure diagnostics

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -328,20 +328,22 @@ async function startServerCheckout(method, lineItems) {
     const endpointCandidates = buildCheckoutEndpointCandidates(stripeSettings.checkoutEndpoint);
     let response;
     let endpointUsed = endpointCandidates[0] || stripeSettings.checkoutEndpoint || '';
-    let networkError = null;
+    const attemptedEndpoints = [];
 
     for (const endpoint of endpointCandidates) {
         endpointUsed = endpoint;
         try {
             response = await postCheckoutSession(endpoint, requestPayload);
         } catch (err) {
-            networkError = err;
+            attemptedEndpoints.push(`${endpoint} (network error)`);
             continue;
         }
 
         if (response.status === 404 || response.status === 405) {
+            attemptedEndpoints.push(`${endpoint} (${response.status})`);
             continue;
         }
+        attemptedEndpoints.push(`${endpoint} (${response.status})`);
         break;
     }
 
@@ -367,8 +369,11 @@ async function startServerCheckout(method, lineItems) {
         const status = `${response.status} ${response.statusText}`.trim();
         const fallbackDetail = rawText ? ` ${rawText.slice(0, 180)}` : '';
         const endpointHint = endpointUsed ? ` Endpoint: ${endpointUsed}.` : '';
-        if ((response.status === 404 || response.status === 405) && networkError) {
-            throw new Error(`Unable to create Stripe Checkout session (${status}).${endpointHint} ${networkError.message || ''}`.trim());
+        const attemptedHint = attemptedEndpoints.length ? ` Tried: ${attemptedEndpoints.join(', ')}.` : '';
+        if (response.status === 404 || response.status === 405) {
+            throw new Error(
+                `Unable to create Stripe Checkout session (${status}).${endpointHint}${attemptedHint} Ensure your server exposes POST /api/stripe/create-checkout-session in production.`
+            );
         }
         throw new Error(payload.error || `Unable to create Stripe Checkout session (${status}).${endpointHint}${fallbackDetail}`);
     }


### PR DESCRIPTION
### Motivation
- Make server-side Stripe Checkout failures more actionable by surfacing which endpoints were tried and why they failed instead of a single opaque error.

### Description
- Track all attempted checkout endpoints (including network errors and 404/405 responses) in `startServerCheckout` and record their outcomes.
- Include a `Tried:` list of attempted endpoints in non-OK error messages to provide more context to operators.
- Provide a clearer, targeted error for 404/405 responses that points out the expected production route `POST /api/stripe/create-checkout-session`.
- Changes are localized to `cart.js` and maintain existing behavior for non-404/405 failures while improving endpoint context.

### Testing
- Ran a static syntax check with `node --check cart.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1210ecfbc8321a1e9cde467a07de6)