### PR TITLE
Point Render Stripe API at main and ensure Stripe backend routes are present

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,7 +1,7 @@
 services:
   - type: web
     name: maybenot-stripe-api
-    branch: work
+    branch: main
     runtime: node
     plan: starter
     rootDir: .


### PR DESCRIPTION
### Motivation
- Render was deploying `main` which did not include the latest Stripe backend code, causing the live `/api/stripe/*` endpoints to return 404.
- The repository needs to ensure `main` contains the Stripe server, start script, and client checkout wiring so Render can deploy a working Stripe API service.

### Description
- Updated `render.yaml` to point the `maybenot-stripe-api` service branch to `main` so Render will deploy the branch that contains the Stripe backend.
- Verified `stripe-checkout-server.mjs` exposes `POST /api/stripe/create-checkout-session`, `GET /api/stripe/health`, and the webhook handler, and that the server is started via the `start` script in `package.json` (`node stripe-checkout-server.mjs`).
- Confirmed `cart.js` and `stripe-config.json` include the checkout endpoint wiring and price lookup used by the client.
- Repository `main` HEAD after the change is `adac9dff6e3a523022797cc918b6ea1573df090d`.

### Testing
- `rg -n "api/stripe/(health|create-checkout-session)" stripe-checkout-server.mjs` — passed.
- `rg -n '"start"\s*:\s*"node stripe-checkout-server.mjs"' package.json` — passed.
- `rg -n "checkoutEndpoint|STRIPE_CHECKOUT_ENDPOINT" cart.js stripe-config.json` — passed.
- `node --check stripe-checkout-server.mjs` — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1374ed61083218f9d07eeb61a1bd9)