### PR TITLE
Require native Apple Pay authorization and stop silent fallback

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -800,11 +800,9 @@ async function startStripeCheckout(method = 'Stripe', customerEmail = '') {
             return;
         } catch (err) {
             if (err?.code === 'APPLE_PAY_CANCELED') {
-                return;
+                throw new Error('Apple Pay was canceled before authorization.');
             }
-            const applePayFailureMessage = `${err?.message || 'Unable to start Apple Pay.'} We are not redirecting Apple Pay to hosted checkout; please complete payment from the Apple Pay sheet.`;
-            activateEmbeddedCardFallback(applePayFailureMessage);
-            return;
+            throw new Error(err?.message || 'Unable to start Apple Pay.');
         }
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the Apple Pay path truly opens the native wallet and requires authorization instead of silently falling back to card checkout or treating failures as success.

### Description
- Changed the Apple Pay branch in `startStripeCheckout` (in `cart.js`) to throw on cancellation (`Apple Pay was canceled before authorization.`) and to rethrow initialization/processing errors instead of calling `activateEmbeddedCardFallback`.

### Testing
- Ran `node --check cart.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2271eba50832190ed04dd53f1aeac)