### PR TITLE
Wire front/back black & white shirt images into product pages and carousels

### DIFF
--- a/blankshirt.html
+++ b/blankshirt.html
@@ -168,16 +168,16 @@
 </div>
 </header>
 <div class="product-item" data-product="blank-shirt" data-price="15" data-price-id="blank-shirt" data-selected-color="" data-size="" data-style="single">
-    <div class="image-slider" data-images="blankblackshirtback.png,blankwhiteshirtback.png,blankgrayshirt.png,blankgrayshirtback.png,3packblackshirts.png,3packwhiteshirts.png,3packgrayshirts.png,3packcomboshirts.png">
+    <div class="image-slider" data-images="blankblackshirt.png,blankblackshirtback.png,blankwhiteshirt.png,blankwhiteshirtback.png,blankgrayshirt.png,blankgrayshirtback.png,3packblackshirts.png,3packwhiteshirts.png,3packgrayshirts.png,3packcomboshirts.png">
         <button class="prev">&#10094;</button>
-        <img id="product-image" src="blankblackshirtback.png" alt="Blank T-Shirt">
+        <img id="product-image" src="blankblackshirt.png" alt="Blank T-Shirt">
         <button class="next">&#10095;</button>
     </div>
     <h1>Blank T-Shirt</h1>
     <p class="dynamic-price">$15</p>
     <div class="color-options">
-        <span class="color-option" data-color="black" data-style="single" data-price="15" data-price-id="blank-shirt" data-image="blankblackshirtback.png" style="background:#000;" title="Single Black"></span>
-        <span class="color-option" data-color="white" data-style="single" data-price="15" data-price-id="blank-shirt" data-image="blankwhiteshirtback.png" style="background:#fff;border:1px solid #000;" title="Single White"></span>
+        <span class="color-option" data-color="black" data-style="single" data-price="15" data-price-id="blank-shirt" data-image="blankblackshirt.png" style="background:#000;" title="Single Black"></span>
+        <span class="color-option" data-color="white" data-style="single" data-price="15" data-price-id="blank-shirt" data-image="blankwhiteshirt.png" style="background:#fff;border:1px solid #000;" title="Single White"></span>
         <span class="color-option" data-color="gray" data-style="single" data-price="15" data-price-id="blank-shirt" data-image="blankgrayshirt.png" style="background:#808080;" title="Single Gray"></span>
         <span class="color-option" data-color="3pack-black" data-style="3-pack" data-price="30" data-price-id="blank-shirt-3pack" data-image="3packblackshirts.png" style="width:auto;padding:0 8px;line-height:15px;background:#111;color:#fff;font-size:10px;">3PK BLK</span>
         <span class="color-option" data-color="3pack-white" data-style="3-pack" data-price="30" data-price-id="blank-shirt-3pack" data-image="3packwhiteshirts.png" style="width:auto;padding:0 8px;line-height:15px;background:#f5f5f5;color:#000;border:1px solid #000;font-size:10px;">3PK WHT</span>

--- a/footer-highlight.js
+++ b/footer-highlight.js
@@ -69,8 +69,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const productCarouselImages = {
     'hoodie.html': ['blackhoodie.png', 'blackhoodieback.png', 'whitehoodie.png', 'whitehoodieback.png', 'grayhoodie.png', 'grayhoodieback.png'],
     'blankhoodie.html': ['blankblackhoodie.png', 'blankblackhoodieback.png', 'blankwhitehoodie.png', 'blankwhitehoodieback.png', 'blankgrayhoodie.png', 'blankgrayhoodieback.png'],
-    'shirt.html': ['blackshirt.png', 'whiteshirt.png', 'grayshirt.png', 'grayshirtback.png'],
-    'blankshirt.html': ['3packwhiteshirts.png', 'blankblackshirtback.png', 'blankwhiteshirtback.png', 'blankgrayshirt.png', 'blankgrayshirtback.png', '3packblackshirts.png', '3packgrayshirts.png', '3packcomboshirts.png'],
+    'shirt.html': ['blackshirt.png', 'blackshirtback.png', 'whiteshirt.png', 'whiteshirtback.png', 'grayshirt.png', 'grayshirtback.png'],
+    'blankshirt.html': ['blankblackshirt.png', 'blankblackshirtback.png', 'blankwhiteshirt.png', 'blankwhiteshirtback.png', 'blankgrayshirt.png', 'blankgrayshirtback.png', '3packblackshirts.png', '3packwhiteshirts.png', '3packgrayshirts.png', '3packcomboshirts.png'],
     'joggers.html': ['blackjoggers.png', 'whitejoggers.png'],
     'shorts.html': ['blackshorts.png', 'whiteshorts.png'],
     'americandenim.html': ['blackjeans.png', 'blackjeansback.png', 'bluejeans.png', 'bluejeansback.png'],

--- a/product.js
+++ b/product.js
@@ -233,7 +233,7 @@ document.addEventListener('DOMContentLoaded', () => {
     { href: 'blankhoodie.html', img: 'blankblackhoodie.png', alt: 'Blank Hoodie' },
     { href: 'truckerhat.html', img: 'truckerwhitefront.png', alt: 'Trucker Hat' },
     { href: 'camohat.html', img: 'camohatcamo.png', alt: 'Camo Hat' },
-    { href: 'blankshirt.html', img: 'blankblackshirtback.png', alt: 'Blank T-Shirt' },
+    { href: 'blankshirt.html', img: 'blankblackshirt.png', alt: 'Blank T-Shirt' },
     { href: 'socks.html', img: 'blacksocks.png', alt: 'Socks' },
     { href: 'shorts.html', img: 'blackshorts.png', alt: 'Shorts' },
     { href: 'joggers.html', img: 'blackjoggers.png', alt: 'Joggers' },

--- a/shirt.html
+++ b/shirt.html
@@ -168,7 +168,7 @@
 </div>
 </header>
 <div class="product-item" data-product="t-shirt" data-price="30" data-selected-color="" data-size="">
-    <div class="image-slider" data-images="blackshirt.png,whiteshirt.png,grayshirt.png,grayshirtback.png">
+    <div class="image-slider" data-images="blackshirt.png,blackshirtback.png,whiteshirt.png,whiteshirtback.png,grayshirt.png,grayshirtback.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="blackshirt.png" alt="T-Shirt">
         <button class="next">&#10095;</button>

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -359,7 +359,7 @@
 
 <div class="product-item">
     <a href="blankshirt.html">
-        <img src="blankblackshirtback.png" alt="Blank T-Shirt">
+        <img src="blankblackshirt.png" alt="Blank T-Shirt">
         <div class="product-info">
             <p>Blank T-Shirt</p>
             <p>$15</p>


### PR DESCRIPTION
### Motivation
- Ensure the newly added front/back images for black and white shirts are used by product sliders, color selectors, and listing carousels so color selections show the correct front/back views.
- Keep recommendation and carousel thumbnails consistent with the updated product images so previews reflect the front shirt artwork.

### Description
- Updated `blankshirt.html` to include both front and back assets in the slider (`blankblackshirt.png`, `blankblackshirtback.png`, `blankwhiteshirt.png`, `blankwhiteshirtback.png`) and set the main product image to the front black image, and updated the black/white `data-image` on the color-option elements.
- Updated `shirt.html` slider `data-images` to include `blackshirtback.png` and `whiteshirtback.png` so front/back images are available for each color.
- Updated `t-shirts.html` product listing to use `blankblackshirt.png` as the preview image for the Blank T-Shirt.
- Updated shared mappings in `product.js` and `footer-highlight.js` so recommendation/rotation galleries include the new front/back images and the Blank T-Shirt uses the front black image in thumbnails.

### Testing
- Verified all four new image files exist in the repo with a file existence check; the check succeeded for `blankblackshirt.png`, `blankwhiteshirt.png`, `blackshirtback.png`, and `whiteshirtback.png`.
- Verified updated references by searching target files for the new image names; the search matched the intended entries in `blankshirt.html`, `shirt.html`, `t-shirts.html`, `product.js`, and `footer-highlight.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed575f9a38832184af78268b1a825d)