### PR TITLE
Reduce camo hat thumbnail size on grid pages

### DIFF
--- a/all.html
+++ b/all.html
@@ -195,6 +195,11 @@
             filter: drop-shadow(0 4px 10px rgba(0,0,0,0.5));
         }
 
+        .product-item img.camo-hat-thumb {
+            max-width: 78%;
+            max-height: 78%;
+        }
+
         .coming-soon {
             display: flex;
             justify-content: center;
@@ -459,7 +464,7 @@
 
 <div class="product-item">
     <a href="camohat.html">
-        <img src="camohatcamo.png" alt="Camo Hat">
+        <img src="camohatcamo.png" alt="Camo Hat" class="camo-hat-thumb">
         <div class="product-info">
             <p>Camo Hat</p>
             <p>$50</p>

--- a/hats.html
+++ b/hats.html
@@ -195,6 +195,11 @@
             filter: drop-shadow(0 4px 10px rgba(0,0,0,0.5));
         }
 
+        .product-item img.camo-hat-thumb {
+            max-width: 78%;
+            max-height: 78%;
+        }
+
         .coming-soon {
             display: flex;
             justify-content: center;
@@ -359,7 +364,7 @@
     
 <div class="product-item">
     <a href="camohat.html">
-        <img src="camohatcamo.png" alt="Camo Hat">
+        <img src="camohatcamo.png" alt="Camo Hat" class="camo-hat-thumb">
         <div class="product-info">
             <p>Camo Hat</p>
             <p>$50</p>

--- a/new.html
+++ b/new.html
@@ -195,6 +195,11 @@
             filter: drop-shadow(0 4px 10px rgba(0,0,0,0.5));
         }
 
+        .product-item img.camo-hat-thumb {
+            max-width: 78%;
+            max-height: 78%;
+        }
+
         .coming-soon {
             display: flex;
             justify-content: center;
@@ -459,7 +464,7 @@
 
 <div class="product-item">
     <a href="camohat.html">
-        <img src="camohatcamo.png" alt="Camo Hat">
+        <img src="camohatcamo.png" alt="Camo Hat" class="camo-hat-thumb">
         <div class="product-info">
             <p>Camo Hat</p>
             <p>$50</p>


### PR DESCRIPTION
### Motivation
- The camo hat thumbnail appeared visually too large on category and listing grids, so a targeted size reduction was needed without affecting other product thumbnails.

### Description
- Added a scoped CSS rule ` .product-item img.camo-hat-thumb { max-width: 78%; max-height: 78%; } ` to `hats.html`, `all.html`, and `new.html` to scale down the camo thumbnail.
- Applied the `camo-hat-thumb` class to the camo hat `<img>` element on each of those pages so the rule only affects that product.

### Testing
- Ran `git diff --check` to confirm there are no patch formatting issues and it passed. 
- Verified the class and style were applied in all target files with `rg -n "camo-hat-thumb" hats.html all.html new.html` and it returned the expected matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed542595b48321be75e211509b5b68)