### PR TITLE
Reduce camo hat display size to 25%

### DIFF
--- a/camohat.html
+++ b/camohat.html
@@ -118,7 +118,7 @@
         }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
-        .image-slider.camo-size-match img { width:40%; height:40%; }
+        .image-slider.camo-size-match img { width:25%; height:25%; }
         .color-options {
             display: flex;
             gap: 5px;


### PR DESCRIPTION
### Motivation
- Make the camo hat image noticeably smaller on its product page so it appears 75% smaller than the original full-size baseline.

### Description
- Updated the CSS in `camohat.html` to change the `.image-slider.camo-size-match img` rule from `width:40%; height:40%;` to `width:25%; height:25%;` so the camo hat renders at 25% of its original size.

### Testing
- Performed a file-diff verification confirming only `camohat.html` was modified and the sizing rule change applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed44cdf71c8321adbbfe003d6b03ec)