### PR TITLE
Guard `paymentRequest.show()` for non-Promise returns (Apple Pay fix)

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -648,9 +648,19 @@ async function startApplePayPayment(lineItems, customerEmail = '') {
             }
         });
 
-        paymentRequest.show().catch((error) => {
+        let showResult;
+        try {
+            showResult = paymentRequest.show();
+        } catch (error) {
             finalize(() => reject(new Error(error.message || 'Unable to open Apple Pay sheet.')));
-        });
+            return;
+        }
+
+        if (showResult && typeof showResult.catch === 'function') {
+            showResult.catch((error) => {
+                finalize(() => reject(new Error(error.message || 'Unable to open Apple Pay sheet.')));
+            });
+        }
     });
 }
 


### PR DESCRIPTION
### Motivation
- The Apple Pay checkout was crashing with `undefined is not an object (evaluating 'paymentRequest.show().catch')` on environments where `paymentRequest.show()` either throws synchronously or does not return a Promise. 
- The change aims to make the Apple Pay flow robust across browsers/implementations by handling both synchronous throws and promise rejections from `show()`.

### Description
- Wrap `paymentRequest.show()` in a `try/catch` so synchronous exceptions are caught and forwarded to the existing `finalize`/`reject` path. 
- Assign the result of `paymentRequest.show()` to `showResult` and attach `.catch(...)` only when `showResult` is truthy and has a `catch` function. 
- Return early after handling synchronous errors to avoid attempting to call `.catch` on `undefined` and preserve the existing payment completion and error handling logic.

### Testing
- Ran `node --check cart.js` and the syntax check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec51673600832191a370823f615a94)