### PR TITLE
Fix Apple Pay express button not opening payment sheet

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -1243,7 +1243,9 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
             modal.querySelectorAll('.pay-btn').forEach(b => b.classList.remove('selected'));
             btn.classList.add('selected');
         });
-        btn.addEventListener('click', () => {
+        btn.addEventListener('click', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
             handlePayment(btn.dataset.method);
         });
     });
@@ -1958,7 +1960,9 @@ function setupCartPage() {
             page.querySelectorAll('.pay-btn').forEach(b => b.classList.remove('selected'));
             btn.classList.add('selected');
         });
-        btn.addEventListener('click', () => {
+        btn.addEventListener('click', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
             handlePayment(btn.dataset.method);
         });
     });
@@ -2028,7 +2032,9 @@ function setupCheckoutPage() {
             finalPage.querySelectorAll('.pay-btn').forEach(b => b.classList.remove('selected'));
             btn.classList.add('selected');
         });
-        btn.addEventListener('click', () => {
+        btn.addEventListener('click', (event) => {
+            event.preventDefault();
+            event.stopPropagation();
             handlePayment(btn.dataset.method);
         });
     });


### PR DESCRIPTION
### Motivation
- Apple Pay and other express payment buttons could trigger the form's default submit behavior, which can interrupt the Stripe/Apple Pay PaymentRequest flow and prevent the wallet sheet from opening.

### Description
- Added `event.preventDefault()` and `event.stopPropagation()` to `.pay-btn` `click` handlers in `cart.js` (modal, cart page, and final checkout page) so the button click gesture reaches the Stripe/Apple Pay flow without being preempted by form submission.

### Testing
- Ran `node --check cart.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f189a5b34c8321a7a0bc228d680feb)