### PR TITLE
Fix Apple Pay flow to stay in native wallet sheet

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -588,10 +588,6 @@ async function startApplePayPayment(lineItems, customerEmail = '') {
     const availability = await paymentRequest.canMakePayment();
     const hasApplePay = Boolean(availability && availability.applePay);
     if (!hasApplePay) {
-        if (stripeSettings.checkoutEndpoint) {
-            await startServerCheckout('Apple Pay', lineItems, customerEmail);
-            return;
-        }
         throw new Error('Apple Pay is not available on this device/browser right now. On iPhone, use Safari with Apple Pay set up in Wallet.');
     }
 


### PR DESCRIPTION
### Motivation
- Ensure Apple Pay completes on-device using the Stripe Payment Request / native Apple Pay sheet and do not redirect users to a hosted Stripe Checkout page when Apple Pay appears unavailable.

### Description
- Removed the fallback in `startApplePayPayment` that called `startServerCheckout('Apple Pay', ...)` when `paymentRequest.canMakePayment()` reported no Apple Pay support, and now the function throws a clear availability error instead.
- No other payment flows were modified; the native Payment Request handling and confirmation logic remain unchanged.

### Testing
- Ran `node --check cart.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed105ffe0c83218aed80e0b8073cef)