### PR TITLE
Apple Pay: fallback to checkout email when Wallet omits payerEmail

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -669,17 +669,14 @@ async function startApplePayPayment(lineItems, customerEmail = '') {
         paymentMethodHandler = async (event) => {
             try {
                 const payerEmail = (event?.payerEmail || '').trim().toLowerCase();
-                if (!payerEmail) {
-                    event.complete('fail');
-                    finalize(() => reject(new Error('Apple Pay requires an email address from Wallet. Please select a Wallet card that shares email, then try again.')));
-                    return;
-                }
+                const fallbackEmail = (customerEmail || '').trim().toLowerCase();
+                const receiptEmail = payerEmail || fallbackEmail;
 
                 const initialConfirm = await stripe.confirmCardPayment(
                     intentPayload.clientSecret,
                     {
                         payment_method: event.paymentMethod.id,
-                        receipt_email: payerEmail
+                        ...(receiptEmail ? { receipt_email: receiptEmail } : {})
                     },
                     { handleActions: false }
                 );


### PR DESCRIPTION
### Motivation
- Some Apple Pay sessions did not return `event.payerEmail`, which caused the flow to immediately fail even when a checkout email was available.
- The change aims to avoid hard-failing Apple Pay when Wallet omits an email and allow confirmation to proceed using the typed checkout email.

### Description
- Updated the Apple Pay payment handler in `cart.js` to compute `fallbackEmail = (customerEmail || '').trim().toLowerCase()` and `receiptEmail = payerEmail || fallbackEmail` before confirming the payment.
- Only include `receipt_email` in the `stripe.confirmCardPayment` call when `receiptEmail` is present by using `...(receiptEmail ? { receipt_email: receiptEmail } : {})`.
- Removed the early rejection that forced failure when `payerEmail` was missing so Apple Pay can proceed with the checkout email fallback.

### Testing
- Ran `node --check cart.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1840584908321b6ffd73f5271172a)