### PR TITLE
Improve wallet checkout flow and Apple Pay availability checks

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -229,12 +229,14 @@ async function handlePayment(method, customerEmail = '') {
     const handler = paymentHandlers[method];
     if (!handler) {
         alert(`${method} payment not implemented.`);
-        return;
+        return false;
     }
     try {
         await handler(customerEmail);
+        return true;
     } catch (err) {
         alert(err.message || `${method} payment failed.`);
+        return false;
     }
 }
 
@@ -584,8 +586,12 @@ async function startApplePayPayment(lineItems, customerEmail = '') {
     });
 
     const availability = await paymentRequest.canMakePayment();
-    if (!availability || !availability.applePay) {
-        throw new Error('Apple Pay is not available on this device/browser. Please choose another payment method.');
+    const hasSupportedWallet = !!(
+        availability &&
+        (availability.applePay || availability.googlePay || availability.link || availability.browserCard)
+    );
+    if (!hasSupportedWallet) {
+        throw new Error('No supported wallet is available on this device/browser right now. On iPhone, use Safari with Apple Pay set up in Wallet.');
     }
 
     await new Promise((resolve, reject) => {
@@ -1652,7 +1658,7 @@ function setupFinalForm(form) {
             if (warn) warn.style.display = 'none';
         });
     }
-    form.addEventListener('submit', e => {
+    form.addEventListener('submit', async e => {
         e.preventDefault();
         let valid = true;
         let firstInvalid = null;
@@ -1715,10 +1721,12 @@ function setupFinalForm(form) {
             shop: 'Shop Pay',
             klarna: 'Klarna'
         };
-        handlePayment(methodMap[selectedPayment] || 'Stripe', contactEmail);
-        const modal = form.closest('#cart-modal');
-        if (modal) {
-            closeCart();
+        const success = await handlePayment(methodMap[selectedPayment] || 'Stripe', contactEmail);
+        if (success) {
+            const modal = form.closest('#cart-modal');
+            if (modal) {
+                closeCart();
+            }
         }
     });
 }


### PR DESCRIPTION
### Motivation
- Users report Apple Pay popup not appearing on iPhone and the checkout prematurely closing; the code should allow any supported wallet to start and avoid closing the cart modal when a wallet flow fails.
- Provide clearer guidance for iPhone users when wallets are unavailable instead of a generic failure message.

### Description
- Relaxed the Stripe Payment Request availability check in `startApplePayPayment` to accept any supported wallet by testing `availability.applePay || availability.googlePay || availability.link || availability.browserCard` instead of requiring `availability.applePay` only, and replaced the previous error copy with a more actionable message for iPhone/Safari/Wallet setup.
- Changed `handlePayment` to return a boolean success value (`true` on success, `false` on failure) so callers can respond to start failures instead of always proceeding.
- Made the final checkout form submit handler `async` and `await` the result of `handlePayment`, and only close the cart modal when the payment start succeeded to avoid prematurely hiding the UI on wallet errors.
- All code changes are contained in `cart.js`.

### Testing
- Ran a syntax/parse check with `node --check cart.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3e6f71fc8321ba9f8e4cebb7b6bf)