### PR TITLE
Require contact email only for card payments

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -1387,6 +1387,8 @@ function setupFinalForm(form) {
     const emailInput = form.querySelector('input[name="contact_email"]');
     const emailWarning = form.querySelector('.email-warning');
     const creditRadio = form.querySelector('input[name="payment-method"][value="credit"]');
+    const getSelectedPaymentMethod = () => form.querySelector('input[name="payment-method"]:checked')?.value;
+    const requiresContactEmail = () => getSelectedPaymentMethod() === 'credit';
     const addressInputs = form.querySelectorAll('input[name="first_name"], input[name="last_name"], input[name="address"], input[name="city"], input[name="state"], input[name="zip"]');
     const fieldWarnings = {};
     form.querySelectorAll('.field-warning').forEach(p => { fieldWarnings[p.dataset.field] = p; });
@@ -1397,6 +1399,8 @@ function setupFinalForm(form) {
     form.querySelectorAll('input[name="payment-method"]').forEach(input => {
         input.addEventListener('change', () => {
             paymentMsg.innerHTML = '';
+            if (emailInput) emailInput.required = requiresContactEmail();
+            if (!requiresContactEmail() && emailWarning) emailWarning.style.display = 'none';
             if (creditFields) {
                 creditFields.style.display = input.value === 'credit' ? 'block' : 'none';
                 if (input.value !== 'credit' && cardWarning) cardWarning.style.display = 'none';
@@ -1434,6 +1438,7 @@ function setupFinalForm(form) {
         if (warn) warn.style.display = 'none';
     }));
     if (emailInput) {
+        emailInput.required = requiresContactEmail();
         emailInput.addEventListener('input', () => {
             if (emailWarning) emailWarning.style.display = 'none';
         });

--- a/checkout.html
+++ b/checkout.html
@@ -797,7 +797,7 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
         const payBtn = document.getElementById('final-order-submit');
         const paymentMsg = document.getElementById('payment-message');
 
-        const getSelectedPaymentMethod = () => document.querySelector('input[name="payment-method"]:checked')?.value || 'credit';
+        const getSelectedPaymentMethod = () => document.querySelector('input[name="payment-method"]:checked')?.value;
         const requiresContactEmail = () => getSelectedPaymentMethod() === 'credit';
 
 


### PR DESCRIPTION
### Motivation
- The checkout was forcing contact details for non-card payment flows because the payment-method selector defaulted to `credit`, causing an unnecessary `required` for `contact_email`.
- The intent is to only mandate contact email when the user explicitly selects the Credit card payment method.

### Description
- Removed the implicit fallback to `'credit'` in `checkout.html` by changing `getSelectedPaymentMethod` to return the actual selected value (no default).
- In `cart.js` added a per-form `getSelectedPaymentMethod` and `requiresContactEmail` helpers and wired them to toggle `emailInput.required` and hide the email warning when a non-card method is chosen.
- Ensured the cart modal final checkout form sets the initial `required` state for `contact_email` and updates it on payment-method changes.

### Testing
- Ran `node --check cart.js` to validate there are no JavaScript syntax errors and it succeeded.
- Committed the updated `checkout.html` and `cart.js` and verified the local changes applied without script errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14e9139088321a929aeeb60b1531b)