### PR TITLE
Scale camo hat images down 50% to match hat sizing

### DIFF
--- a/camohat.html
+++ b/camohat.html
@@ -118,6 +118,7 @@
         }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
+        .image-slider.camo-size-match img { width:50%; height:50%; }
         .color-options {
             display: flex;
             gap: 5px;
@@ -145,7 +146,7 @@
 </div>
 </header>
 <div class="product-item" data-product="camohat" data-price="50" data-price-id="camohat" data-selected-color="" data-size="">
-    <div class="image-slider" data-images="camohatcamo.png,camohatorange.png,camohatblack.png">
+    <div class="image-slider camo-size-match" data-images="camohatcamo.png,camohatorange.png,camohatblack.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="camohatcamo.png" alt="Camo Hat">
         <button class="next">&#10095;</button>


### PR DESCRIPTION
### Motivation
- Reduce camo hat product images to 50% so the camo variant displays at the same visible size as the original "hat" product.

### Description
- Added a scoped CSS rule `.image-slider.camo-size-match img { width:50%; height:50%; }` and applied the `camo-size-match` class to the camo hat slider in `camohat.html` so only the camo hat page is affected.

### Testing
- Verified the modification with `git diff -- camohat.html` and `git status --short` and committed the change, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4229dad083219ec25c12246e5fdf)