### PR TITLE
Reduce camo hat thumbnail size on product page

### DIFF
--- a/camohat.html
+++ b/camohat.html
@@ -118,7 +118,7 @@
         }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
-        .image-slider.camo-size-match img { width:50%; height:50%; }
+        .image-slider.camo-size-match img { width:40%; height:40%; }
         .color-options {
             display: flex;
             gap: 5px;


### PR DESCRIPTION
### Motivation
- Make the camo hat product thumbnail smaller because the previous 50% sizing was still too large.

### Description
- Update CSS in `camohat.html` to change `.image-slider.camo-size-match img` `width`/`height` from `50%` to `40%` so the displayed thumbnail renders smaller.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4359851083218a6d53d59b2b464c)