### PR TITLE
Allow credit card form to load without contact email

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -474,11 +474,8 @@ async function ensureEmbeddedPaymentReady(form) {
         throw new Error(`Stripe price IDs missing for: ${missing.join(', ')}.`);
     }
     const contactEmail = form.querySelector('input[name="contact_email"]')?.value?.trim() || '';
-    if (!contactEmail) {
-        throw new Error('Please provide your contact email for this order.');
-    }
-
-    const lineItemsSignature = JSON.stringify({ lineItems, contactEmail: contactEmail.toLowerCase() });
+    const normalizedEmail = contactEmail.toLowerCase();
+    const lineItemsSignature = JSON.stringify({ lineItems, contactEmail: normalizedEmail });
     const shouldReuse = (
         stripeEmbeddedState.elements &&
         stripeEmbeddedState.lineItemsSignature === lineItemsSignature &&
@@ -493,7 +490,7 @@ async function ensureEmbeddedPaymentReady(form) {
     const intentResponse = await fetch(paymentIntentEndpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ lineItems, cart, customerEmail: contactEmail })
+        body: JSON.stringify({ lineItems, cart, customerEmail: normalizedEmail })
     });
     const intentPayload = await intentResponse.json().catch(() => ({}));
     if (!intentResponse.ok || !intentPayload.clientSecret) {

--- a/stripe-checkout-server.mjs
+++ b/stripe-checkout-server.mjs
@@ -298,9 +298,6 @@ async function handleCreatePaymentIntent(req, res) {
     );
   }
   const customerEmail = typeof body.customerEmail === 'string' ? body.customerEmail.trim().toLowerCase() : '';
-  if (!customerEmail) {
-    return jsonResponse(res, 400, { error: 'customerEmail is required.' }, requestOrigin);
-  }
 
   try {
     const priceCache = new Map();
@@ -334,8 +331,10 @@ async function handleCreatePaymentIntent(req, res) {
     params.set('amount', String(amount));
     params.set('currency', currency);
     params.set('automatic_payment_methods[enabled]', 'true');
-    params.set('receipt_email', customerEmail);
-    params.set('metadata[customer_email]', customerEmail);
+    if (customerEmail) {
+      params.set('receipt_email', customerEmail);
+      params.set('metadata[customer_email]', customerEmail);
+    }
 
     const paymentIntent = await stripeApiRequest('/v1/payment_intents', {
       method: 'POST',


### PR DESCRIPTION
### Motivation
- Allow users to open and fill credit-card fields before entering a contact email while still enforcing email as required at submit time for certain payment flows. 
- Prevent the embedded Stripe Payment Element from being blocked by an empty contact email while preserving normalized email when supplied. 
- Make the server-side payment-intent endpoint tolerant of missing `customerEmail` and avoid attaching empty receipt/metadata values.

### Description
- In `cart.js`, removed the hard failure when `contact_email` is empty inside `ensureEmbeddedPaymentReady` and instead normalize the email and include it in the payment-intent request only if present. 
- In `cart.js`, compute the `lineItemsSignature` using the normalized email to preserve element reuse/caching behavior. 
- In `stripe-checkout-server.mjs`, made `customerEmail` optional and only set `receipt_email` and `metadata[customer_email]` when a non-empty email is provided. 
- Left client-side submit-time validation intact so missing required fields are still highlighted and prevent submission.

### Testing
- Ran `node --check cart.js` and it succeeded. 
- Ran `node --check stripe-checkout-server.mjs` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e25d6bb4248321ab713383f46d8514)