### PR TITLE
Adjust camo hat ordering and thumbnail rotation timing on product grids

### DIFF
--- a/footer-highlight.js
+++ b/footer-highlight.js
@@ -55,7 +55,17 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  // Rotate product thumbnail images on shop/category grids every 3 seconds
+  // Keep Camo Hat as the second product tile on all/new/shop grids
+  if (['all.html', 'new.html', 'shop.html'].includes(current)) {
+    document.querySelectorAll('.product-grid').forEach(grid => {
+      const camoItem = grid.querySelector('.product-item a[href="camohat.html"]')?.closest('.product-item');
+      const firstItem = grid.querySelector('.product-item');
+      if (!camoItem || !firstItem || camoItem === firstItem) return;
+      firstItem.insertAdjacentElement('afterend', camoItem);
+    });
+  }
+
+  // Rotate product thumbnail images on shop/category grids every 5 seconds
   const productCarouselImages = {
     'hoodie.html': ['blackhoodie.png', 'blackhoodieback.png', 'whitehoodie.png', 'whitehoodieback.png', 'grayhoodie.png', 'grayhoodieback.png'],
     'blankhoodie.html': ['blankblackhoodie.png', 'blankblackhoodieback.png', 'blankwhitehoodie.png', 'blankwhitehoodieback.png', 'blankgrayhoodie.png', 'blankgrayhoodieback.png'],
@@ -88,7 +98,7 @@ document.addEventListener('DOMContentLoaded', () => {
     setInterval(() => {
       index = (index + 1) % gallery.length;
       image.src = gallery[index];
-    }, 3000);
+    }, 5000);
   });
 
   // Allow long press on the logo to return to the homepage


### PR DESCRIPTION
### Motivation
- Ensure the Camo Hat appears consistently as the second tile on the `all`, `new`, and `shop` product grids without editing each page's HTML. 
- Reduce visual churn by increasing the product thumbnail auto-rotation interval from 3 seconds to 5 seconds.

### Description
- Added a runtime reordering block in `footer-highlight.js` that, when the current page is `all.html`, `new.html`, or `shop.html`, finds the `.product-item` linking to `camohat.html` and moves it to the second position by inserting it after the first `.product-item` in each `.product-grid`.
- Updated the thumbnail carousel interval in `footer-highlight.js` from `3000` ms to `5000` ms so product grid thumbnails rotate every 5 seconds instead of every 3 seconds.
- Changes include defensive checks to skip reordering when the camo tile or grid is missing or already in place, and preserve the existing `productCarouselImages` behavior.

### Testing
- Ran `node --check footer-highlight.js` to verify JavaScript syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3f3ce70c8321aedb234a1435e52f)