### PR TITLE
Add fallback from Apple Pay sheet to server-side Stripe Checkout

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -727,8 +727,23 @@ async function startStripeCheckout(method = 'Stripe', customerEmail = '') {
     }
 
     if (method === 'Apple Pay') {
-        await startApplePayPayment(lineItems, customerEmail);
-        return;
+        try {
+            await startApplePayPayment(lineItems, customerEmail);
+            return;
+        } catch (err) {
+            if (stripeSettings.checkoutEndpoint) {
+                const fallbackMessage = 'Apple Pay quick sheet is unavailable on this device/browser right now. Redirecting to secure checkout where Apple Pay may still be available.';
+                alert(`${err?.message || 'Unable to start Apple Pay.'} ${fallbackMessage}`);
+                try {
+                    await startServerCheckout(method, lineItems, customerEmail);
+                    return;
+                } catch (serverErr) {
+                    alert(serverErr.message || 'Unable to start server-side checkout.');
+                    return;
+                }
+            }
+            throw err;
+        }
     }
 
     if (stripeSettings.checkoutEndpoint) {


### PR DESCRIPTION
### Motivation
- Apple Pay was failing on some devices/browsers when the native payment sheet could not be opened or completed, causing the checkout to hard-fail. 
- Provide a seamless fallback to the hosted/server-created Stripe Checkout so customers can still complete payment when the quick Apple Pay flow is unavailable.

### Description
- Wrapped the direct Apple Pay flow (`startApplePayPayment`) in a `try/catch` inside `startStripeCheckout` in `cart.js` to detect failures and avoid a hard error. 
- When Apple Pay initialization fails and `stripeSettings.checkoutEndpoint` is configured, the code now shows an alert explaining the fallback and calls `startServerCheckout` to redirect to a server-created Stripe Checkout session. 
- Server-side checkout errors are caught and surfaced with an alert, while the original Apple Pay error is rethrown if no checkout endpoint exists, preserving prior behavior for unconfigured environments. 

### Testing
- Ran `node --check cart.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f013aea4a883219861efa215621868)