### PR TITLE
Fix Apple Pay availability check and add cancellation/cleanup handlers

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -586,27 +586,30 @@ async function startApplePayPayment(lineItems, customerEmail = '') {
     });
 
     const availability = await paymentRequest.canMakePayment();
-    const hasSupportedWallet = !!(
-        availability &&
-        (availability.applePay || availability.googlePay || availability.link || availability.browserCard)
-    );
-    if (!hasSupportedWallet) {
+    const hasApplePay = Boolean(availability && availability.applePay);
+    if (!hasApplePay) {
         if (stripeSettings.checkoutEndpoint) {
             await startServerCheckout('Apple Pay', lineItems, customerEmail);
             return;
         }
-        throw new Error('No supported wallet is available on this device/browser right now. On iPhone, use Safari with Apple Pay set up in Wallet.');
+        throw new Error('Apple Pay is not available on this device/browser right now. On iPhone, use Safari with Apple Pay set up in Wallet.');
     }
 
     await new Promise((resolve, reject) => {
         let completed = false;
+        let paymentMethodHandler = null;
+        let cancelHandler = null;
         const finalize = (callback) => {
             if (completed) return;
             completed = true;
+            if (typeof paymentRequest.off === 'function') {
+                if (paymentMethodHandler) paymentRequest.off('paymentmethod', paymentMethodHandler);
+                if (cancelHandler) paymentRequest.off('cancel', cancelHandler);
+            }
             callback();
         };
 
-        paymentRequest.on('paymentmethod', async (event) => {
+        paymentMethodHandler = async (event) => {
             try {
                 const initialConfirm = await stripe.confirmCardPayment(
                     intentPayload.clientSecret,
@@ -650,7 +653,13 @@ async function startApplePayPayment(lineItems, customerEmail = '') {
                 event.complete('fail');
                 finalize(() => reject(new Error(error.message || 'Apple Pay payment failed.')));
             }
-        });
+        };
+        paymentRequest.on('paymentmethod', paymentMethodHandler);
+
+        cancelHandler = () => {
+            finalize(() => reject(new Error('Apple Pay payment was canceled.')));
+        };
+        paymentRequest.on('cancel', cancelHandler);
 
         let showResult;
         try {


### PR DESCRIPTION
### Motivation

- Apple Pay flow could proceed when other wallets (Google Pay/Link/browser card) were available, causing incorrect behavior when the user explicitly chose Apple Pay.
- Canceled Apple Pay sheets could leave the flow unresolved and leave event listeners attached, causing duplicate handlers on retries.

### Description

- Require explicit Apple Pay availability by checking `availability.applePay` before attempting the Apple Pay flow in `cart.js`.
- Update the user-facing error to say `Apple Pay is not available...` when Apple Pay is unavailable.
- Add tracked `paymentmethod` and `cancel` handler variables and remove them on finalize using `paymentRequest.off` when available, preventing stale/duplicate listeners across retries.
- Add an explicit `cancel` listener that rejects the Apple Pay promise with a clear `Apple Pay payment was canceled.` error.

### Testing

- Ran `node --check cart.js` which completed without errors.
- Ran `node --check stripe-checkout-server.mjs` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec75737fc083218338c536f230e14b)