### PR TITLE
Fix Apple Pay behavior in cart popup checkout

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -1508,7 +1508,9 @@ function setupFinalForm(form) {
     const signupBtn = form.querySelector('.signup-btn');
     const signupPhone = form.querySelector('input[name="signup_phone"]');
 
-    form.querySelectorAll('input[name="payment-method"]').forEach(input => {
+    const paymentMethodInputs = form.querySelectorAll('input[name="payment-method"]');
+
+    paymentMethodInputs.forEach(input => {
         input.addEventListener('change', () => {
             paymentMsg.innerHTML = '';
             if (emailInput) emailInput.required = requiresContactAndDeliveryDetails();
@@ -1548,6 +1550,27 @@ function setupFinalForm(form) {
             }
         });
     });
+
+    form.querySelectorAll('.payment-option').forEach(option => {
+        option.addEventListener('click', (event) => {
+            if (event.target.closest('.more-logos') || event.target.closest('.more-logos-box')) {
+                return;
+            }
+            const radio = option.querySelector('input[name="payment-method"]');
+            if (!radio) return;
+            if (!radio.checked) {
+                radio.checked = true;
+                radio.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+            const applePayGraphic = event.target.closest('img[alt="Apple Pay"]');
+            if (applePayGraphic && radio.value === 'apple') {
+                event.preventDefault();
+                event.stopPropagation();
+                form.requestSubmit();
+            }
+        });
+    });
+
     addressInputs.forEach(inp => inp.addEventListener('input', () => {
         const warn = fieldWarnings[inp.name];
         if (warn) warn.style.display = 'none';


### PR DESCRIPTION
### Motivation
- Apple Pay flow worked on the full `cart.html` page but clicking the Apple Pay png or the payment rows inside the cart popup did not reliably start checkout. 
- The popup UI should behave the same as the full cart page so users can trigger Apple Pay by clicking the graphic or anywhere on the payment row.

### Description
- Centralized handling of the payment radio inputs by introducing `paymentMethodInputs` in `setupFinalForm` and attaching a shared `change` handler to them. 
- Added a click handler on each `.payment-option` row to select the corresponding radio and dispatch a `change` event so clicking the row acts like selecting the radio. 
- Preserved the existing expanded-card behavior by ignoring clicks originating from `.more-logos` and `.more-logos-box`. 
- Detects clicks on the Apple Pay graphic (`img[alt="Apple Pay"]`) and calls `form.requestSubmit()` when the Apple Pay radio is selected so the popup submission triggers the Apple Pay flow.

### Testing
- Ran `node --check cart.js` and the file passed the Node syntax check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f299cabb508321b732e6e400768b2c)