### PR TITLE
Scale camo hat image to 15% (make it 85% smaller)

### DIFF
--- a/camohat.html
+++ b/camohat.html
@@ -118,7 +118,7 @@
         }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
-        .image-slider.camo-size-match img { width:25%; height:25%; }
+        .image-slider.camo-size-match img { width:15%; height:15%; }
         .color-options {
             display: flex;
             gap: 5px;


### PR DESCRIPTION
### Motivation
- The product page required the camo hat graphic to appear 85% smaller than its original size instead of the previous 75% reduction.

### Description
- Updated the CSS in `camohat.html` by changing `.image-slider.camo-size-match img` from `width:25%; height:25%;` to `width:15%; height:15%;` so the camo hat displays at 15% of its original size.

### Testing
- Verified the change with `git diff -- camohat.html` and `git status --short`, and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed45e44c848321a8627c1e57e01185)