### PR TITLE
Reduce trucker hat thumbnail size on listing pages

### DIFF
--- a/all.html
+++ b/all.html
@@ -200,6 +200,11 @@
             max-height: 78%;
         }
 
+        .product-item img.trucker-hat-thumb {
+            max-width: 68%;
+            max-height: 68%;
+        }
+
         .coming-soon {
             display: flex;
             justify-content: center;
@@ -454,7 +459,7 @@
     
 <div class="product-item">
     <a href="truckerhat.html">
-        <img src="truckerwhitefront.png" alt="Trucker Hat" class="camo-hat-thumb">
+        <img src="truckerwhitefront.png" alt="Trucker Hat" class="trucker-hat-thumb">
         <div class="product-info">
             <p>Trucker Hat</p>
             <p>$50</p>

--- a/hats.html
+++ b/hats.html
@@ -200,6 +200,11 @@
             max-height: 78%;
         }
 
+        .product-item img.trucker-hat-thumb {
+            max-width: 68%;
+            max-height: 68%;
+        }
+
         .coming-soon {
             display: flex;
             justify-content: center;
@@ -374,7 +379,7 @@
 
 <div class="product-item">
     <a href="truckerhat.html">
-        <img src="truckerwhitefront.png" alt="Trucker Hat" class="camo-hat-thumb">
+        <img src="truckerwhitefront.png" alt="Trucker Hat" class="trucker-hat-thumb">
         <div class="product-info">
             <p>Trucker Hat</p>
             <p>$50</p>

--- a/new.html
+++ b/new.html
@@ -200,6 +200,11 @@
             max-height: 78%;
         }
 
+        .product-item img.trucker-hat-thumb {
+            max-width: 68%;
+            max-height: 68%;
+        }
+
         .coming-soon {
             display: flex;
             justify-content: center;
@@ -454,7 +459,7 @@
     
 <div class="product-item">
     <a href="truckerhat.html">
-        <img src="truckerwhitefront.png" alt="Trucker Hat">
+        <img src="truckerwhitefront.png" alt="Trucker Hat" class="trucker-hat-thumb">
         <div class="product-info">
             <p>Trucker Hat</p>
             <p>$50</p>


### PR DESCRIPTION
### Motivation
- The trucker hat thumbnail appeared larger than other hat thumbnails on listing pages because it used the default/camo sizing, so a dedicated smaller thumbnail size was needed to improve visual balance.

### Description
- Added a new rule ` .product-item img.trucker-hat-thumb { max-width: 68%; max-height: 68%; }` to the top CSS in `hats.html`, `all.html`, and `new.html`.
- Updated the trucker hat product image tags on the three listing pages to include `class="trucker-hat-thumb"` so only the trucker thumbnail is reduced and other thumbnail rules (e.g., `camo-hat-thumb`) remain unchanged.

### Testing
- No automated test suite is configured for this static HTML/CSS repository, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed60dbde948321bcc89528b5f2d6df)