### PR TITLE
Fix Apple Pay buttons to avoid unintended form submits

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -558,12 +558,12 @@
     <div class="express-checkout">
         <h3>Express checkout</h3>
         <div class="payment-icons">
-            <button class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
-            <button class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
-            <button class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
-            <button class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
-            <button class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna" class="klarna-logo"></button>
-            <button class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
+            <button type="button" class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
+            <button type="button" class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
+            <button type="button" class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
+            <button type="button" class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
+            <button type="button" class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna" class="klarna-logo"></button>
+            <button type="button" class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
         </div>
     </div>
     <form id="checkout-form" style="display:none;">
@@ -577,12 +577,12 @@
         <button type="button" class="signup-btn">Sign Up</button>
         <h3>Express checkout</h3>
         <div class="payment-icons">
-            <button class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
-            <button class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
-            <button class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
-            <button class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
-            <button class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna" class="klarna-logo"></button>
-            <button class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
+            <button type="button" class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
+            <button type="button" class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
+            <button type="button" class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
+            <button type="button" class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
+            <button type="button" class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna" class="klarna-logo"></button>
+            <button type="button" class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
         </div>
     </form>
     <div id="final-checkout" style="display:none;">
@@ -598,12 +598,12 @@
             <button type="button" class="signup-btn">Sign Up</button>
             <h3>Express checkout</h3>
             <div class="payment-icons">
-                <button class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
-                <button class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
-                <button class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
-                <button class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
-                <button class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna" class="klarna-logo"></button>
-                <button class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
+                <button type="button" class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
+                <button type="button" class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
+                <button type="button" class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
+                <button type="button" class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
+                <button type="button" class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna" class="klarna-logo"></button>
+                <button type="button" class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
             </div>
             <div class="or">OR</div>
             <div class="contact-header">

--- a/cart.js
+++ b/cart.js
@@ -1062,12 +1062,12 @@ function createCartModal() {
             <div class="express-checkout">
                 <h3>Express checkout</h3>
                 <div class="payment-icons">
-                    <button class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
-                    <button class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
-                    <button class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
-                    <button class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
-                    <button class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna" class="klarna-logo"></button>
-                    <button class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
+                    <button type="button" class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
+                    <button type="button" class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
+                    <button type="button" class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
+                    <button type="button" class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
+                    <button type="button" class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna" class="klarna-logo"></button>
+                    <button type="button" class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
                 </div>
             </div>
             <form id="checkout-form" style="display:none;">
@@ -1081,12 +1081,12 @@ function createCartModal() {
                 <button type="button" class="signup-btn">Sign Up</button>
                 <h3>Express checkout</h3>
                 <div class="payment-icons">
-                    <button class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
-                    <button class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
-                    <button class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
-                    <button class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
-                    <button class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna" class="klarna-logo"></button>
-                    <button class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
+                    <button type="button" class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
+                    <button type="button" class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
+                    <button type="button" class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
+                    <button type="button" class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
+                    <button type="button" class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna" class="klarna-logo"></button>
+                    <button type="button" class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
                 </div>
             </form>
             <div id="final-checkout" style="display:none;">
@@ -1115,12 +1115,12 @@ function createCartModal() {
                     <button type="button" class="signup-btn">Sign Up</button>
                     <h3>Express checkout</h3>
                     <div class="payment-icons">
-                        <button class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
-                        <button class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
-                        <button class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
-                        <button class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
-                        <button class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna" class="klarna-logo"></button>
-                        <button class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
+                        <button type="button" class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
+                        <button type="button" class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
+                        <button type="button" class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
+                        <button type="button" class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
+                        <button type="button" class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna" class="klarna-logo"></button>
+                        <button type="button" class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
                     </div>
                     <div class="or">OR</div>
                     <div class="contact-header">

--- a/checkout.html
+++ b/checkout.html
@@ -566,12 +566,12 @@
             <button type="button" class="signup-btn">Sign Up</button>
             <h3>Express checkout</h3>
             <div class="payment-icons">
-                <button class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
-                <button class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
-                <button class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
-                <button class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
-                <button class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna" class="klarna-logo"></button>
-                <button class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
+                <button type="button" class="pay-btn" data-method="Shop Pay"><img src="shoppay.png" alt="Shop Pay"></button>
+                <button type="button" class="pay-btn" data-method="Apple Pay"><img src="applepay.png" alt="Apple Pay"></button>
+                <button type="button" class="pay-btn paypal" data-method="PayPal"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></button>
+                <button type="button" class="pay-btn" data-method="Google Pay"><img src="googlepay.png" alt="Google Pay"></button>
+                <button type="button" class="pay-btn" data-method="Klarna"><img src="klarna.png" alt="Klarna" class="klarna-logo"></button>
+                <button type="button" class="pay-btn" data-method="Venmo"><img src="venmo.png" alt="Venmo"></button>
             </div>
             <div class="or">OR</div>
             <div class="contact-header">


### PR DESCRIPTION
### Motivation
- Prevent express checkout icon buttons from acting as implicit form submit buttons which can block JavaScript payment handlers (notably Apple Pay) from running when clicked.
- Ensure the Wallet sheet reliably opens when users click the Apple Pay logo or button inside forms or modal content.

### Description
- Added `type="button"` to all `.pay-btn` elements in `cart.html` so express checkout icons are not treated as submit buttons.
- Added `type="button"` to the `.pay-btn` elements in `checkout.html` for the standalone checkout page for consistency.
- Updated the modal/final checkout templates generated in `cart.js` to render express checkout buttons with `type="button"` so dynamically-injected buttons behave the same at runtime.
- No payment logic or Stripe flow changes were made; this is strictly a DOM/markup behavior fix.

### Testing
- Verified via ripgrep that no `.pay-btn` buttons remain without an explicit `type` attribute using `rg -n "<button class=\"pay-btn|<button class=\"pay-btn paypal" cart.html checkout.html cart.js`, which returned no offending matches (success).
- Inspected modified templates with `nl` and confirmed `type="button"` appears in static and generated express checkout sections (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f262b5b59883218b9d7184c838ceb7)