### PR TITLE
Finalize production Stripe backend setup and wire frontend to Render-hosted API

### DIFF
--- a/STRIPE_CHECKOUT_SETUP.md
+++ b/STRIPE_CHECKOUT_SETUP.md
@@ -1,6 +1,6 @@
 # Stripe one-time Checkout integration
 
-This project now includes a server-side Stripe Checkout flow:
+This project now uses a production-hosted server-side Stripe Checkout flow:
 
 1. Frontend sends `lineItems` (or `cart`) to `POST /api/stripe/create-checkout-session`.
 2. Server validates Stripe price IDs (`price_...`) and quantity values.
@@ -10,45 +10,80 @@ This project now includes a server-side Stripe Checkout flow:
    - `success_url` and `cancel_url`
 4. Server returns JSON `{ id, url }` to the browser.
 
-## Environment variables
+## Production backend URL
 
-Set these before running:
+- **Checkout API base:** `https://maybenot-stripe-api.onrender.com`
+- **Create session endpoint:** `https://maybenot-stripe-api.onrender.com/api/stripe/create-checkout-session`
+- **Health endpoint:** `https://maybenot-stripe-api.onrender.com/api/stripe/health`
 
-- `STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}`
-- `STRIPE_PUBLISHABLE_KEY=${STRIPE_PUBLISHABLE_KEY}`
-- `STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}`
+`stripe-config.json` is now configured to call that exact create-session endpoint.
 
-Get the key values from your Stripe Dashboard.
+## Hosting / deployment
 
-Optional overrides:
+- Render blueprint is included in `render.yaml`.
+- Runtime/start metadata is included in `package.json`.
+- The backend entrypoint is `stripe-checkout-server.mjs`.
+
+Deploy with Render Blueprint from this repo and service name `maybenot-stripe-api`.
+
+## Required environment variables
+
+Set these in your production host (Render service environment):
+
+- `STRIPE_SECRET_KEY` (required)
+- `STRIPE_WEBHOOK_SECRET` (required for webhook signature verification)
+- `STRIPE_ALLOWED_ORIGINS=https://maybenot.com,https://www.maybenot.com`
+- `STRIPE_SUCCESS_URL=https://maybenot.com/success.html`
+- `STRIPE_CANCEL_URL=https://maybenot.com/cart.html`
+
+Optional:
 
 - `PORT=4242`
-- `STRIPE_SUCCESS_URL=https://your-site.example/success.html`
-- `STRIPE_CANCEL_URL=https://your-site.example/cart.html`
-- `STRIPE_ALLOWED_ORIGIN=https://your-site.example`
 
-## Endpoint configuration tips
+## CORS
 
-- In production, point `checkoutEndpoint` to an HTTPS URL on the same origin as your storefront (for example `/api/stripe/create-checkout-session`).
-- Avoid `http://localhost:4242/...` in production `stripe-config.json`; that causes browser network errors like `TypeError: Failed to fetch` for real users.
-- If frontend and API are on different origins, allow the storefront origin with CORS on your checkout-session API route.
-- This repo no longer relies on Netlify Functions or Netlify redirects for checkout-session creation.
+The server now enforces origin allowlisting and includes `https://maybenot.com` and `https://www.maybenot.com` by default.
 
-## Hosting note for maybenot.com (GitHub Pages)
+To customize allowed origins, set `STRIPE_ALLOWED_ORIGINS` as a comma-separated list.
 
-GitHub Pages serves static files only, so it cannot execute `POST /api/stripe/create-checkout-session` by itself.
-Run `stripe-checkout-server.mjs` on the platform that serves your production domain requests, and route:
+## Verify deployed environment
 
-- `POST /api/stripe/create-checkout-session`
-- `POST /api/stripe/webhook`
-- `GET /api/stripe/health`
-
-to that Node process.
-
-## Run
+After deployment, run:
 
 ```bash
-node stripe-checkout-server.mjs
+curl -i https://maybenot-stripe-api.onrender.com/api/stripe/health
+```
+
+Expected response includes:
+
+- `"ok": true`
+- `"hasStripeSecretKey": true`
+- `"allowedOrigins"` containing `https://maybenot.com`
+
+Then validate checkout-session route against the deployed host:
+
+```bash
+curl -i -X POST https://maybenot-stripe-api.onrender.com/api/stripe/create-checkout-session \
+  -H 'Content-Type: application/json' \
+  -H 'Origin: https://maybenot.com' \
+  --data '{
+    "lineItems": [{"price": "price_1TMrxb6vAbsTB4QVVI8wB6tb", "quantity": 1}],
+    "successUrl": "https://maybenot.com/success.html",
+    "cancelUrl": "https://maybenot.com/cart.html"
+  }'
+```
+
+Expected response:
+
+- HTTP `200`
+- JSON containing `id` and `url`
+
+If `STRIPE_SECRET_KEY` is missing, the endpoint returns `500` with `Missing STRIPE_SECRET_KEY.`.
+
+## Local run
+
+```bash
+npm start
 ```
 
 Server routes:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mbnt-stripe-checkout-backend",
+  "private": true,
+  "type": "module",
+  "version": "1.0.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "start": "node stripe-checkout-server.mjs"
+  }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,22 @@
+services:
+  - type: web
+    name: maybenot-stripe-api
+    runtime: node
+    plan: starter
+    rootDir: .
+    buildCommand: "npm install"
+    startCommand: "npm start"
+    autoDeploy: true
+    envVars:
+      - key: NODE_VERSION
+        value: 20
+      - key: STRIPE_ALLOWED_ORIGINS
+        value: https://maybenot.com,https://www.maybenot.com
+      - key: STRIPE_SUCCESS_URL
+        value: https://maybenot.com/success.html
+      - key: STRIPE_CANCEL_URL
+        value: https://maybenot.com/cart.html
+      - key: STRIPE_SECRET_KEY
+        sync: false
+      - key: STRIPE_WEBHOOK_SECRET
+        sync: false

--- a/stripe-checkout-server.mjs
+++ b/stripe-checkout-server.mjs
@@ -5,23 +5,55 @@ import { createHmac, timingSafeEqual } from 'node:crypto';
 const port = Number(process.env.PORT || 4242);
 const stripeSecretKey = process.env.STRIPE_SECRET_KEY || '';
 const webhookSigningSecret = process.env.STRIPE_WEBHOOK_SECRET || '';
-const allowedOrigin = process.env.STRIPE_ALLOWED_ORIGIN || '*';
+
+const defaultAllowedOrigins = [
+  'https://maybenot.com',
+  'https://www.maybenot.com',
+  'http://localhost:4242',
+  'http://127.0.0.1:4242'
+];
+
+const configuredAllowedOrigins = (process.env.STRIPE_ALLOWED_ORIGINS || process.env.STRIPE_ALLOWED_ORIGIN || '')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+const allowedOrigins = configuredAllowedOrigins.length ? configuredAllowedOrigins : defaultAllowedOrigins;
 
 const defaultSuccessUrl = process.env.STRIPE_SUCCESS_URL || 'https://maybenot.com/success.html';
 const defaultCancelUrl = process.env.STRIPE_CANCEL_URL || 'https://maybenot.com/cart.html';
 
-function corsHeaders() {
-  return {
-    'Access-Control-Allow-Origin': allowedOrigin,
-    'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type, Stripe-Signature'
-  };
+function getAllowedOrigin(requestOrigin) {
+  if (!requestOrigin) {
+    return allowedOrigins[0] || 'https://maybenot.com';
+  }
+
+  if (allowedOrigins.includes('*')) {
+    return '*';
+  }
+
+  return allowedOrigins.includes(requestOrigin) ? requestOrigin : '';
 }
 
-function jsonResponse(res, statusCode, payload) {
+function corsHeaders(requestOrigin) {
+  const allowedOrigin = getAllowedOrigin(requestOrigin);
+  const headers = {
+    'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Stripe-Signature',
+    Vary: 'Origin'
+  };
+
+  if (allowedOrigin) {
+    headers['Access-Control-Allow-Origin'] = allowedOrigin;
+  }
+
+  return headers;
+}
+
+function jsonResponse(res, statusCode, payload, requestOrigin = '') {
   res.writeHead(statusCode, {
     'Content-Type': 'application/json; charset=utf-8',
-    ...corsHeaders()
+    ...corsHeaders(requestOrigin)
   });
   res.end(`${JSON.stringify(payload)}\n`);
 }
@@ -99,8 +131,10 @@ async function readBody(req) {
 }
 
 async function handleCreateCheckoutSession(req, res) {
+  const requestOrigin = req.headers.origin || '';
+
   if (!stripeSecretKey) {
-    return jsonResponse(res, 500, { error: 'Missing STRIPE_SECRET_KEY.' });
+    return jsonResponse(res, 500, { error: 'Missing STRIPE_SECRET_KEY.' }, requestOrigin);
   }
 
   const rawBody = await readBody(req);
@@ -108,12 +142,17 @@ async function handleCreateCheckoutSession(req, res) {
   try {
     body = rawBody ? JSON.parse(rawBody) : {};
   } catch {
-    return jsonResponse(res, 400, { error: 'Invalid JSON body.' });
+    return jsonResponse(res, 400, { error: 'Invalid JSON body.' }, requestOrigin);
   }
 
   const lineItems = sanitizeLineItems(body);
   if (!lineItems.length) {
-    return jsonResponse(res, 400, { error: 'Request must include lineItems or cart with valid Stripe price IDs.' });
+    return jsonResponse(
+      res,
+      400,
+      { error: 'Request must include lineItems or cart with valid Stripe price IDs.' },
+      requestOrigin
+    );
   }
 
   const successUrl = typeof body.successUrl === 'string' && body.successUrl ? body.successUrl : defaultSuccessUrl;
@@ -139,33 +178,45 @@ async function handleCreateCheckoutSession(req, res) {
     const stripePayload = await response.json();
     if (!response.ok) {
       const message = stripePayload?.error?.message || 'Stripe session creation failed.';
-      return jsonResponse(res, response.status, { error: message });
+      return jsonResponse(res, response.status, { error: message }, requestOrigin);
     }
 
-    return jsonResponse(res, 200, {
-      id: stripePayload.id,
-      url: stripePayload.url
-    });
+    return jsonResponse(
+      res,
+      200,
+      {
+        id: stripePayload.id,
+        url: stripePayload.url
+      },
+      requestOrigin
+    );
   } catch (error) {
-    return jsonResponse(res, 500, { error: error.message || 'Unable to create checkout session.' });
+    return jsonResponse(res, 500, { error: error.message || 'Unable to create checkout session.' }, requestOrigin);
   }
 }
 
 async function handleStripeWebhook(req, res) {
+  const requestOrigin = req.headers.origin || '';
   const signatureHeader = req.headers['stripe-signature'];
   const rawBody = await readBody(req);
 
   if (!verifyStripeSignature(rawBody, signatureHeader)) {
-    return jsonResponse(res, 400, { error: 'Webhook signature verification failed.' });
+    return jsonResponse(res, 400, { error: 'Webhook signature verification failed.' }, requestOrigin);
   }
 
-  return jsonResponse(res, 200, { received: true });
+  return jsonResponse(res, 200, { received: true }, requestOrigin);
 }
 
 const server = createServer(async (req, res) => {
+  const requestOrigin = req.headers.origin || '';
   try {
     if (req.method === 'OPTIONS') {
-      res.writeHead(204, corsHeaders());
+      const responseOrigin = getAllowedOrigin(requestOrigin);
+      if (requestOrigin && !responseOrigin) {
+        return jsonResponse(res, 403, { error: 'Origin not allowed by CORS.' }, requestOrigin);
+      }
+
+      res.writeHead(204, corsHeaders(requestOrigin));
       res.end();
       return;
     }
@@ -179,12 +230,21 @@ const server = createServer(async (req, res) => {
     }
 
     if (req.method === 'GET' && req.url === '/api/stripe/health') {
-      return jsonResponse(res, 200, { ok: true });
+      return jsonResponse(
+        res,
+        200,
+        {
+          ok: true,
+          hasStripeSecretKey: Boolean(stripeSecretKey),
+          allowedOrigins
+        },
+        requestOrigin
+      );
     }
 
-    return jsonResponse(res, 404, { error: 'Not found.' });
+    return jsonResponse(res, 404, { error: 'Not found.' }, requestOrigin);
   } catch (error) {
-    return jsonResponse(res, 500, { error: error.message || 'Internal server error.' });
+    return jsonResponse(res, 500, { error: error.message || 'Internal server error.' }, requestOrigin);
   }
 });
 

--- a/stripe-config.json
+++ b/stripe-config.json
@@ -1,6 +1,6 @@
 {
   "publishableKey": "${STRIPE_PUBLISHABLE_KEY}",
-  "checkoutEndpoint": "/api/stripe/create-checkout-session",
+  "checkoutEndpoint": "https://maybenot-stripe-api.onrender.com/api/stripe/create-checkout-session",
   "successUrl": "/success.html",
   "cancelUrl": "/cart.html",
   "priceLookup": {


### PR DESCRIPTION
### Motivation
- Provide a real production backend for Stripe Checkout because GitHub Pages cannot run server-side code, and ensure the frontend calls an exact deployed endpoint with proper CORS and secrets configured.
- Harden CORS and add runtime metadata so the deployed service can be validated and only allow the maybenot.com origin in production.

### Description
- Added a Render blueprint (`render.yaml`) and `package.json` so `stripe-checkout-server.mjs` can be deployed as a Node web service named `maybenot-stripe-api` on Render.
- Updated `stripe-config.json` to point `checkoutEndpoint` to the exact production URL `https://maybenot-stripe-api.onrender.com/api/stripe/create-checkout-session` used by the frontend.
- Reworked `stripe-checkout-server.mjs` to use allowlist-based CORS, honor `STRIPE_ALLOWED_ORIGINS` / `STRIPE_ALLOWED_ORIGIN`, reject disallowed preflight origins with `403`, and include `GET /api/stripe/health` that reports `hasStripeSecretKey` and `allowedOrigins`.
- Added/updated docs in `STRIPE_CHECKOUT_SETUP.md` describing the production URL, required environment variables, deployment instructions, and verification `curl` commands.

### Testing
- Ran `node --check stripe-checkout-server.mjs` for syntax validation and it succeeded.
- Verified JSON parsing of `stripe-config.json` and `package.json` with `node -e` checks and both succeeded.
- Started the server locally with `STRIPE_SECRET_KEY=sk_test_dummy STRIPE_WEBHOOK_SECRET=whsec_dummy node stripe-checkout-server.mjs` and validated `GET /api/stripe/health` returned `ok: true`, `hasStripeSecretKey: true`, and `allowedOrigins` successfully.
- Exercised CORS behavior with `OPTIONS /api/stripe/create-checkout-session` from `Origin: https://maybenot.com` (returned `204`) and from `Origin: https://evil.example` (returned `403`), and tested `POST /api/stripe/create-checkout-session` with an empty body returning the expected `400` validation error.
- Attempted external verification of `https://maybenot-stripe-api.onrender.com/api/stripe/health` from this environment but outbound network restrictions returned `CONNECT tunnel failed, response 403`, so live remote checks are documented but could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12bf629f48321a55d075e5710839a)