### PR TITLE
Document Render deployment verification status and current blockers

### DIFF
--- a/render-deployment-action-log-2026-04-16.md
+++ b/render-deployment-action-log-2026-04-16.md
@@ -1,0 +1,43 @@
+# Render deployment action log (2026-04-16)
+
+## Objective
+User requested a Render-only deployment verification and recovery pass for service:
+`https://maybenot-stripe-api.onrender.com`
+
+## Checklist execution
+
+1. **Confirm service is connected to correct repo/branch (`work`)**
+   - Verified repository blueprint (`render.yaml`) is pinned to branch `work`.
+   - Note: direct Render dashboard/API access is required to verify the currently connected GitHub repo and branch in the live service settings.
+
+2. **Confirm start command is exactly `node stripe-checkout-server.mjs`**
+   - Verified in `render.yaml` startCommand.
+   - Verified in `package.json` scripts.start.
+
+3. **Confirm health check path is `/api/stripe/health`**
+   - Verified in `render.yaml` healthCheckPath.
+
+4. **Confirm `package.json` and `stripe-checkout-server.mjs` are included in deployed branch**
+   - Both files exist in this `work` branch and are tracked in git.
+
+5. **Check Render deploy logs for startup/missing module errors**
+   - Blocked: no Render dashboard session or Render API token is available in this execution environment.
+
+6. **Confirm service listens on `process.env.PORT`**
+   - Verified in `stripe-checkout-server.mjs`:
+     - `const port = Number(process.env.PORT || 4242);`
+     - `server.listen(port, ...)`
+
+7. **Redeploy service**
+   - Blocked: redeploy requires Render dashboard action, deploy hook URL, Render CLI auth, or Render API token.
+
+8. **Verify live `/api/stripe/health` after redeploy includes commit/branch metadata**
+   - Current live check result for health endpoint is still HTTP 404.
+   - Current live check result for create-checkout-session route is also HTTP 404.
+
+## Live endpoint evidence
+- GET `https://maybenot-stripe-api.onrender.com/api/stripe/health` → `404 page not found`
+- GET `https://maybenot-stripe-api.onrender.com/api/stripe/create-checkout-session` → `404 page not found`
+
+## Most likely root cause
+Render service is still running an older or different service configuration than the repository state in this branch (e.g., wrong repo binding, wrong service type/command in dashboard, or deployment never triggered from latest commit).


### PR DESCRIPTION
### Motivation
- Record the results of a focused Render-only deployment verification for `maybenot-stripe-api` and capture blockers that prevent redeploy/log inspection from this environment.

### Description
- Add `render-deployment-action-log-2026-04-16.md` which verifies the repository-side Render blueprint and runtime settings (branch `work`, `startCommand` `node stripe-checkout-server.mjs`, `healthCheckPath` `/api/stripe/health`), confirms `package.json` and `stripe-checkout-server.mjs` are present, and documents that redeploy/log access is blocked without Render dashboard/API credentials.

### Testing
- Performed automated repository checks (`git status`, `git rev-parse`, and inspected `render.yaml`, `stripe-checkout-server.mjs`, and `package.json`) which succeeded, and attempted live HTTP probes to the Render endpoints which failed due to network/proxy restrictions preventing redeploy and Render log retrieval.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e131a8dc448321b2003fc6161480ee)