### PR TITLE
Fix Render Stripe API deployment wiring and remove checkout endpoint fallback

### DIFF
--- a/STRIPE_CHECKOUT_SETUP.md
+++ b/STRIPE_CHECKOUT_SETUP.md
@@ -23,6 +23,8 @@ This project now uses a production-hosted server-side Stripe Checkout flow:
 - Render blueprint is included in `render.yaml`.
 - Runtime/start metadata is included in `package.json`.
 - The backend entrypoint is `stripe-checkout-server.mjs`.
+- Blueprint deploys from branch `work` and starts with `node stripe-checkout-server.mjs`.
+- Render health check path is `/api/stripe/health`.
 
 Deploy with Render Blueprint from this repo and service name `maybenot-stripe-api`.
 
@@ -59,6 +61,8 @@ Expected response includes:
 - `"ok": true`
 - `"hasStripeSecretKey": true`
 - `"allowedOrigins"` containing `https://maybenot.com`
+- `"branch"` matching Render deploy branch (expected `work`)
+- `"commit"` matching Render's deployed commit SHA
 
 Then validate checkout-session route against the deployed host:
 

--- a/cart.js
+++ b/cart.js
@@ -299,11 +299,7 @@ function buildStripeLineItems() {
 
 function buildCheckoutEndpointCandidates(primaryEndpoint) {
     const configured = normalizeCheckoutUrl(primaryEndpoint, '');
-    const fallbacks = [
-        '/api/stripe/create-checkout-session'
-    ].map((path) => normalizeCheckoutUrl(path, ''));
-
-    return [...new Set([configured, ...fallbacks].filter(Boolean))];
+    return configured ? [configured] : [];
 }
 
 async function postCheckoutSession(endpoint, payload) {
@@ -323,6 +319,11 @@ async function startServerCheckout(method, lineItems) {
         cancelUrl: stripeSettings.cancelUrl
     };
     const endpointCandidates = buildCheckoutEndpointCandidates(stripeSettings.checkoutEndpoint);
+    if (!endpointCandidates.length) {
+        throw new Error(
+            'Stripe checkout endpoint is not configured. Set checkoutEndpoint in stripe-config.json to your Render API URL.'
+        );
+    }
     let response;
     let endpointUsed = endpointCandidates[0] || stripeSettings.checkoutEndpoint || '';
     const attemptedEndpoints = [];

--- a/render.yaml
+++ b/render.yaml
@@ -1,11 +1,13 @@
 services:
   - type: web
     name: maybenot-stripe-api
+    branch: work
     runtime: node
     plan: starter
     rootDir: .
     buildCommand: "npm install"
-    startCommand: "npm start"
+    startCommand: "node stripe-checkout-server.mjs"
+    healthCheckPath: /api/stripe/health
     autoDeploy: true
     envVars:
       - key: NODE_VERSION

--- a/stripe-checkout-server.mjs
+++ b/stripe-checkout-server.mjs
@@ -5,6 +5,9 @@ import { createHmac, timingSafeEqual } from 'node:crypto';
 const port = Number(process.env.PORT || 4242);
 const stripeSecretKey = process.env.STRIPE_SECRET_KEY || '';
 const webhookSigningSecret = process.env.STRIPE_WEBHOOK_SECRET || '';
+const renderGitCommit = process.env.RENDER_GIT_COMMIT || '';
+const renderGitBranch = process.env.RENDER_GIT_BRANCH || '';
+const renderServiceName = process.env.RENDER_SERVICE_NAME || '';
 
 const defaultAllowedOrigins = [
   'https://maybenot.com',
@@ -209,6 +212,8 @@ async function handleStripeWebhook(req, res) {
 
 const server = createServer(async (req, res) => {
   const requestOrigin = req.headers.origin || '';
+  const requestUrl = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+  const pathname = requestUrl.pathname.replace(/\/+$/, '') || '/';
   try {
     if (req.method === 'OPTIONS') {
       const responseOrigin = getAllowedOrigin(requestOrigin);
@@ -221,22 +226,25 @@ const server = createServer(async (req, res) => {
       return;
     }
 
-    if (req.method === 'POST' && req.url === '/api/stripe/create-checkout-session') {
+    if (req.method === 'POST' && pathname === '/api/stripe/create-checkout-session') {
       return await handleCreateCheckoutSession(req, res);
     }
 
-    if (req.method === 'POST' && req.url === '/api/stripe/webhook') {
+    if (req.method === 'POST' && pathname === '/api/stripe/webhook') {
       return await handleStripeWebhook(req, res);
     }
 
-    if (req.method === 'GET' && req.url === '/api/stripe/health') {
+    if (req.method === 'GET' && pathname === '/api/stripe/health') {
       return jsonResponse(
         res,
         200,
         {
           ok: true,
           hasStripeSecretKey: Boolean(stripeSecretKey),
-          allowedOrigins
+          allowedOrigins,
+          service: renderServiceName || null,
+          branch: renderGitBranch || null,
+          commit: renderGitCommit || null
         },
         requestOrigin
       );


### PR DESCRIPTION
### Motivation
- Ensure the Render service `maybenot-stripe-api` actually runs the intended server entrypoint and exposes the expected production routes.
- Prevent query string/trailing-slash mismatches from causing 404s by normalizing request paths in the backend router.
- Remove the frontend same-origin fallback that masked deployment misconfiguration and forced checkout to use the configured Render endpoint only.

### Description
- Update `render.yaml` to pin the service to branch `work`, run `node stripe-checkout-server.mjs` as the start command, and set `healthCheckPath: /api/stripe/health`.
- Harden server routing in `stripe-checkout-server.mjs` to parse the request URL pathname, normalize trailing slashes, and ensure the server listens on `process.env.PORT` (with a fallback), and include Render deployment metadata (`service`, `branch`, `commit`) in the `GET /api/stripe/health` response.
- Remove the same-origin fallback from `cart.js` so checkout only uses the configured `checkoutEndpoint` and throw a clear error when the endpoint is not configured.
- Update docs in `STRIPE_CHECKOUT_SETUP.md` to document the blueprint branch, start command, health path, and to expect branch/commit metadata in the health response.

### Testing
- Static checks: `node --check stripe-checkout-server.mjs` and `node --check cart.js` both completed successfully.
- Local runtime smoke test: started the server with `PORT=5050 STRIPE_ALLOWED_ORIGINS='https://maybenot.com' node stripe-checkout-server.mjs` and verified `GET http://127.0.0.1:5050/api/stripe/health` returned `200` with the expected JSON and that `POST /api/stripe/create-checkout-session` returned `500` with `Missing STRIPE_SECRET_KEY.` as the expected guard; these checks passed.
- Live Render verification could not be performed from this environment due to outbound network/proxy restrictions (direct CLI requests to `maybenot-stripe-api.onrender.com` returned `CONNECT ... 403`), so please redeploy the updated blueprint on Render and validate the live `GET /api/stripe/health` and `POST /api/stripe/create-checkout-session` responses (the health response will include `branch` and `commit` to confirm what Render deployed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e130571e688321a7816640259cb928)