### PR TITLE
Only require email for card checkout, verify Stripe returns, and update success page layout

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -1404,7 +1404,7 @@ function setupFinalForm(form) {
     form.querySelectorAll('input[name="payment-method"]').forEach(input => {
         input.addEventListener('change', () => {
             paymentMsg.innerHTML = '';
-            if (emailInput) emailInput.required = true;
+            if (emailInput) emailInput.required = requiresContactAndDeliveryDetails();
             addressInputs.forEach(field => {
                 field.required = requiresContactAndDeliveryDetails();
             });
@@ -1446,7 +1446,7 @@ function setupFinalForm(form) {
         if (warn) warn.style.display = 'none';
     }));
     if (emailInput) {
-        emailInput.required = true;
+        emailInput.required = requiresContactAndDeliveryDetails();
         emailInput.addEventListener('input', () => {
             if (emailWarning) emailWarning.style.display = 'none';
         });
@@ -1555,8 +1555,9 @@ function setupFinalForm(form) {
         e.preventDefault();
         let valid = true;
         let firstInvalid = null;
+        const requiresDetails = requiresContactAndDeliveryDetails();
         const contactEmail = emailInput ? emailInput.value.trim() : '';
-        if (!contactEmail) {
+        if (requiresDetails && !contactEmail) {
             if (emailWarning) emailWarning.style.display = 'block';
             firstInvalid = firstInvalid || emailInput;
             valid = false;
@@ -1568,7 +1569,7 @@ function setupFinalForm(form) {
             firstInvalid = firstInvalid || phoneInput;
             valid = false;
         }
-        if (requiresContactAndDeliveryDetails()) {
+        if (requiresDetails) {
             addressInputs.forEach(inp => {
                 const fw = fieldWarnings[inp.name];
                 if (inp.value.trim() === '') {

--- a/stripe-checkout-server.mjs
+++ b/stripe-checkout-server.mjs
@@ -90,6 +90,9 @@ function toFormBody(params) {
   form.append('mode', params.mode);
   form.append('success_url', params.success_url);
   form.append('cancel_url', params.cancel_url);
+  if (params.customer_creation) {
+    form.append('customer_creation', params.customer_creation);
+  }
   if (params.customer_email) {
     form.append('customer_email', params.customer_email);
   }
@@ -181,9 +184,6 @@ async function handleCreateCheckoutSession(req, res) {
   const successUrl = typeof body.successUrl === 'string' && body.successUrl ? body.successUrl : defaultSuccessUrl;
   const cancelUrl = typeof body.cancelUrl === 'string' && body.cancelUrl ? body.cancelUrl : defaultCancelUrl;
   const customerEmail = typeof body.customerEmail === 'string' ? body.customerEmail.trim().toLowerCase() : '';
-  if (!customerEmail) {
-    return jsonResponse(res, 400, { error: 'customerEmail is required.' }, requestOrigin);
-  }
 
   const payload = {
     line_items: lineItems,
@@ -192,6 +192,7 @@ async function handleCreateCheckoutSession(req, res) {
       ? `${successUrl}&session_id={CHECKOUT_SESSION_ID}`
       : `${successUrl}?session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: cancelUrl,
+    customer_creation: 'always',
     customer_email: customerEmail
   };
 
@@ -222,6 +223,41 @@ async function handleCreateCheckoutSession(req, res) {
     );
   } catch (error) {
     return jsonResponse(res, 500, { error: error.message || 'Unable to create checkout session.' }, requestOrigin);
+  }
+}
+
+async function handleVerifyReturn(req, res, requestUrl) {
+  const requestOrigin = req.headers.origin || '';
+  if (!stripeSecretKey) {
+    return jsonResponse(res, 500, { error: 'Missing STRIPE_SECRET_KEY.' }, requestOrigin);
+  }
+
+  const sessionId = (requestUrl.searchParams.get('session_id') || '').trim();
+  const paymentIntentId = (requestUrl.searchParams.get('payment_intent') || '').trim();
+  if (!sessionId && !paymentIntentId) {
+    return jsonResponse(res, 400, { error: 'session_id or payment_intent is required.' }, requestOrigin);
+  }
+
+  try {
+    if (sessionId) {
+      const session = await stripeApiRequest(`/v1/checkout/sessions/${encodeURIComponent(sessionId)}`);
+      const paid = session.payment_status === 'paid' || session.status === 'complete';
+      const email = session.customer_details?.email || session.customer_email || '';
+      return jsonResponse(res, 200, { paid, source: 'checkout_session', id: session.id, email }, requestOrigin);
+    }
+
+    const paymentIntent = await stripeApiRequest(`/v1/payment_intents/${encodeURIComponent(paymentIntentId)}`);
+    const paidStatuses = new Set(['succeeded', 'processing', 'requires_capture']);
+    const paid = paidStatuses.has(String(paymentIntent.status || '').toLowerCase());
+    const email = paymentIntent.receipt_email || paymentIntent.metadata?.customer_email || '';
+    return jsonResponse(
+      res,
+      200,
+      { paid, source: 'payment_intent', id: paymentIntent.id, status: paymentIntent.status, email },
+      requestOrigin
+    );
+  } catch (error) {
+    return jsonResponse(res, 500, { error: error.message || 'Unable to verify Stripe return status.' }, requestOrigin);
   }
 }
 
@@ -347,6 +383,10 @@ const server = createServer(async (req, res) => {
 
     if (req.method === 'POST' && pathname === '/api/stripe/webhook') {
       return await handleStripeWebhook(req, res);
+    }
+
+    if (req.method === 'GET' && pathname === '/api/stripe/verify-return') {
+      return await handleVerifyReturn(req, res, requestUrl);
     }
 
     if (req.method === 'GET' && pathname === '/api/stripe/health') {

--- a/success.html
+++ b/success.html
@@ -16,8 +16,47 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-            justify-content: center;
             text-align: center;
+        }
+        .header-container {
+            width: 100%;
+            padding: 10px 10px 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+        }
+        .logo-container {
+            position: relative;
+            width: 20vw;
+            height: 15vh;
+            min-width: 90px;
+            min-height: 70px;
+        }
+        .logo-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            cursor: pointer;
+            z-index: 10;
+        }
+        .logo-container iframe {
+            width: 100%;
+            height: 100%;
+            border: none;
+        }
+        .header-line {
+            border-top: 1px solid #000;
+            width: 100%;
+            margin-top: 6px;
+        }
+        .success-content {
+            width: 100%;
+            max-width: 520px;
+            padding: 20px;
+            margin: auto 0;
         }
         h1 { margin-bottom: 10px; }
         p { max-width: 420px; line-height: 1.4; }
@@ -25,22 +64,98 @@
         .actions { margin-top: 20px; display: flex; gap: 15px; flex-wrap: wrap; justify-content: center; }
         .actions a { padding: 10px 14px; border: 1px solid #000; background: #fff; }
         .actions a:hover { background: red; color: #fff; }
+        .full-site-link {
+            margin: 20px 0 30px;
+        }
     </style>
 </head>
 <body>
-    <h1>Thanks for your order!</h1>
-    <p>Your payment was received successfully. A confirmation email was sent to the address you entered at checkout.</p>
-    <p id="order-reference" style="font-weight:bold;"></p>
-    <div class="actions">
-        <a href="shop.html">Continue shopping</a>
-        <a href="contact.html">Contact support</a>
+    <header class="header-container">
+        <div class="logo-container">
+            <iframe
+                id="logo-frame"
+                src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1"
+                frameborder="0"
+                aria-label="Maybe Not logo"
+            ></iframe>
+            <div class="logo-overlay" aria-hidden="true"></div>
+        </div>
+        <div class="header-line"></div>
+    </header>
+    <main class="success-content">
+        <h1>Thanks for your order!</h1>
+        <p id="confirmation-message">Verifying your payment status…</p>
+        <p id="order-reference" style="font-weight:bold;"></p>
+        <div class="actions">
+            <a href="shop.html">Continue shopping</a>
+            <a href="contact.html">Contact support</a>
+        </div>
+    </main>
+    <div class="full-site-link" id="full-site-link">
+        <a href="index.html">View Full Site</a>
     </div>
     <script>
         const params = new URLSearchParams(window.location.search);
-        const orderRef = params.get('session_id') || params.get('payment_intent');
-        if (orderRef) {
-            document.getElementById('order-reference').textContent = `Order reference: ${orderRef}`;
+        const sessionId = params.get('session_id');
+        const paymentIntentId = params.get('payment_intent');
+        const reference = sessionId || paymentIntentId;
+        const confirmationMessage = document.getElementById('confirmation-message');
+        const orderReference = document.getElementById('order-reference');
+
+        function getCheckoutApiBase(checkoutEndpoint) {
+            if (!checkoutEndpoint) return '';
+            try {
+                const parsed = new URL(checkoutEndpoint, window.location.origin);
+                return parsed.origin;
+            } catch (_) {
+                return '';
+            }
         }
+
+        async function loadStripeConfig() {
+            try {
+                const response = await fetch('stripe-config.json', { cache: 'no-store' });
+                if (!response.ok) return {};
+                return await response.json();
+            } catch (_) {
+                return {};
+            }
+        }
+
+        async function verifyAndRender() {
+            if (!reference) {
+                window.location.replace('cart.html');
+                return;
+            }
+
+            const config = await loadStripeConfig();
+            const apiBase = getCheckoutApiBase(config.checkoutEndpoint || '');
+            if (!apiBase) {
+                window.location.replace('cart.html');
+                return;
+            }
+
+            const verifyUrl = new URL('/api/stripe/verify-return', apiBase);
+            if (sessionId) verifyUrl.searchParams.set('session_id', sessionId);
+            if (paymentIntentId) verifyUrl.searchParams.set('payment_intent', paymentIntentId);
+
+            try {
+                const response = await fetch(verifyUrl.toString(), { credentials: 'omit' });
+                const payload = await response.json().catch(() => ({}));
+                if (!response.ok || !payload.paid) {
+                    window.location.replace('cart.html');
+                    return;
+                }
+
+                const emailNote = payload.email ? ` A confirmation email was sent to ${payload.email}.` : '';
+                confirmationMessage.textContent = `Your payment was received successfully.${emailNote}`;
+                orderReference.textContent = `Order reference: ${payload.id || reference}`;
+            } catch (_) {
+                window.location.replace('cart.html');
+            }
+        }
+
+        verifyAndRender();
     </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Stop requiring the on-site contact email when customers use express payment buttons (Shop Pay / Klarna / PayPal / etc.) so users can jump straight into hosted Stripe checkout without friction.
- Ensure the site does not show a false order confirmation when customers cancel or fail to complete Stripe Checkout and are returned to the site.
- Let Stripe collect customer email in hosted checkout and preserve the ability to capture that email when present.
- Align the success/thanks page layout with the requested centered header logo and move the “View Full Site” link to the bottom.

### Description
- Updated `cart.js` so the contact email and delivery fields are only required when the selected payment method is the credit-card path (the credit flow); express payment methods no longer force `contact_email` to be prefilled or required (`emailInput.required = requiresContactAndDeliveryDetails()` and form submit checks use `requiresContactAndDeliveryDetails()`).
- Changed server-side checkout session creation in `stripe-checkout-server.mjs` to stop rejecting empty `customerEmail`, to include `customer_creation=always` in the Checkout Session form body, and to append that parameter when creating a session so Stripe may collect the customer email in hosted checkout.
- Added a new backend verification route `GET /api/stripe/verify-return` in `stripe-checkout-server.mjs` that accepts a `session_id` or `payment_intent` and returns whether the payment is actually paid plus any email available from Stripe.
- Reworked `success.html` to center the main logo in a top header, add a bottom `View Full Site` link, and perform verification on load by calling the new `/api/stripe/verify-return` endpoint; if verification fails or the payment is not paid the page redirects to `cart.html`, otherwise it shows the confirmed reference and email when available.

### Testing
- Ran `node --check cart.js && node --check stripe-checkout-server.mjs` and both files passed JavaScript syntax checks (success).
- Attempted HTML validation with `xmllint --html --noout success.html` but `xmllint` is not available in the environment (tool missing) so only manual inspection was done for `success.html` behavior and script logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e253871774832187f1a01eef2ca5ab)