### PR TITLE
Lowercase summer labels and re-enable secure Stripe card element on checkout

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -370,6 +370,20 @@
         .credit-card-fields input {
             width: 100%;
         }
+        .stripe-payment-element {
+            width: 100%;
+            min-height: 52px;
+            padding: 10px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            box-sizing: border-box;
+            background: #fff;
+        }
+        .stripe-payment-status {
+            margin-top: 8px;
+            font-size: 0.8rem;
+            text-align: left;
+        }
         .payment-option {
             display: flex;
             align-items: center;
@@ -606,16 +620,10 @@
                 </label>
             </div>
             <div class="credit-card-fields" style="display:none;">
-                <input type="text" name="card_number" placeholder="Enter a card number">
-                <p class="field-warning empty-cart-message" data-field="card_number" style="display:none;">Please enter a card number.</p>
-                <input type="text" name="exp_date" placeholder="Enter a valid expiration date">
-                <p class="field-warning empty-cart-message" data-field="exp_date" style="display:none;">Please enter an expiration date.</p>
-                <input type="text" name="cvv" placeholder="Enter the CVV or security code on your card">
-                <p class="field-warning empty-cart-message" data-field="cvv" style="display:none;">Please enter the CVV or security code.</p>
-                <input type="text" name="card_name" placeholder="Enter your name exactly as it’s written on your card">
-                <p class="field-warning empty-cart-message" data-field="card_name" style="display:none;">Please enter the name on your card.</p>
+                <div class="stripe-payment-element" aria-label="Secure payment form"></div>
+                <p class="stripe-payment-status"></p>
             </div>
-            <p class="card-warning empty-cart-message" style="display:none;">Please fill out credit card details.</p>
+            <p class="card-warning empty-cart-message" style="display:none;">Please complete your secure payment details.</p>
             <div class="payment-option">
                 <input type="radio" name="payment-method" id="pay-apple" value="apple">
                 <label for="pay-apple">

--- a/index.html
+++ b/index.html
@@ -271,8 +271,8 @@
     <nav class="desktop-nav">
         <ul>
             <li><a href="news.html">news</a></li> <!-- Fix for first link hover -->
-            <li><a href="soon.html">Summer 2026 preview</a></li>
-            <li><a href="soon.html">Summer 2026 lookbook</a></li>
+            <li><a href="soon.html">summer 2026 preview</a></li>
+            <li><a href="soon.html">summer 2026 lookbook</a></li>
             <li><a href="shop.html">shop</a></li>
             <li><a href="random.html">random</a></li>
             <li><a href="about.html">about</a></li>

--- a/news.html
+++ b/news.html
@@ -46,7 +46,7 @@
 <main>
     <h1>news</h1>
     <div class="news-item">
-        <h2>Summer 2026 drop incoming</h2>
+        <h2>summer 2026 drop incoming</h2>
         <p>06/2026 – First delivery of the season lands soon.</p>
     </div>
     <div class="news-item">


### PR DESCRIPTION
### Motivation
- Normalize visible copy to all-lowercase `summer` labels on the index and news pages for brand/consistency.
- Restore secure credit-card entry on the checkout page by re-enabling the Stripe Payment Element mount point so the embedded, PCI-compliant form can initialize again.

### Description
- Updated desktop navigation links in `index.html` to `summer 2026 preview` and `summer 2026 lookbook`.
- Updated the news headline in `news.html` to `summer 2026 drop incoming`.
- Replaced the plain-text credit card inputs in `checkout.html` with a mount container `<div class="stripe-payment-element">` and a `<p class="stripe-payment-status">` for the Stripe Payment Element.
- Added CSS for `.stripe-payment-element` and `.stripe-payment-status` and updated the credit-card warning copy to reflect the embedded secure form.

### Testing
- Verified lowercase changes with `rg -n "Summer" index.html news.html` which returned no remaining uppercase matches.
- Verified checkout changes with `rg -n "stripe-payment-element|card_number|exp_date|cvv|card_name" checkout.html` to confirm the mount container is present and the raw inputs were removed.
- Reviewed diffs with `git diff -- index.html news.html checkout.html` and committed the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e25a6f81408321ac8777a957049f7e)