### PR TITLE
Improve Apple Pay eligibility diagnostics and user guidance

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -633,8 +633,9 @@ async function startApplePayPayment(lineItems, customerEmail = '') {
     });
 
     const availability = await paymentRequest.canMakePayment();
-    const nativeApplePayAvailable = typeof window !== 'undefined'
-        && typeof window.ApplePaySession !== 'undefined'
+    const hasApplePaySession = typeof window !== 'undefined'
+        && typeof window.ApplePaySession !== 'undefined';
+    const nativeApplePayAvailable = hasApplePaySession
         && typeof window.ApplePaySession.canMakePayments === 'function'
         && window.ApplePaySession.canMakePayments();
     const hasApplePay = Boolean(
@@ -644,12 +645,20 @@ async function startApplePayPayment(lineItems, customerEmail = '') {
     );
     if (!hasApplePay) {
         const isSecureContext = window.location.protocol === 'https:' || window.location.hostname === 'localhost';
-        const baseMessage = 'Apple Pay is unavailable for this checkout right now.';
-        const setupHint = 'If Wallet is already set up, this domain may not be verified for Apple Pay in Stripe yet.';
+        const browserHint = hasApplePaySession
+            ? ''
+            : 'Use Safari on iPhone/iPad or Safari on Mac with Apple Pay enabled.';
         const contextHint = isSecureContext
-            ? setupHint
+            ? 'If Wallet is set up, this domain may not be verified for Apple Pay in Stripe yet.'
             : 'Apple Pay requires HTTPS (or localhost during development).';
-        throw new Error(`${baseMessage} ${contextHint}`);
+        const setupHint = 'On your iPhone, open Settings > Wallet & Apple Pay and confirm Apple Pay is ON with at least one active card.';
+        const parts = [
+            'Apple Pay is unavailable for this checkout right now.',
+            browserHint,
+            contextHint,
+            setupHint
+        ].filter(Boolean);
+        throw new Error(parts.join(' '));
     }
 
     await new Promise((resolve, reject) => {


### PR DESCRIPTION
### Motivation
- Apple Pay attempts could fail silently on unsupported browsers or unverified domains, producing unclear errors for customers.
- The checkout needs clearer, actionable diagnostics so users (especially iPhone users) can resolve common local issues before blaming the merchant integration.

### Description
- Updated `startApplePayPayment` in `cart.js` to explicitly detect presence of `ApplePaySession` before calling `ApplePaySession.canMakePayments()` to avoid calling the API on browsers that don't expose it. 
- Expanded the Apple Pay unavailable error to include a browser hint (recommend Safari), an HTTPS/domain-verification hint, and an iPhone Wallet setup checklist so users receive concrete next steps. 
- Consolidated the various context and setup hints into a single composed error message to reduce ambiguity when Apple Pay is not available.

### Testing
- Ran `node --check cart.js` to validate the modified JavaScript file and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f256f8b4c8832185f077fe5082fbc2)