### PR TITLE
Remove legacy Apple Pay Payment Request flow

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -231,7 +231,6 @@ const unsupportedMethodNotices = {
 
 const paymentHandlers = {
     'Shop Pay': (customerEmail) => startStripeCheckout('Shop Pay', customerEmail),
-    'Apple Pay': (customerEmail) => startStripeCheckout('Apple Pay', customerEmail),
     'PayPal': (customerEmail) => startStripeCheckout('PayPal', customerEmail),
     'Google Pay': (customerEmail) => startStripeCheckout('Google Pay', customerEmail),
     'Klarna': (customerEmail) => startStripeCheckout('Klarna', customerEmail),
@@ -1026,13 +1025,6 @@ function createCartModal() {
                     </div>
                     <p class="card-warning empty-cart-message" style="display:none;">Please complete your secure payment details.</p>
                     <div class="payment-option">
-                        <input type="radio" name="payment-method" id="cart-pay-apple" value="apple">
-                        <label for="cart-pay-apple">
-                            <span class="payment-label">Apple Pay</span>
-                            <span class="payment-logos"><img src="applepay.png" alt="Apple Pay"></span>
-                        </label>
-                    </div>
-                    <div class="payment-option">
                         <input type="radio" name="payment-method" id="cart-pay-paypal" value="paypal">
                         <label for="cart-pay-paypal">
                             <span class="payment-label">PayPal</span>
@@ -1118,19 +1110,6 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
         window.location.href = 'cart.html';
     });
     modal.querySelector('#cart-checkout').addEventListener('click', () => showCheckoutForm(modal));
-    modal.querySelectorAll('.pay-btn').forEach(btn => {
-        btn.addEventListener('pointerdown', () => {
-            modal.querySelectorAll('.pay-btn').forEach(b => b.classList.remove('selected'));
-            btn.classList.add('selected');
-        });
-        btn.addEventListener('click', (event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            handlePayment(btn.dataset.method);
-        });
-    });
-
-
     function updateCartTime() {
         const options = {
             timeZone: 'America/Chicago',
@@ -1529,9 +1508,6 @@ function setupFinalForm(form) {
                 });
             }
             switch (input.value) {
-                case 'apple':
-                    payBtn.textContent = 'Pay with Apple Pay';
-                    break;
                 case 'paypal':
                     payBtn.innerHTML = 'Pay now with <img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal" class="paypal-inline">';
                     paymentMsg.innerHTML = '<div class="redirect-icon">↗</div>After clicking "Pay with PayPal", you will be redirected to PayPal to complete your purchase securely.';
@@ -1716,7 +1692,6 @@ function setupFinalForm(form) {
         }
 
         const methodMap = {
-            apple: 'Apple Pay',
             paypal: 'PayPal',
             shop: 'Shop Pay',
             klarna: 'Klarna'
@@ -1837,17 +1812,6 @@ function setupCartPage() {
     page.querySelector('#cart-checkout').addEventListener('click', () => {
         showFinalPage(page);
     });
-    page.querySelectorAll('.pay-btn').forEach(btn => {
-        btn.addEventListener('pointerdown', () => {
-            page.querySelectorAll('.pay-btn').forEach(b => b.classList.remove('selected'));
-            btn.classList.add('selected');
-        });
-        btn.addEventListener('click', (event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            handlePayment(btn.dataset.method);
-        });
-    });
     const finalForm = page.querySelector('#final-form');
     if (finalForm) {
         setupFinalForm(finalForm);
@@ -1909,17 +1873,6 @@ function setupCheckoutPage() {
         }
     }
     setupFinalForm(finalPage.querySelector('#final-form'));
-    finalPage.querySelectorAll('.pay-btn').forEach(btn => {
-        btn.addEventListener('pointerdown', () => {
-            finalPage.querySelectorAll('.pay-btn').forEach(b => b.classList.remove('selected'));
-            btn.classList.add('selected');
-        });
-        btn.addEventListener('click', (event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            handlePayment(btn.dataset.method);
-        });
-    });
 }
 
 function updateCartCounter() {

--- a/checkout.html
+++ b/checkout.html
@@ -619,13 +619,6 @@
             </div>
             <p class="card-warning empty-cart-message" style="display:none;">Please complete your secure payment details.</p>
             <div class="payment-option">
-                <input type="radio" name="payment-method" id="pay-apple" value="apple">
-                <label for="pay-apple">
-                    <span class="payment-label">Apple Pay</span>
-                    <span class="payment-logos"><img src="applepay.png" alt="Apple Pay"></span>
-                </label>
-            </div>
-            <div class="payment-option">
                 <input type="radio" name="payment-method" id="pay-paypal" value="paypal">
                 <label for="pay-paypal">
                     <span class="payment-label">PayPal</span>
@@ -812,9 +805,6 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
                 });
                 if (!requiresContactAndDeliveryDetails() && emailWarning) emailWarning.style.display = 'none';
                 switch (input.value) {
-                    case 'apple':
-                        payBtn.textContent = 'Pay with Apple Pay';
-                        break;
                     case 'paypal':
                         payBtn.innerHTML = 'Pay now with <img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal" class="paypal-inline">';
                         if (paymentMsg) {


### PR DESCRIPTION
### Motivation
- Remove the old Stripe Payment Request / manual Apple Pay flows that trigger the browser Apple Pay sheet outside of the Stripe Elements Express flow, and ensure Apple Pay is only handled via the Express Checkout Element confirm path.

### Description
- Remove Apple Pay routing from the `paymentHandlers` map so manual routing into legacy flows no longer occurs (updated `cart.js`).
- Remove the Apple Pay radio/input UI and related `case 'apple'` UI logic from cart and checkout markup and scripts so there is no manual Apple Pay button (updated `cart.js` and `checkout.html`).
- Remove the `.pay-btn` click/pointer handlers that invoked manual payment handlers from cart modal, cart page, and final checkout page so manual wallet-opening hooks are no longer registered (updated `cart.js`).
- Preserve and rely on the existing Stripe Express Checkout Element flow (`elements.create("expressCheckout", ...)` and `expressCheckoutElement.on("confirm", ...)`) for Apple Pay via Stripe Elements.

### Testing
- Searched the repo for legacy Payment Request markers with `rg -n "paymentRequest|ApplePaySession|startApplePayPayment|Continuing to Stripe Checkout|data-method=\"Apple Pay\""` and confirmed those legacy markers are no longer present, so the manual Payment Request integration was removed (success).
- Verified the modified files staged and committed with `git status --short` and commit message `Remove legacy Apple Pay Payment Request flow` (success).
- Performed targeted edits and confirmed changes in `cart.js` and `checkout.html` were applied and committed (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f28bd780d083218729f097e144ae19)