### PR TITLE
Fallback to Stripe Checkout when Apple Pay is unavailable

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -802,12 +802,21 @@ async function startStripeCheckout(method = 'Stripe', customerEmail = '') {
             if (err?.code === 'APPLE_PAY_CANCELED') {
                 throw new Error('Apple Pay was canceled before authorization.');
             }
+
             const fallbackMessage = err?.message || 'Unable to start Apple Pay.';
-            const switchedToCard = activateEmbeddedCardFallback(fallbackMessage);
-            if (switchedToCard) {
-                return;
+            alert(`${fallbackMessage} Continuing to Stripe Checkout.`);
+
+            if (stripeSettings.checkoutEndpoint) {
+                try {
+                    await startServerCheckout('Stripe', lineItems, customerEmail);
+                    return;
+                } catch (serverErr) {
+                    alert(`${serverErr.message || 'Unable to start server-side checkout.'} Trying direct Stripe checkout.`);
+                }
             }
-            throw new Error(fallbackMessage);
+
+            await startClientCheckout(lineItems);
+            return;
         }
     }
 


### PR DESCRIPTION
### Motivation
- Apple Pay initialization can fail due to device, browser, or domain verification issues which blocked customers from completing checkout. 
- The change ensures customers are routed to a working checkout flow instead of stopping on an embedded-card fallback.

### Description
- Updated `startStripeCheckout` in `cart.js` so that when `method === 'Apple Pay'` and `startApplePayPayment` fails (except for `APPLE_PAY_CANCELED`), the code now shows an alert and falls back to Stripe Checkout rather than throwing an error. 
- The fallback first attempts server-side checkout via `startServerCheckout('Stripe', ...)` if `stripeSettings.checkoutEndpoint` is configured, and if that fails it tries client-side checkout via `startClientCheckout(...)`.
- Preserved the existing Apple Pay cancellation handling by still throwing for `err?.code === 'APPLE_PAY_CANCELED'` and added user-facing alerts explaining the fallback path.

### Testing
- Ran syntax check with `node --check cart.js`, which completed successfully.
- No additional automated tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2504452e883219502c4cacb915f24)