### PR TITLE
Fix live Stripe frontend config for embedded cart payment form

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -610,7 +610,7 @@
                 <h3>Contact</h3>
                 <button type="button" id="login-btn" onclick="window.location.href='/account/login';">Log in</button>
             </div>
-            <input type="email" name="contact_email" placeholder="Enter an email" required>
+            <input type="email" name="contact_email" placeholder="Enter an email">
             <p class="email-warning empty-cart-message" style="display:none;">Please provide your contact email for this order.</p>
             <h3>Delivery</h3>
             <p>This will also be used as your billing address for this order.</p>

--- a/cart.js
+++ b/cart.js
@@ -37,7 +37,7 @@ const defaultPriceLookup = {
 };
 
 const defaultStripeSettings = {
-    publishableKey: window.STRIPE_PUBLISHABLE_KEY || 'pk_test_REPLACE_WITH_YOUR_PUBLISHABLE_KEY',
+    publishableKey: window.STRIPE_PUBLISHABLE_KEY || '',
     successUrl: window.STRIPE_SUCCESS_URL || `${window.location.origin}/success.html`,
     cancelUrl: window.STRIPE_CANCEL_URL || `${window.location.origin}/cart.html`,
     checkoutEndpoint: window.STRIPE_CHECKOUT_ENDPOINT || '',
@@ -72,6 +72,18 @@ function buildStripeLookupAliasMap() {
 }
 
 const stripeLookupAliasMap = buildStripeLookupAliasMap();
+const activeStripeProductKeys = new Set(Object.keys(defaultPriceLookup));
+
+function filterActivePriceLookup(config = {}) {
+    return Object.entries(config).reduce((lookup, [rawKey, value]) => {
+        if (typeof value !== 'string' || !value) return lookup;
+        const canonicalKey = canonicalizeStripeProductKey(rawKey);
+        if (!canonicalKey || !activeStripeProductKeys.has(canonicalKey)) return lookup;
+        lookup[canonicalKey] = value;
+        return lookup;
+    }, {});
+}
+
 
 function normalizeCheckoutUrl(url, fallback) {
     if (typeof url !== 'string' || !url.trim()) return fallback;
@@ -138,8 +150,8 @@ function applyStripeSettings(overrides = {}) {
     );
     stripeSettings.priceLookup = {
         ...defaultPriceLookup,
-        ...normalizePriceLookupMap(overrides.priceLookup || {}),
-        ...normalizePriceLookupMap(window.STRIPE_PRICE_LOOKUP || {})
+        ...filterActivePriceLookup(overrides.priceLookup || {}),
+        ...filterActivePriceLookup(window.STRIPE_PRICE_LOOKUP || {})
     };
 }
 
@@ -243,7 +255,10 @@ function loadStripeJs() {
 
 async function getStripe() {
     if (!stripeSettings.publishableKey || stripeSettings.publishableKey.includes('REPLACE')) {
-        throw new Error('Stripe is not configured. Please set STRIPE_PUBLISHABLE_KEY and STRIPE_PRICE_LOOKUP.');
+        throw new Error('Stripe is not configured. Please set a live STRIPE_PUBLISHABLE_KEY and STRIPE_PRICE_LOOKUP.');
+    }
+    if (stripeSettings.publishableKey.startsWith('pk_test_')) {
+        throw new Error('Stripe publishable key is in test mode. Configure a live pk_live_ key to match production checkout.');
     }
     await loadStripeJs();
     if (!window.Stripe) {
@@ -858,7 +873,7 @@ function createCartModal() {
                         <h3>Contact</h3>
                         <button type="button" id="login-btn" onclick="window.location.href='/account/login';">Log in</button>
                     </div>
-                    <input type="email" name="contact_email" placeholder="Enter an email" required>
+                    <input type="email" name="contact_email" placeholder="Enter an email">
                     <p class="email-warning empty-cart-message" style="display:none;">Please provide your contact email for this order.</p>
                     <h3>Delivery</h3>
                     <p>This will also be used as your billing address for this order.</p>
@@ -1546,11 +1561,6 @@ function setupFinalForm(form) {
             if (cardWarning) cardWarning.style.display = 'none';
         } else if (cardWarning) {
             cardWarning.style.display = 'none';
-        }
-        if (emailInput && emailInput.value.trim() === '') {
-            if (emailWarning) emailWarning.style.display = 'block';
-            firstInvalid = firstInvalid || emailInput;
-            valid = false;
         }
         if (!valid) {
             highlightField(firstInvalid);

--- a/stripe-config.json
+++ b/stripe-config.json
@@ -1,5 +1,5 @@
 {
-  "publishableKey": "${STRIPE_PUBLISHABLE_KEY}",
+  "publishableKey": "pk_live_51TMeEa6vAbsTB4QVTasJRtaEMgTI683GLL2rPYlW8rlJpq6f2YtReDI339OBuwgbSiEDNieWPzYiIkunzjeD4sJb006WwAL9eH",
   "checkoutEndpoint": "https://maybenot-stripe-api.onrender.com/api/stripe/create-checkout-session",
   "successUrl": "/success.html",
   "cancelUrl": "/cart.html",


### PR DESCRIPTION
### Motivation
- The on-page embedded payment form failed to initialize due to missing frontend Stripe configuration and placeholder fallbacks, causing users to see "Loading secure payment form..." and an error about missing STRIPE config. 
- Ensure the frontend uses a real live publishable key and only active product price IDs so line-item lookup succeeds. 
- Allow the Stripe Payment Element to collect required contact details without blocking the payment flow by making contact email optional in the form.

### Description
- Set the real live publishable key in `stripe-config.json` by adding the provided `pk_live_...` value so frontend config is resolved at runtime. (`stripe-config.json`)
- Add `filterActivePriceLookup` and `activeStripeProductKeys` in `cart.js` and use them in `applyStripeSettings` so `STRIPE_PRICE_LOOKUP` is filtered to active storefront product keys before mapping line items. (`cart.js`)
- Remove the test-key fallback and make the default publishable fallback empty, and add an explicit guard that rejects `pk_test_` keys at runtime to avoid mixed test/live usage. (`cart.js`, function `getStripe`)
- Make contact email optional by removing the HTML `required` attribute and removing the submit-time blocking check that prevented payment when email was empty, allowing the Payment Element/Stripe flow to collect necessary details. (`cart.html`, `cart.js`)
- Kept all embedded Payment Element initialization and server endpoints unchanged (`https://js.stripe.com/v3`, `elements.create('payment')`, and `/api/stripe/create-payment-intent`), and preserved server-side-only handling of `STRIPE_SECRET_KEY`.

### Testing
- Ran `node --check cart.js` which completed successfully. 
- Validated JSON in `stripe-config.json` with `python -m json.tool stripe-config.json` which passed. 
- Confirmed code changes and presence of key markers with `rg` searches such as `rg -n "pk_live_51TMeEa6|filterActivePriceLookup|pk_test_|name=\"contact_email\" placeholder=\"Enter an email\"" cart.js cart.html stripe-config.json` which returned the expected matches. 
- Confirmed the Stripe-related runtime paths remain present with `rg` for `create-payment-intent`, `create-checkout-session`, `js.stripe.com/v3`, and `elements.create('payment')`, all of which were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14a670a808321b8b1f32febe07615)