### PR TITLE
Improve Apple Pay fallback to embedded checkout form

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -736,6 +736,32 @@ async function startApplePayPayment(lineItems, customerEmail = '') {
     });
 }
 
+
+function activateEmbeddedCardFallback(message) {
+    const activeCheckout = document.querySelector('#cart-modal #final-checkout[style*="display: block"], #cart-modal #final-checkout:not([style*="display: none"])')
+        || document.querySelector('#final-checkout');
+    if (!activeCheckout) {
+        if (message) alert(message);
+        return false;
+    }
+
+    const creditRadio = activeCheckout.querySelector('input[name="payment-method"][value="credit"]');
+    if (creditRadio) {
+        creditRadio.checked = true;
+        creditRadio.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    const form = activeCheckout.querySelector('form.checkout-form');
+    if (form) {
+        ensureEmbeddedPaymentReady(form).catch(() => {});
+    }
+
+    if (message) {
+        alert(message + ' Please continue with secure card checkout below.');
+    }
+    return true;
+}
+
 async function startStripeCheckout(method = 'Stripe', customerEmail = '') {
     if (!cart.length) {
         alert('Your cart is empty.');
@@ -764,8 +790,12 @@ async function startStripeCheckout(method = 'Stripe', customerEmail = '') {
             await startApplePayPayment(lineItems, customerEmail);
             return;
         } catch (err) {
-            const applePayFallbackMessage = 'Apple Pay quick sheet is unavailable on this device/browser right now. Redirecting to secure checkout where Apple Pay may still be available.';
-            alert(`${err?.message || 'Unable to start Apple Pay.'} ${applePayFallbackMessage}`);
+            const applePayFallbackMessage = 'Apple Pay quick sheet is unavailable on this device/browser right now.';
+            const fallbackNotice = `${err?.message || 'Unable to start Apple Pay.'} ${applePayFallbackMessage}`;
+            if (activateEmbeddedCardFallback(fallbackNotice)) {
+                return;
+            }
+            alert(`${fallbackNotice} Redirecting to secure checkout where Apple Pay may still be available.`);
             if (stripeSettings.checkoutEndpoint) {
                 try {
                     await startServerCheckout(method, lineItems, customerEmail);


### PR DESCRIPTION
### Motivation
- Apple Pay quick sheet can fail to open on some devices/browsers and previously always fell back to a redirect, breaking the in-page checkout flow. 
- Provide a better in-page user experience by switching to the secure embedded card form when the Apple Pay sheet is unavailable. 
- Reduce friction by auto-initializing the embedded Stripe payment element so users can complete payment without leaving the current page.

### Description
- Added a new helper `activateEmbeddedCardFallback` that locates the active checkout area, auto-selects the credit card payment radio, dispatches a change event, and calls `ensureEmbeddedPaymentReady` to initialize the Stripe Payment Element. 
- Updated the Apple Pay error path inside `startStripeCheckout` to attempt the embedded fallback first and only proceed to redirect-based server/client checkout if no in-page form is available. 
- Adjusted user-facing messaging to surface the fallback notice before redirecting to the secure checkout flow.

### Testing
- Ran `node --check cart.js` to validate the modified JavaScript and the check completed successfully. 
- No automated unit tests exist for checkout flows in this repo, so only static syntax validation was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1630a01a083219d303a52b05baba8)