### PR TITLE
Reorder new/all product cards and add 3s thumbnail rotation

### DIFF
--- a/all.html
+++ b/all.html
@@ -368,6 +368,26 @@
 </div>
     
 <div class="product-item">
+    <a href="blankhoodie.html">
+        <img src="blankblackhoodie.png" alt="Blank Hoodie">
+        <div class="product-info">
+            <p>Blank Hoodie</p>
+            <p>$60</p>
+        </div>
+    </a>
+</div>
+    
+<div class="product-item">
+    <a href="blankshirt.html">
+        <img src="3packwhiteshirts.png" alt="Blank T-Shirt">
+        <div class="product-info">
+            <p>Blank T-Shirt</p>
+            <p>$15</p>
+        </div>
+    </a>
+</div>
+    
+<div class="product-item">
     <a href="shirt.html">
         <img src="whiteshirt.png" alt="T-Shirt">
         <div class="product-info">
@@ -443,26 +463,6 @@
         <div class="product-info">
             <p>Camo Hat</p>
             <p>$50</p>
-        </div>
-    </a>
-</div>
-
-<div class="product-item">
-    <a href="blankshirt.html">
-        <img src="blankblackshirtback.png" alt="Blank T-Shirt">
-        <div class="product-info">
-            <p>Blank T-Shirt</p>
-            <p>$15</p>
-        </div>
-    </a>
-</div>
-
-<div class="product-item">
-    <a href="blankhoodie.html">
-        <img src="blankblackhoodie.png" alt="Blank Hoodie">
-        <div class="product-info">
-            <p>Blank Hoodie</p>
-            <p>$60</p>
         </div>
     </a>
 </div>

--- a/footer-highlight.js
+++ b/footer-highlight.js
@@ -55,6 +55,42 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  // Rotate product thumbnail images on shop/category grids every 3 seconds
+  const productCarouselImages = {
+    'hoodie.html': ['blackhoodie.png', 'blackhoodieback.png', 'whitehoodie.png', 'whitehoodieback.png', 'grayhoodie.png', 'grayhoodieback.png'],
+    'blankhoodie.html': ['blankblackhoodie.png', 'blankblackhoodieback.png', 'blankwhitehoodie.png', 'blankwhitehoodieback.png', 'blankgrayhoodie.png', 'blankgrayhoodieback.png'],
+    'shirt.html': ['blackshirt.png', 'whiteshirt.png', 'grayshirt.png', 'grayshirtback.png'],
+    'blankshirt.html': ['3packwhiteshirts.png', 'blankblackshirtback.png', 'blankwhiteshirtback.png', 'blankgrayshirt.png', 'blankgrayshirtback.png', '3packblackshirts.png', '3packgrayshirts.png', '3packcomboshirts.png'],
+    'joggers.html': ['blackjoggers.png', 'whitejoggers.png'],
+    'shorts.html': ['blackshorts.png', 'whiteshorts.png'],
+    'americandenim.html': ['blackjeans.png', 'blackjeansback.png', 'bluejeans.png', 'bluejeansback.png'],
+    'dufflebag.html': ['dufflebag1.png', 'dufflebag2.png', 'dufflebag3.png', 'dufflebag4.png', 'dufflebag5.png', 'dufflebag6.png', 'dufflebag7.png', 'dufflebag8.png', 'dufflebag9.png'],
+    'backpack.html': ['backpackblack.png', 'backpackwhite.png', 'backpackwhite2.png'],
+    'hat.html': ['blackhat.png', 'whitehat.png'],
+    'truckerhat.html': ['truckerwhitefront.png', 'truckerwhiteback.png', 'truckerwhitehat.png', 'truckerblackfront.png', 'truckerbackblack.png', 'truckerblackhat.png'],
+    'camohat.html': ['camohatcamo.png', 'camohatorange.png', 'camohatblack.png'],
+    'socks.html': ['blacksocks.png', 'blacksocks2.png'],
+    'skateboard1.html': ['skateboard3v2.png'],
+    'skateboard2.html': ['skateboard4.png'],
+    'skateboard3.html': ['skateboard1.png']
+  };
+
+  document.querySelectorAll('.product-grid .product-item a[href]').forEach(link => {
+    const image = link.querySelector('img');
+    if (!image) return;
+    const href = link.getAttribute('href');
+    const gallery = productCarouselImages[href];
+    if (!gallery || gallery.length < 2) return;
+
+    let index = Math.max(gallery.indexOf(image.getAttribute('src')), 0);
+    image.src = gallery[index];
+
+    setInterval(() => {
+      index = (index + 1) % gallery.length;
+      image.src = gallery[index];
+    }, 3000);
+  });
+
   // Allow long press on the logo to return to the homepage
   const logoOverlay = document.querySelector('.logo-overlay');
   if (logoOverlay) {

--- a/new.html
+++ b/new.html
@@ -368,6 +368,26 @@
 </div>
     
 <div class="product-item">
+    <a href="blankhoodie.html">
+        <img src="blankblackhoodie.png" alt="Blank Hoodie">
+        <div class="product-info">
+            <p>Blank Hoodie</p>
+            <p>$60</p>
+        </div>
+    </a>
+</div>
+    
+<div class="product-item">
+    <a href="blankshirt.html">
+        <img src="3packwhiteshirts.png" alt="Blank T-Shirt">
+        <div class="product-info">
+            <p>Blank T-Shirt</p>
+            <p>$15</p>
+        </div>
+    </a>
+</div>
+    
+<div class="product-item">
     <a href="shirt.html">
         <img src="whiteshirt.png" alt="T-Shirt">
         <div class="product-info">
@@ -443,26 +463,6 @@
         <div class="product-info">
             <p>Camo Hat</p>
             <p>$50</p>
-        </div>
-    </a>
-</div>
-
-<div class="product-item">
-    <a href="blankshirt.html">
-        <img src="blankblackshirtback.png" alt="Blank T-Shirt">
-        <div class="product-info">
-            <p>Blank T-Shirt</p>
-            <p>$15</p>
-        </div>
-    </a>
-</div>
-
-<div class="product-item">
-    <a href="blankhoodie.html">
-        <img src="blankblackhoodie.png" alt="Blank Hoodie">
-        <div class="product-info">
-            <p>Blank Hoodie</p>
-            <p>$60</p>
         </div>
     </a>
 </div>


### PR DESCRIPTION
### Motivation
- Adjust visible product ordering on the `new` and `all` collection pages to surface Blank Hoodie and Blank T-Shirt next to their related items and use the 3-pack white image as the blank shirt primary thumbnail.
- Add an automatic thumbnail rotation for product cards in shop/category grids so each product card cycles through its gallery images to better showcase variants.

### Description
- Updated `new.html` and `all.html` to place `blankhoodie.html` immediately after `hoodie.html` and to place `blankshirt.html` before `shirt.html` while changing the blank shirt card image to `3packwhiteshirts.png`.
- Added a `productCarouselImages` mapping and per-card `setInterval` logic to `footer-highlight.js` that rotates product card images on `.product-grid` pages every `3000ms` using each product’s gallery array.
- The rotation only runs for product links that have an entry in the mapping and cycles the `img.src` in place to avoid touching other DOM structure.
- Modified files: `new.html`, `all.html`, and `footer-highlight.js`.

### Testing
- Ran a small automated Python check that reads `new.html` and `all.html` and prints product href positions to confirm the new ordering, which succeeded.
- Performed an automated search to confirm the new image source and the presence of the rotation mapping in `footer-highlight.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3dcefdc4832182f16e03695a7494)