### PR TITLE
Add Apple Pay fallback to embedded card checkout

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -802,7 +802,12 @@ async function startStripeCheckout(method = 'Stripe', customerEmail = '') {
             if (err?.code === 'APPLE_PAY_CANCELED') {
                 throw new Error('Apple Pay was canceled before authorization.');
             }
-            throw new Error(err?.message || 'Unable to start Apple Pay.');
+            const fallbackMessage = err?.message || 'Unable to start Apple Pay.';
+            const switchedToCard = activateEmbeddedCardFallback(fallbackMessage);
+            if (switchedToCard) {
+                return;
+            }
+            throw new Error(fallbackMessage);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Provide a smooth fallback to the embedded secure card checkout when Apple Pay fails to launch so customers can complete payments instead of hitting a hard error.
- Preserve explicit Apple Pay cancellation behavior (`APPLE_PAY_CANCELED`) so user-initiated cancels are still reported separately.

### Description
- Modified `cart.js` to update the Apple Pay error handling in `startStripeCheckout` so non-cancel failures compute a `fallbackMessage` and call `activateEmbeddedCardFallback(fallbackMessage)`.
- If `activateEmbeddedCardFallback` successfully switches the UI to the embedded card form the function returns early, otherwise the original error is rethrown.

### Testing
- Ran `node --check cart.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22f64e8988321a6f535b7c532657c)