### PR TITLE
Add 2026-04-16 live deployment verification report

### DIFF
--- a/deployment-verification-2026-04-16.md
+++ b/deployment-verification-2026-04-16.md
@@ -1,0 +1,25 @@
+# Live production verification attempt (2026-04-16)
+
+## Scope requested
+- Health check: `https://maybenot-stripe-api.onrender.com/api/stripe/health`
+- Checkout session: `https://maybenot-stripe-api.onrender.com/api/stripe/create-checkout-session`
+- Frontend wiring and cache staleness checks.
+
+## What was verified from repository configuration
+- `stripe-config.json` points checkout to Render endpoint:
+  - `https://maybenot-stripe-api.onrender.com/api/stripe/create-checkout-session`
+- `cart.js` loads `stripe-config.json` and uses that `checkoutEndpoint`.
+- `cart.js` also has a same-origin fallback path `/api/stripe/create-checkout-session`.
+
+## Live endpoint verification attempt results from this environment
+- `curl -sS -D /tmp/health_headers.txt https://maybenot-stripe-api.onrender.com/api/stripe/health -o /tmp/health_body.json`
+  - Failed with: `curl: (56) CONNECT tunnel failed, response 403`
+- `python urllib.request.urlopen("https://maybenot-stripe-api.onrender.com/api/stripe/health")`
+  - Failed with: `URLError <urlopen error Tunnel connection failed: 403 Forbidden>`
+- `curl --noproxy '*' https://maybenot-stripe-api.onrender.com/api/stripe/health`
+  - Failed with: `curl: (7) Failed to connect ... Couldn't connect to server`
+
+## Conclusion
+This execution environment can access some public pages (e.g. `https://maybenot.com`) through its built-in web fetcher, but direct CLI HTTPS requests to the Render host are blocked by proxy policy (`CONNECT ... 403`).
+
+As a result, I could not directly validate the live health JSON, post a real checkout-session request, or capture exact Render status/body from a browser network panel within this environment.


### PR DESCRIPTION
### Motivation
- Preserve an auditable verification log of attempted live production checks for the Stripe health and checkout endpoints and to separate repository-level wiring confirmation from environment-limited live validation.

### Description
- Add `deployment-verification-2026-04-16.md` which records that `stripe-config.json` points to the Render checkout endpoint, that `cart.js` loads and uses that config (with a same-origin fallback), and that live endpoint checks from this environment were blocked by proxy/tunnel errors.

### Testing
- Ran `curl -sS -D /tmp/health_headers.txt https://maybenot-stripe-api.onrender.com/api/stripe/health -o /tmp/health_body.json` (failed: `CONNECT tunnel failed, response 403`), `python` `urllib.request.urlopen("https://maybenot-stripe-api.onrender.com/api/stripe/health")` (failed: `Tunnel connection failed: 403 Forbidden`), and `curl --noproxy '*' https://maybenot-stripe-api.onrender.com/api/stripe/health` (failed to connect), and performed repository inspections with `rg -n "cart\.js|stripe-config\.json|create-checkout-session|maybenot-stripe-api"` (succeeded) and committed the report with `git commit` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12dc5cc3c83218aa711fb0a49d71f)