### PR TITLE
Fix home logo/time stacking and reduce shop footer footprint

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
             margin: 0;
             padding: 0;
             text-align: center;
+            z-index: 2;
         }
 
         .logo-overlay {
@@ -56,10 +57,12 @@
         }
 
         .time {
-            margin-top: -90px; /* Adjusted spacing closer to logo */
+            margin-top: 8px;
             font-size: 0.7rem;
             text-align: center;
             font-weight: 600; /* Semi-bold for time */
+            position: relative;
+            z-index: 1;
         }
 
         .header-line {
@@ -214,7 +217,7 @@
             }
 
             .time {
-                margin-top: -110px; /* Move time closer to logo on mobile */
+                margin-top: 8px;
             }
 
             .cookie-banner {
@@ -239,7 +242,7 @@
             }
 
             .time {
-                margin-top: -100px; /* Keep time in place as logo moves up */
+                margin-top: 12px;
             }
 
         .social-icons {

--- a/shop.html
+++ b/shop.html
@@ -168,7 +168,7 @@
             display: flex;
             justify-content: center;
             flex-wrap: wrap;
-            gap: 15px;
+            gap: 8px;
             background-color: #f7f7f7; /* Footer background color */
         }
 
@@ -176,8 +176,8 @@
             display: flex;
             justify-content: center;
             flex-wrap: wrap;
-            gap: 15px;
-            padding-bottom: 10px;
+            gap: 10px;
+            padding-bottom: 6px;
         }
 
         .footer-line.extra-padding {
@@ -185,13 +185,13 @@
         }
 
         .footer-line.less-padding {
-            padding-bottom: 25px;
+            padding-bottom: 10px;
         }
 
         .footer-links a {
             color: #000;
             text-decoration: none;
-            font-size: 0.7rem;
+            font-size: 0.65rem;
             transition: all 0.3s ease;
         }
 
@@ -282,12 +282,12 @@
             }
 
             footer {
-                position: fixed;
-                bottom: 0;
+                position: static;
                 width: 100%;
                 text-align: center;
                 background-color: #f7f7f7; /* Apply the off-white background color for desktop footer */
-                padding: 20px 0;
+                padding: 8px 0;
+                margin-top: 20px;
             }
 
             footer .footer-links {
@@ -296,15 +296,15 @@
             }
 
             .footer-line {
-                justify-content: space-between;
+                justify-content: center;
                 flex-wrap: wrap;
-                width: 70%;
-                font-size: 0.9rem;
-                letter-spacing: 0.1rem;
+                width: min(90%, 820px);
+                font-size: 0.65rem;
+                letter-spacing: 0.02rem;
             }
 
             .footer-links {
-                padding-bottom: 30px;
+                padding-bottom: 10px;
             }
 
             .full-site-link {
@@ -428,9 +428,7 @@
 </nav>
 
 <footer>
-    <br>
-    <br>
-        <div class="footer-links">
+    <div class="footer-links">
         <div class="footer-line extra-padding">
             <a href="shop.html">shop</a>
             <a href="all.html">view all</a>
@@ -438,8 +436,6 @@
             <a href="soon.html">lookbook</a>
             <a href="news.html">news</a>
         </div>
-        <br>
-        <br>
         <div class="footer-line">
             <a href="random.html">random</a>
             <a href="about.html">about</a>


### PR DESCRIPTION
### Motivation
- Windows desktop layouts showed the vectary logo iframe overlapping the date/time on `index.html` and the `shop.html` footer was large enough to cut off navigation links, so the pages should match the compact appearance seen on Apple desktop screens.

### Description
- Updated `index.html` CSS to give the `.logo-container` a higher stacking context and made `.time` use positive margins with `z-index: 1` so the logo iframe visually sits above the date/time across breakpoints.
- Adjusted mobile and desktop `.time` margin values to remove negative offsets so the time block no longer overlaps the iframe on Windows sizes.
- Updated `shop.html` footer styling to reduce gaps and paddings (`.footer-links`, `.footer-line`, `.footer-line.less-padding`) and decreased footer link size to `0.65rem` for a more compact look.
- Changed desktop footer positioning from `fixed` to `static`, reduced footer padding and removed extra `<br>` spacers in the footer markup to prevent the footer from overlaying navigation links.

### Testing
- Ran `git diff -- index.html shop.html` to review the applied changes and it completed successfully.
- Ran `git status --short` to confirm the working tree state and it completed successfully.
- Executed the Python replacement script used to apply the CSS/HTML edits and it ran without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edacf5013c8321a7035dda8063f60e)