### PR TITLE
Handle Apple Pay sheet cancellation without triggering card-fallback alert

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -721,7 +721,9 @@ async function startApplePayPayment(lineItems, customerEmail = '') {
         paymentRequest.on('paymentmethod', paymentMethodHandler);
 
         cancelHandler = () => {
-            finalize(() => reject(new Error('Apple Pay payment was canceled.')));
+            const cancelError = new Error('Apple Pay sheet was canceled before payment was authorized.');
+            cancelError.code = 'APPLE_PAY_CANCELED';
+            finalize(() => reject(cancelError));
         };
         paymentRequest.on('cancel', cancelHandler);
 
@@ -797,6 +799,9 @@ async function startStripeCheckout(method = 'Stripe', customerEmail = '') {
             await startApplePayPayment(lineItems, customerEmail);
             return;
         } catch (err) {
+            if (err?.code === 'APPLE_PAY_CANCELED') {
+                return;
+            }
             const applePayFailureMessage = `${err?.message || 'Unable to start Apple Pay.'} We are not redirecting Apple Pay to hosted checkout; please complete payment from the Apple Pay sheet.`;
             activateEmbeddedCardFallback(applePayFailureMessage);
             return;


### PR DESCRIPTION
### Motivation
- Dismissing the Apple Pay sheet was being treated as a hard failure which caused the UI to show the embedded card fallback alert and messaging even when the user simply canceled the Apple Pay sheet.

### Description
- In `cart.js` mark user-initiated Apple Pay cancellations by rejecting with an Error that has `code = 'APPLE_PAY_CANCELED'` when the payment request `cancel` event fires.
- In `startStripeCheckout` treat errors with `err?.code === 'APPLE_PAY_CANCELED'` as a non-failure and return silently instead of calling `activateEmbeddedCardFallback`.
- Preserve existing fallback behavior and messages for other Apple Pay failures so configuration/auth/domain/authentication errors still trigger the card checkout fallback.

### Testing
- Ran `node --check cart.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21756c7708321a719b99b4608eaf4)