### PR TITLE
Reduce camo hat image scale to 5%

### DIFF
--- a/camohat.html
+++ b/camohat.html
@@ -118,7 +118,7 @@
         }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
-        .image-slider.camo-size-match img { width:15%; height:15%; }
+        .image-slider.camo-size-match img { width:5%; height:5%; }
         .color-options {
             display: flex;
             gap: 5px;


### PR DESCRIPTION
### Motivation
- The camo hat image on the product page was visually too large and should be reduced to roughly 95% smaller for correct display.

### Description
- Change the CSS in `camohat.html` by updating `.image-slider.camo-size-match img` from `width:15%; height:15%;` to `width:5%; height:5%;`.

### Testing
- Verified the edit with `git diff -- camohat.html`, confirmed file status with `git status --short`, and created a commit `Reduce camo hat product image scale by 95%`; no runtime tests were run because this is a CSS-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4a9a42608321beef4d264f3cd83c)