### PR TITLE
Fix production Stripe checkout POST endpoint routing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,14 @@
+[build]
+  functions = "netlify/functions"
+
+[[redirects]]
+  from = "/api/stripe/create-checkout-session"
+  to = "/.netlify/functions/create-checkout-session"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/api/create-checkout-session"
+  to = "/.netlify/functions/create-checkout-session"
+  status = 200
+  force = true

--- a/netlify/functions/create-checkout-session.js
+++ b/netlify/functions/create-checkout-session.js
@@ -1,0 +1,115 @@
+const STRIPE_API_BASE = 'https://api.stripe.com/v1';
+
+function json(statusCode, payload) {
+  return {
+    statusCode,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Headers': 'Content-Type',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS'
+    },
+    body: JSON.stringify(payload)
+  };
+}
+
+function sanitizeLineItems(body) {
+  const directItems = Array.isArray(body?.lineItems) ? body.lineItems : [];
+  const direct = directItems
+    .map((item) => ({
+      price: typeof item?.price === 'string' ? item.price.trim() : '',
+      quantity: Number.isFinite(Number(item?.quantity)) ? Math.max(1, Number(item.quantity)) : 1
+    }))
+    .filter((item) => item.price.startsWith('price_'));
+
+  if (direct.length) return direct;
+
+  const cartItems = Array.isArray(body?.cart) ? body.cart : [];
+  return cartItems
+    .map((item) => ({
+      price: typeof item?.stripePriceId === 'string' ? item.stripePriceId.trim() : '',
+      quantity: Number.isFinite(Number(item?.quantity)) ? Math.max(1, Number(item.quantity)) : 1
+    }))
+    .filter((item) => item.price.startsWith('price_'));
+}
+
+function toFormBody(params) {
+  const form = new URLSearchParams();
+  params.line_items.forEach((item, index) => {
+    form.append(`line_items[${index}][price]`, item.price);
+    form.append(`line_items[${index}][quantity]`, String(item.quantity));
+  });
+  form.append('mode', params.mode);
+  form.append('success_url', params.success_url);
+  form.append('cancel_url', params.cancel_url);
+  return form;
+}
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 204,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS'
+      },
+      body: ''
+    };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return json(405, { error: 'Method Not Allowed. Use POST.' });
+  }
+
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    return json(500, { error: 'Missing STRIPE_SECRET_KEY.' });
+  }
+
+  let body;
+  try {
+    body = event.body ? JSON.parse(event.body) : {};
+  } catch {
+    return json(400, { error: 'Invalid JSON body.' });
+  }
+
+  const lineItems = sanitizeLineItems(body);
+  if (!lineItems.length) {
+    return json(400, { error: 'Request must include lineItems or cart with valid Stripe price IDs.' });
+  }
+
+  const successUrl = typeof body.successUrl === 'string' && body.successUrl ? body.successUrl : 'https://maybenot.com/success.html';
+  const cancelUrl = typeof body.cancelUrl === 'string' && body.cancelUrl ? body.cancelUrl : 'https://maybenot.com/cart.html';
+
+  const payload = {
+    line_items: lineItems,
+    mode: 'payment',
+    success_url: successUrl,
+    cancel_url: cancelUrl
+  };
+
+  try {
+    const response = await fetch(`${STRIPE_API_BASE}/checkout/sessions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${secretKey}`,
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: toFormBody(payload)
+    });
+
+    const stripePayload = await response.json();
+    if (!response.ok) {
+      const message = stripePayload?.error?.message || 'Stripe session creation failed.';
+      return json(response.status, { error: message });
+    }
+
+    return json(200, {
+      id: stripePayload.id,
+      url: stripePayload.url
+    });
+  } catch (error) {
+    return json(500, { error: error.message || 'Unable to create checkout session.' });
+  }
+};


### PR DESCRIPTION
### Motivation
- POST requests to the Stripe checkout endpoints were returning 405 because POST traffic landed on static pages rather than a server handler, so a real server-side POST handler and correct routing were required to create Checkout Sessions using the secret key.

### Description
- Added a Netlify Function `netlify/functions/create-checkout-session.js` that implements `OPTIONS` and strict `POST` handling, parses JSON bodies, and applies CORS headers for browser requests.
- The function sanitizes `lineItems` (and falls back to `cart` entries with `stripePriceId`), encodes the request as `application/x-www-form-urlencoded`, and calls the Stripe API using the server-side `STRIPE_SECRET_KEY` to create a Checkout Session, returning JSON with `id` and `url` on success.
- Added `netlify.toml` with redirects that route `/api/stripe/create-checkout-session` and `/api/create-checkout-session` to `/.netlify/functions/create-checkout-session` with `force = true` so POSTs reach the function instead of static files.
- Responses include structured JSON error messages and proper status codes for `405`, `400`, `500`, and Stripe API errors.

### Testing
- Executed the function locally via `node -e "const fn=require('./netlify/functions/create-checkout-session.js'); (async()=>{const r=await fn.handler({httpMethod:'GET'}); console.log(r.statusCode, r.body); const r2=await fn.handler({httpMethod:'POST', body:'{}'}); console.log(r2.statusCode, r2.body);})();"` and observed `GET` returns `405` and `POST` returned `500` with `Missing STRIPE_SECRET_KEY`, demonstrating method routing and handler execution.
- Verified the new `netlify.toml` contains redirects from `/api/stripe/create-checkout-session` and `/api/create-checkout-session` to `/.netlify/functions/create-checkout-session`, which addresses the 405s caused by POSTs hitting static routes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1277992148321938977bdbea062b3)