### PR TITLE
Adjust camo hat product image sizing

### DIFF
--- a/camohat.html
+++ b/camohat.html
@@ -118,7 +118,6 @@
         }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
-        .image-slider.camo-size-match img { width:5%; height:5%; }
         .color-options {
             display: flex;
             gap: 5px;

--- a/product.js
+++ b/product.js
@@ -12,8 +12,9 @@ function initSliders() {
     let index = 0;
     const img = slider.querySelector('img');
     if (img) {
-      img.style.width = '100%';
-      img.style.height = '100%';
+      const isCamoHatSlider = slider.classList.contains('camo-size-match');
+      img.style.width = isCamoHatSlider ? '72%' : '100%';
+      img.style.height = isCamoHatSlider ? '72%' : '100%';
       img.style.objectFit = 'contain';
       img.style.filter = PRODUCT_SHADOW;
     }


### PR DESCRIPTION
### Motivation
- The Camo Hat product was rendering much larger/narrower than the standard `hat` product, so the intent is to make the camo hat image render at a smaller scale to visually match the regular hat listing.

### Description
- Update `product.js` slider initialization to detect sliders with the `camo-size-match` class and set the image inline size to `72%` (width/height) for those sliders, while leaving other sliders at `100%`.
- Remove the unused `.image-slider.camo-size-match img` CSS rule from `camohat.html` because sizing is now handled by the JavaScript initialization.

### Testing
- Ran `node --check product.js` which completed successfully.
- Reviewed the code diffs for `camohat.html` and `product.js` to confirm the intended changes were applied and no other files were affected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed516955908321ba8ec403f5166991)