### PR TITLE
Require customer email on checkout and attach it to Stripe flows

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -216,23 +216,23 @@ const unsupportedMethodNotices = {
 };
 
 const paymentHandlers = {
-    'Shop Pay': () => startStripeCheckout('Shop Pay'),
-    'Apple Pay': () => startStripeCheckout('Apple Pay'),
-    'PayPal': () => startStripeCheckout('PayPal'),
-    'Google Pay': () => startStripeCheckout('Google Pay'),
-    'Klarna': () => startStripeCheckout('Klarna'),
-    'Venmo': () => startStripeCheckout('Venmo'),
-    Stripe: () => startStripeCheckout('Stripe')
+    'Shop Pay': (customerEmail) => startStripeCheckout('Shop Pay', customerEmail),
+    'Apple Pay': (customerEmail) => startStripeCheckout('Apple Pay', customerEmail),
+    'PayPal': (customerEmail) => startStripeCheckout('PayPal', customerEmail),
+    'Google Pay': (customerEmail) => startStripeCheckout('Google Pay', customerEmail),
+    'Klarna': (customerEmail) => startStripeCheckout('Klarna', customerEmail),
+    'Venmo': (customerEmail) => startStripeCheckout('Venmo', customerEmail),
+    Stripe: (customerEmail) => startStripeCheckout('Stripe', customerEmail)
 };
 
-async function handlePayment(method) {
+async function handlePayment(method, customerEmail = '') {
     const handler = paymentHandlers[method];
     if (!handler) {
         alert(`${method} payment not implemented.`);
         return;
     }
     try {
-        await handler();
+        await handler(customerEmail);
     } catch (err) {
         alert(err.message || `${method} payment failed.`);
     }
@@ -327,11 +327,12 @@ async function postCheckoutSession(endpoint, payload) {
     });
 }
 
-async function startServerCheckout(method, lineItems) {
+async function startServerCheckout(method, lineItems, customerEmail = '') {
     const requestPayload = {
         method,
         lineItems,
         cart,
+        customerEmail,
         successUrl: stripeSettings.successUrl,
         cancelUrl: stripeSettings.cancelUrl
     };
@@ -472,8 +473,12 @@ async function ensureEmbeddedPaymentReady(form) {
     if (missing.length) {
         throw new Error(`Stripe price IDs missing for: ${missing.join(', ')}.`);
     }
+    const contactEmail = form.querySelector('input[name="contact_email"]')?.value?.trim() || '';
+    if (!contactEmail) {
+        throw new Error('Please provide your contact email for this order.');
+    }
 
-    const lineItemsSignature = JSON.stringify(lineItems);
+    const lineItemsSignature = JSON.stringify({ lineItems, contactEmail: contactEmail.toLowerCase() });
     const shouldReuse = (
         stripeEmbeddedState.elements &&
         stripeEmbeddedState.lineItemsSignature === lineItemsSignature &&
@@ -488,7 +493,7 @@ async function ensureEmbeddedPaymentReady(form) {
     const intentResponse = await fetch(paymentIntentEndpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ lineItems, cart })
+        body: JSON.stringify({ lineItems, cart, customerEmail: contactEmail })
     });
     const intentPayload = await intentResponse.json().catch(() => ({}));
     if (!intentResponse.ok || !intentPayload.clientSecret) {
@@ -547,7 +552,7 @@ async function submitEmbeddedPayment(form, paymentMsg) {
     window.location.assign(successUrl.toString());
 }
 
-async function startStripeCheckout(method = 'Stripe') {
+async function startStripeCheckout(method = 'Stripe', customerEmail = '') {
     if (!cart.length) {
         alert('Your cart is empty.');
         return;
@@ -572,7 +577,7 @@ async function startStripeCheckout(method = 'Stripe') {
 
     if (stripeSettings.checkoutEndpoint) {
         try {
-            await startServerCheckout(method, lineItems);
+            await startServerCheckout(method, lineItems, customerEmail);
             return;
         } catch (err) {
             alert(err.message || 'Unable to start server-side checkout.');
@@ -1399,11 +1404,11 @@ function setupFinalForm(form) {
     form.querySelectorAll('input[name="payment-method"]').forEach(input => {
         input.addEventListener('change', () => {
             paymentMsg.innerHTML = '';
-            if (emailInput) emailInput.required = requiresContactAndDeliveryDetails();
+            if (emailInput) emailInput.required = true;
             addressInputs.forEach(field => {
                 field.required = requiresContactAndDeliveryDetails();
             });
-            if (!requiresContactAndDeliveryDetails() && emailWarning) emailWarning.style.display = 'none';
+            if (emailWarning) emailWarning.style.display = 'none';
             if (creditFields) {
                 creditFields.style.display = input.value === 'credit' ? 'block' : 'none';
                 if (input.value !== 'credit' && cardWarning) cardWarning.style.display = 'none';
@@ -1441,7 +1446,7 @@ function setupFinalForm(form) {
         if (warn) warn.style.display = 'none';
     }));
     if (emailInput) {
-        emailInput.required = requiresContactAndDeliveryDetails();
+        emailInput.required = true;
         emailInput.addEventListener('input', () => {
             if (emailWarning) emailWarning.style.display = 'none';
         });
@@ -1550,6 +1555,14 @@ function setupFinalForm(form) {
         e.preventDefault();
         let valid = true;
         let firstInvalid = null;
+        const contactEmail = emailInput ? emailInput.value.trim() : '';
+        if (!contactEmail) {
+            if (emailWarning) emailWarning.style.display = 'block';
+            firstInvalid = firstInvalid || emailInput;
+            valid = false;
+        } else if (emailWarning) {
+            emailWarning.style.display = 'none';
+        }
         if (remember && remember.checked && phoneInput && phoneInput.value.trim() === '') {
             if (warn) warn.style.display = 'block';
             firstInvalid = firstInvalid || phoneInput;
@@ -1600,7 +1613,7 @@ function setupFinalForm(form) {
             shop: 'Shop Pay',
             klarna: 'Klarna'
         };
-        handlePayment(methodMap[selectedPayment] || 'Stripe');
+        handlePayment(methodMap[selectedPayment] || 'Stripe', contactEmail);
         const modal = form.closest('#cart-modal');
         if (modal) {
             closeCart();

--- a/stripe-checkout-server.mjs
+++ b/stripe-checkout-server.mjs
@@ -90,6 +90,9 @@ function toFormBody(params) {
   form.append('mode', params.mode);
   form.append('success_url', params.success_url);
   form.append('cancel_url', params.cancel_url);
+  if (params.customer_email) {
+    form.append('customer_email', params.customer_email);
+  }
   return form;
 }
 
@@ -177,12 +180,19 @@ async function handleCreateCheckoutSession(req, res) {
 
   const successUrl = typeof body.successUrl === 'string' && body.successUrl ? body.successUrl : defaultSuccessUrl;
   const cancelUrl = typeof body.cancelUrl === 'string' && body.cancelUrl ? body.cancelUrl : defaultCancelUrl;
+  const customerEmail = typeof body.customerEmail === 'string' ? body.customerEmail.trim().toLowerCase() : '';
+  if (!customerEmail) {
+    return jsonResponse(res, 400, { error: 'customerEmail is required.' }, requestOrigin);
+  }
 
   const payload = {
     line_items: lineItems,
     mode: 'payment',
-    success_url: successUrl,
-    cancel_url: cancelUrl
+    success_url: successUrl.includes('?')
+      ? `${successUrl}&session_id={CHECKOUT_SESSION_ID}`
+      : `${successUrl}?session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: cancelUrl,
+    customer_email: customerEmail
   };
 
   try {
@@ -251,6 +261,10 @@ async function handleCreatePaymentIntent(req, res) {
       requestOrigin
     );
   }
+  const customerEmail = typeof body.customerEmail === 'string' ? body.customerEmail.trim().toLowerCase() : '';
+  if (!customerEmail) {
+    return jsonResponse(res, 400, { error: 'customerEmail is required.' }, requestOrigin);
+  }
 
   try {
     const priceCache = new Map();
@@ -284,6 +298,8 @@ async function handleCreatePaymentIntent(req, res) {
     params.set('amount', String(amount));
     params.set('currency', currency);
     params.set('automatic_payment_methods[enabled]', 'true');
+    params.set('receipt_email', customerEmail);
+    params.set('metadata[customer_email]', customerEmail);
 
     const paymentIntent = await stripeApiRequest('/v1/payment_intents', {
       method: 'POST',

--- a/success.html
+++ b/success.html
@@ -29,10 +29,18 @@
 </head>
 <body>
     <h1>Thanks for your order!</h1>
-    <p>Your payment was received successfully. Check your email for a receipt and order details.</p>
+    <p>Your payment was received successfully. A confirmation email was sent to the address you entered at checkout.</p>
+    <p id="order-reference" style="font-weight:bold;"></p>
     <div class="actions">
         <a href="shop.html">Continue shopping</a>
         <a href="contact.html">Contact support</a>
     </div>
+    <script>
+        const params = new URLSearchParams(window.location.search);
+        const orderRef = params.get('session_id') || params.get('payment_intent');
+        if (orderRef) {
+            document.getElementById('order-reference').textContent = `Order reference: ${orderRef}`;
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Ensure every completed order includes a customer email so Stripe sends a receipt and the store can reference the order for follow-up.
- Prevent checkout/payment initialization when the customer email is missing to avoid orders without contact information.

### Description
- Require `contact_email` on the final checkout form and surface a validation error if it's empty, making the email required for all payment methods (not only credit card); changes applied in `cart.js` (`setupFinalForm` and form submit flow).
- Thread customer email through client-side checkout functions by adding a `customerEmail` argument to `startStripeCheckout`, `startServerCheckout`, `handlePayment`, and payment handler entries in `cart.js` so non-credit payment flows also send the email.
- Require and pass the contact email when creating a PaymentIntent from the Payment Element flow (`ensureEmbeddedPaymentReady` now blocks when email missing and passes `customerEmail` to the server) and include it in the PaymentIntent request as `receipt_email` and `metadata[customer_email]` in `stripe-checkout-server.mjs`.
- Require `customerEmail` for server-created Checkout Sessions and set `customer_email` on the session while also appending `session_id={CHECKOUT_SESSION_ID}` to the success URL so the session ID is returned to `success.html` in the redirect (`stripe-checkout-server.mjs`).
- Update `success.html` text and add a bold `Order reference` that displays either `session_id` or `payment_intent` from the URL query so customers see a reference number after payment.

### Testing
- Ran JavaScript syntax checks: `node --check cart.js` succeeded. 
- Ran JavaScript syntax checks: `node --check stripe-checkout-server.mjs` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e16270045883218318c7420735240a)