### PR TITLE
Require Wallet email and enforce native Apple Pay flow

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -668,9 +668,19 @@ async function startApplePayPayment(lineItems, customerEmail = '') {
 
         paymentMethodHandler = async (event) => {
             try {
+                const payerEmail = (event?.payerEmail || '').trim().toLowerCase();
+                if (!payerEmail) {
+                    event.complete('fail');
+                    finalize(() => reject(new Error('Apple Pay requires an email address from Wallet. Please select a Wallet card that shares email, then try again.')));
+                    return;
+                }
+
                 const initialConfirm = await stripe.confirmCardPayment(
                     intentPayload.clientSecret,
-                    { payment_method: event.paymentMethod.id },
+                    {
+                        payment_method: event.paymentMethod.id,
+                        receipt_email: payerEmail
+                    },
                     { handleActions: false }
                 );
 
@@ -790,27 +800,9 @@ async function startStripeCheckout(method = 'Stripe', customerEmail = '') {
             await startApplePayPayment(lineItems, customerEmail);
             return;
         } catch (err) {
-            const applePayFallbackMessage = 'Apple Pay quick sheet is unavailable on this device/browser right now.';
-            const fallbackNotice = `${err?.message || 'Unable to start Apple Pay.'} ${applePayFallbackMessage}`;
-            if (activateEmbeddedCardFallback(fallbackNotice)) {
-                return;
-            }
-            alert(`${fallbackNotice} Redirecting to secure checkout where Apple Pay may still be available.`);
-            if (stripeSettings.checkoutEndpoint) {
-                try {
-                    await startServerCheckout(method, lineItems, customerEmail);
-                    return;
-                } catch (serverErr) {
-                    alert(`${serverErr.message || 'Unable to start server-side checkout.'} Trying direct Stripe checkout.`);
-                }
-            }
-            try {
-                await startClientCheckout(lineItems);
-                return;
-            } catch (clientErr) {
-                alert(clientErr.message || 'Unable to start direct Stripe checkout.');
-                return;
-            }
+            const applePayFailureMessage = `${err?.message || 'Unable to start Apple Pay.'} We are not redirecting Apple Pay to hosted checkout; please complete payment from the Apple Pay sheet.`;
+            activateEmbeddedCardFallback(applePayFailureMessage);
+            return;
         }
     }
 


### PR DESCRIPTION
### Motivation
- Ensure Apple Pay uses the native Apple Wallet sheet (not redirecting to Stripe Checkout) and that an email address is collected from the Wallet for customer contact and receipts.
- Avoid silently falling back to hosted Stripe Checkout for Apple Pay failures, preferring the embedded card form instead.

### Description
- Added a check for `event.payerEmail` in the Apple Pay `paymentmethod` handler and fail the payment if no email is provided. 
- Pass the Wallet email into Stripe as `receipt_email` when calling `stripe.confirmCardPayment` for Apple Pay.
- Removed the previous Apple Pay fallback path that attempted to redirect users to hosted Stripe Checkout, and replaced it with a call to `activateEmbeddedCardFallback` with a clear message.
- Changes applied to `cart.js` to enforce the above behavior.

### Testing
- Ran `node --check cart.js` to validate syntax, which succeeded.
- Basic smoke validation performed by running the local JS syntax check and confirming the modified file stage; no automated runtime tests were executed in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16466c82c8321bb14ab1c6be4da1b)