### PR TITLE
Add Apple Pay fallback to server-created Stripe Checkout session

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -591,6 +591,10 @@ async function startApplePayPayment(lineItems, customerEmail = '') {
         (availability.applePay || availability.googlePay || availability.link || availability.browserCard)
     );
     if (!hasSupportedWallet) {
+        if (stripeSettings.checkoutEndpoint) {
+            await startServerCheckout('Apple Pay', lineItems, customerEmail);
+            return;
+        }
         throw new Error('No supported wallet is available on this device/browser right now. On iPhone, use Safari with Apple Pay set up in Wallet.');
     }
 


### PR DESCRIPTION
### Motivation
- Prevent Apple Pay from hard-failing on devices/browsers that cannot present a native wallet by providing a server-side checkout path when available.

### Description
- In `cart.js` inside `startApplePayPayment`, when `paymentRequest.canMakePayment()` indicates no supported wallet and `stripeSettings.checkoutEndpoint` is configured, call `startServerCheckout('Apple Pay', lineItems, customerEmail)` and return instead of throwing an error.

### Testing
- Ran `node --check cart.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec53e00e60832180829f6149e8c653)