### PR TITLE
Improve Apple Pay detection and troubleshooting messaging on checkout

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -600,9 +600,23 @@ async function startApplePayPayment(lineItems, customerEmail = '') {
     });
 
     const availability = await paymentRequest.canMakePayment();
-    const hasApplePay = Boolean(availability && availability.applePay);
+    const nativeApplePayAvailable = typeof window !== 'undefined'
+        && typeof window.ApplePaySession !== 'undefined'
+        && typeof window.ApplePaySession.canMakePayments === 'function'
+        && window.ApplePaySession.canMakePayments();
+    const hasApplePay = Boolean(
+        availability?.applePay
+        || availability?.wallets?.applePay
+        || nativeApplePayAvailable
+    );
     if (!hasApplePay) {
-        throw new Error('Apple Pay is not available on this device/browser right now. On iPhone, use Safari with Apple Pay set up in Wallet.');
+        const isSecureContext = window.location.protocol === 'https:' || window.location.hostname === 'localhost';
+        const baseMessage = 'Apple Pay is unavailable for this checkout right now.';
+        const setupHint = 'If Wallet is already set up, this domain may not be verified for Apple Pay in Stripe yet.';
+        const contextHint = isSecureContext
+            ? setupHint
+            : 'Apple Pay requires HTTPS (or localhost during development).';
+        throw new Error(`${baseMessage} ${contextHint}`);
     }
 
     await new Promise((resolve, reject) => {
@@ -675,13 +689,15 @@ async function startApplePayPayment(lineItems, customerEmail = '') {
         try {
             showResult = paymentRequest.show();
         } catch (error) {
-            finalize(() => reject(new Error(error.message || 'Unable to open Apple Pay sheet.')));
+            const defaultMessage = 'Unable to open Apple Pay sheet. If Wallet is set up, verify this site domain is registered for Apple Pay in Stripe.';
+            finalize(() => reject(new Error(error.message || defaultMessage)));
             return;
         }
 
         if (showResult && typeof showResult.catch === 'function') {
             showResult.catch((error) => {
-                finalize(() => reject(new Error(error.message || 'Unable to open Apple Pay sheet.')));
+                const defaultMessage = 'Unable to open Apple Pay sheet. If Wallet is set up, verify this site domain is registered for Apple Pay in Stripe.';
+                finalize(() => reject(new Error(error.message || defaultMessage)));
             });
         }
     });


### PR DESCRIPTION
### Motivation
- Prevent false “device/browser not available” errors for Apple Pay on supported iPhones by making availability checks more robust. 
- Provide users actionable guidance when Apple Pay fails because of site configuration or non-secure contexts. 
- Make fallback error text clearer when the Apple Pay sheet cannot be opened so troubleshooting points to domain/Stripe setup instead of implying a device/browser fault.

### Description
- Enhanced Apple Pay availability detection in `cart.js` to combine Stripe `paymentRequest.canMakePayment()` results with native `ApplePaySession.canMakePayments()` checks and support `availability.wallets.applePay` fields. 
- Replaced the generic unavailable error with a context-aware message that differentiates HTTPS/localhost requirements from likely Stripe domain verification/configuration issues. 
- Improved fallback error text used when `paymentRequest.show()` throws or rejects to recommend verifying the site domain registration for Apple Pay in Stripe.

### Testing
- Ran `node --check cart.js` in the project root and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00567e16883218e46aa11cf0931c9)