### PR TITLE
Fix blank shirt carousel order and link back-side images

### DIFF
--- a/blankshirt.html
+++ b/blankshirt.html
@@ -168,7 +168,7 @@
 </div>
 </header>
 <div class="product-item" data-product="blank-shirt" data-price="15" data-price-id="blank-shirt" data-selected-color="" data-size="" data-style="single">
-    <div class="image-slider" data-images="blankblackshirt.png,blankblackshirtback.png,blankwhiteshirt.png,blankwhiteshirtback.png,blankgrayshirt.png,blankgrayshirtback.png,3packblackshirts.png,3packwhiteshirts.png,3packgrayshirts.png,3packcomboshirts.png">
+    <div class="image-slider" data-images="blankblackshirt.png,blankwhiteshirt.png,blankgrayshirt.png,blankblackshirtback.png,blankwhiteshirtback.png,blankgrayshirtback.png,3packblackshirts.png,3packwhiteshirts.png,3packgrayshirts.png,3packcomboshirts.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="blankblackshirt.png" alt="Blank T-Shirt">
         <button class="next">&#10095;</button>
@@ -176,9 +176,9 @@
     <h1>Blank T-Shirt</h1>
     <p class="dynamic-price">$15</p>
     <div class="color-options">
-        <span class="color-option" data-color="black" data-style="single" data-price="15" data-price-id="blank-shirt" data-image="blankblackshirt.png" style="background:#000;" title="Single Black"></span>
-        <span class="color-option" data-color="white" data-style="single" data-price="15" data-price-id="blank-shirt" data-image="blankwhiteshirt.png" style="background:#fff;border:1px solid #000;" title="Single White"></span>
-        <span class="color-option" data-color="gray" data-style="single" data-price="15" data-price-id="blank-shirt" data-image="blankgrayshirt.png" style="background:#808080;" title="Single Gray"></span>
+        <span class="color-option" data-color="black" data-style="single" data-price="15" data-price-id="blank-shirt" data-image="blankblackshirt.png" data-images="blankblackshirt.png,blankblackshirtback.png" style="background:#000;" title="Single Black"></span>
+        <span class="color-option" data-color="white" data-style="single" data-price="15" data-price-id="blank-shirt" data-image="blankwhiteshirt.png" data-images="blankwhiteshirt.png,blankwhiteshirtback.png" style="background:#fff;border:1px solid #000;" title="Single White"></span>
+        <span class="color-option" data-color="gray" data-style="single" data-price="15" data-price-id="blank-shirt" data-image="blankgrayshirt.png" data-images="blankgrayshirt.png,blankgrayshirtback.png" style="background:#808080;" title="Single Gray"></span>
         <span class="color-option" data-color="3pack-black" data-style="3-pack" data-price="30" data-price-id="blank-shirt-3pack" data-image="3packblackshirts.png" style="width:auto;padding:0 8px;line-height:15px;background:#111;color:#fff;font-size:10px;">3PK BLK</span>
         <span class="color-option" data-color="3pack-white" data-style="3-pack" data-price="30" data-price-id="blank-shirt-3pack" data-image="3packwhiteshirts.png" style="width:auto;padding:0 8px;line-height:15px;background:#f5f5f5;color:#000;border:1px solid #000;font-size:10px;">3PK WHT</span>
         <span class="color-option" data-color="3pack-gray" data-style="3-pack" data-price="30" data-price-id="blank-shirt-3pack" data-image="3packgrayshirts.png" style="width:auto;padding:0 8px;line-height:15px;background:#888;color:#fff;font-size:10px;">3PK GRY</span>

--- a/footer-highlight.js
+++ b/footer-highlight.js
@@ -70,7 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
     'hoodie.html': ['blackhoodie.png', 'blackhoodieback.png', 'whitehoodie.png', 'whitehoodieback.png', 'grayhoodie.png', 'grayhoodieback.png'],
     'blankhoodie.html': ['blankblackhoodie.png', 'blankblackhoodieback.png', 'blankwhitehoodie.png', 'blankwhitehoodieback.png', 'blankgrayhoodie.png', 'blankgrayhoodieback.png'],
     'shirt.html': ['blackshirt.png', 'blackshirtback.png', 'whiteshirt.png', 'whiteshirtback.png', 'grayshirt.png', 'grayshirtback.png'],
-    'blankshirt.html': ['blankblackshirt.png', 'blankblackshirtback.png', 'blankwhiteshirt.png', 'blankwhiteshirtback.png', 'blankgrayshirt.png', 'blankgrayshirtback.png', '3packblackshirts.png', '3packwhiteshirts.png', '3packgrayshirts.png', '3packcomboshirts.png'],
+    'blankshirt.html': ['blankblackshirt.png', 'blankwhiteshirt.png', 'blankgrayshirt.png', 'blankblackshirtback.png', 'blankwhiteshirtback.png', 'blankgrayshirtback.png', '3packblackshirts.png', '3packwhiteshirts.png', '3packgrayshirts.png', '3packcomboshirts.png'],
     'joggers.html': ['blackjoggers.png', 'whitejoggers.png'],
     'shorts.html': ['blackshorts.png', 'whiteshorts.png'],
     'americandenim.html': ['blackjeans.png', 'blackjeansback.png', 'bluejeans.png', 'bluejeansback.png'],

--- a/product.js
+++ b/product.js
@@ -42,7 +42,12 @@ function initSliders() {
     product?.querySelectorAll('.color-option').forEach((opt) => {
       opt.addEventListener('click', () => {
         const color = opt.dataset.color || '';
-        images = color ? allImages.filter(src => src.includes(color)) : [...allImages];
+        const explicitImages = opt.dataset.images
+          ? opt.dataset.images.split(',').map(src => src.trim()).filter(Boolean)
+          : [];
+        images = explicitImages.length
+          ? explicitImages
+          : (color ? allImages.filter(src => src.includes(color)) : [...allImages]);
         if (images.length === 0) images = [opt.dataset.image];
         const idx = images.indexOf(opt.dataset.image);
         index = idx !== -1 ? idx : 0;


### PR DESCRIPTION
### Motivation
- Ensure front views of the Blank T-Shirt (black/white/gray) appear before their back views in the shop thumbnail carousel and product slider so customers see the front first.
- Ensure selecting a color option on the Blank T-Shirt product page reliably links the color to its paired back-side image.

### Description
- Reordered the `data-images` sequence in `blankshirt.html` so front images (`blankblackshirt.png`, `blankwhiteshirt.png`, `blankgrayshirt.png`) come before the corresponding back images in the product slider `data-images` attribute.
- Added explicit `data-images` attributes to the single-color `.color-option` elements in `blankshirt.html` to pair each color with its front and back images (e.g. `data-images="blankblackshirt.png,blankblackshirtback.png"`).
- Updated slider logic in `product.js` to prioritize an option's `data-images` when present (parsing `opt.dataset.images`), falling back to the existing color-filter (`allImages.filter`) behavior when not provided.
- Updated the rotating thumbnail map in `footer-highlight.js` for `'blankshirt.html'` so the shop/category carousel order matches the new front-before-back ordering.

### Testing
- Ran `node --check product.js` and it succeeded.
- Ran `node --check footer-highlight.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed58c4dee88321b0f38fdc52510471)