### PR TITLE
Reorder hats on hats.html to put Camo Hat after Hat

### DIFF
--- a/hats.html
+++ b/hats.html
@@ -358,20 +358,20 @@
 </div>
     
 <div class="product-item">
-    <a href="truckerhat.html">
-        <img src="truckerwhitefront.png" alt="Trucker Hat">
+    <a href="camohat.html">
+        <img src="camohatcamo.png" alt="Camo Hat">
         <div class="product-info">
-            <p>Trucker Hat</p>
+            <p>Camo Hat</p>
             <p>$50</p>
         </div>
     </a>
 </div>
 
 <div class="product-item">
-    <a href="camohat.html">
-        <img src="camohatcamo.png" alt="Camo Hat">
+    <a href="truckerhat.html">
+        <img src="truckerwhitefront.png" alt="Trucker Hat">
         <div class="product-info">
-            <p>Camo Hat</p>
+            <p>Trucker Hat</p>
             <p>$50</p>
         </div>
     </a>


### PR DESCRIPTION
### Motivation
- Ensure the Camo Hat product card appears immediately after the first Hat product card in the hats listing so the display order matches the intended sequence.

### Description
- Swapped the two hat product-item blocks in `hats.html` so the Camo Hat card is directly after the Hat card and the Trucker Hat follows it.
- Updated the `href`, `img` `src`/`alt` attributes and the visible product name text for the affected cards to match the new order.
- No other markup or styles were modified.

### Testing
- Inspected the updated markup region with `nl -ba /workspace/MBNT/hats.html | sed -n '346,392p'` to confirm the Camo Hat now appears after Hat and Trucker Hat follows it, which succeeded.
- Verified the file diff to confirm only the intended product-item blocks were swapped, which succeeded.
- Saved the changes to the repository working tree and confirmed the updated `hats.html` contains the correct product sequence (Hat → Camo Hat → Trucker Hat).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed40e397788321b27cf6f351eed8ec)