### PR TITLE
Scope Express Checkout to cart popup root to fix Apple Pay and wallet buttons

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -471,9 +471,9 @@ function buildPaymentIntentEndpoint(checkoutEndpoint) {
     }
 }
 
-async function mountExpressCheckout() {
-    const expressContainer = document.getElementById("express-checkout-element");
-    const expressError = document.getElementById("express-error");
+async function mountExpressCheckout(root = document) {
+    const expressContainer = root.querySelector("#express-checkout-element");
+    const expressError = root.querySelector("#express-error");
     if (!expressContainer) return;
     expressContainer.innerHTML = "";
     if (expressError) expressError.textContent = "";
@@ -504,7 +504,7 @@ async function mountExpressCheckout() {
             buttonTheme: { applePay: "white-outline", googlePay: "white", paypal: "gold" },
             buttonType: { applePay: "plain", googlePay: "pay", paypal: "paypal" }
         });
-        expressCheckoutElement.mount("#express-checkout-element");
+        expressCheckoutElement.mount(expressContainer);
         expressCheckoutElement.on("ready", ({ availablePaymentMethods }) => {
             expressContainer.style.display = availablePaymentMethods ? "block" : "none";
         });
@@ -1368,7 +1368,7 @@ function showCheckoutForm(root = document.getElementById('cart-modal')) {
     const count = root.querySelector('.item-count');
     if (count) count.style.display = 'none';
     root.querySelector('#checkout-form').style.display = 'block';
-    mountExpressCheckout();
+    mountExpressCheckout(root);
     const footer = root.querySelector('.cart-footer');
     if (footer) footer.style.display = 'block';
     const footerLinks = root.querySelector('.footer-links');
@@ -1452,7 +1452,7 @@ function showFinalPage(root = document.getElementById('cart-modal')) {
     const finalPage = root.querySelector('#final-checkout');
     if (finalPage) {
         finalPage.style.display = 'block';
-        mountExpressCheckout();
+        mountExpressCheckout(root);
         populateOrderSummary(finalPage);
         const bar = finalPage.querySelector('.order-summary-bar');
         const details = finalPage.querySelector('.order-summary-details.top-summary');


### PR DESCRIPTION
### Motivation
- The cart popup was initializing Stripe Express Checkout against global DOM selectors which could attach the widget to the wrong (hidden) duplicate element, causing express payment images and Apple Pay behavior to not appear or function in the popup.
- The change scopes initialization to the active popup/root so wallet buttons and payment graphics render where the user can interact with them, matching `cart.html` behavior.

### Description
- Changed `mountExpressCheckout()` to accept an optional `root` parameter with a default of `document` so lookups can be scoped to the active container via `root.querySelector`.
- Switched `expressCheckoutElement.mount()` to mount using the resolved `expressContainer` element instead of a global selector string.
- Updated call sites to pass the active `root` into `mountExpressCheckout(root)` in popup and final-checkout flows so the express checkout element and associated error node are scoped to the popup.
- Preserved default behavior by keeping `root` default to `document` so page-level usage is unchanged.

### Testing
- Ran `node --check cart.js` to validate the modified file parses without syntax errors, and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29b8975cc83219d80f2cd214ec1ae)