### PR TITLE
Add color-specific American Denim images to carousel

### DIFF
--- a/americandenim.html
+++ b/americandenim.html
@@ -171,7 +171,7 @@
 </div>
 </header>
 <div class="product-item" data-product="american-denim" data-price="90" data-selected-color="" data-size="">
-    <div class="image-slider" data-images="blackjeans.png,bluejeans.png">
+    <div class="image-slider" data-images="blackjeans.png,blackjeansback.png,bluejeans.png,bluejeansback.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="blackjeans.png" alt="American Denim Jeans">
         <button class="next">&#10095;</button>


### PR DESCRIPTION
### Motivation
- Ensure the newly added denim images are included in the product carousel so selecting the `black` or `blue` color option shows the correct image set (front/back) for that color.

### Description
- Updated `americandenim.html` by expanding the `.image-slider` `data-images` list to `"blackjeans.png,blackjeansback.png,bluejeans.png,bluejeansback.png"` so the existing `product.js` color-filter behavior will cycle the color-specific images.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec5933f25483219ffd580eaf134a29)