### PR TITLE
Update site seasonal timeline copy to Summer 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,8 +271,8 @@
     <nav class="desktop-nav">
         <ul>
             <li><a href="news.html">news</a></li> <!-- Fix for first link hover -->
-            <li><a href="soon.html">winter 2025 preview</a></li>
-            <li><a href="soon.html">winter 2025 lookbook</a></li>
+            <li><a href="soon.html">Summer 2026 preview</a></li>
+            <li><a href="soon.html">Summer 2026 lookbook</a></li>
             <li><a href="shop.html">shop</a></li>
             <li><a href="random.html">random</a></li>
             <li><a href="about.html">about</a></li>

--- a/mailinglist.html
+++ b/mailinglist.html
@@ -53,7 +53,7 @@
 </header>
 <main>
     <h1>mailing list</h1>
-    <p>Our webstore is currently closed and will reopen soon with our Fall/Winter 2025 collection.</p>
+    <p>Our webstore is currently closed and will reopen soon with our Summer 2026 collection.</p>
     <p>For information regarding future news and releases, please sign up for our mailing list below.</p>
     <p>Name is optional. Submit your email or your mobile phone number.</p>
     <form>

--- a/news.html
+++ b/news.html
@@ -46,8 +46,8 @@
 <main>
     <h1>news</h1>
     <div class="news-item">
-        <h2>fall/winter 2025 drop incoming</h2>
-        <p>10/01/2025 – First delivery of the season lands soon.</p>
+        <h2>Summer 2026 drop incoming</h2>
+        <p>06/2026 – First delivery of the season lands soon.</p>
     </div>
     <div class="news-item">
         <h2>pop-up recap</h2>


### PR DESCRIPTION
### Motivation
- Remove outdated "winter 2025" / "Fall/Winter 2025" references and update the site timeline and promotional copy to reflect the upcoming Summer 2026 season.

### Description
- Replaced the homepage desktop nav labels `winter 2025 preview` and `winter 2025 lookbook` with `Summer 2026 preview` and `Summer 2026 lookbook` in `index.html`.
- Updated the news headline to `Summer 2026 drop incoming` and changed the delivery line to `06/2026` in `news.html`.
- Changed the mailing list copy from `Fall/Winter 2025 collection` to `Summer 2026 collection` in `mailinglist.html`.

### Testing
- Ran a targeted search with `rg -n "winter 2025|Winter 2025|Fall/Winter 2025|fall/winter 2025" index.html news.html mailinglist.html` which returned no remaining matches in the updated pages.
- Inspected the updated files with `nl -ba index.html news.html mailinglist.html` to verify the new lines are present and correctly rendered, which confirmed the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e25698369c8321ad149353d295b7ff)