### PR TITLE
Fix PayPal icon path and Apple Pay flow consistency in checkout

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -254,6 +254,20 @@ async function handlePayment(method, customerEmail = '') {
     }
 }
 
+function handleExpressButtonClick(root, method) {
+    if (method === 'Apple Pay') {
+        const appleOption = root?.querySelector('input[name="payment-method"][value="apple"]');
+        if (appleOption) {
+            appleOption.checked = true;
+            appleOption.dispatchEvent(new Event('change', { bubbles: true }));
+            const paymentSection = appleOption.closest('.payment-option');
+            if (paymentSection) paymentSection.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            return;
+        }
+    }
+    handlePayment(method);
+}
+
 let stripePromise = null;
 function loadStripeJs() {
     if (window.Stripe) return Promise.resolve();
@@ -1134,7 +1148,7 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
         btn.addEventListener('click', (event) => {
             event.preventDefault();
             event.stopPropagation();
-            handlePayment(btn.dataset.method);
+            handleExpressButtonClick(modal, btn.dataset.method);
         });
     });
 
@@ -1876,7 +1890,7 @@ function setupCartPage() {
         btn.addEventListener('click', (event) => {
             event.preventDefault();
             event.stopPropagation();
-            handlePayment(btn.dataset.method);
+            handleExpressButtonClick(page, btn.dataset.method);
         });
     });
     const finalForm = page.querySelector('#final-form');
@@ -1948,7 +1962,7 @@ function setupCheckoutPage() {
         btn.addEventListener('click', (event) => {
             event.preventDefault();
             event.stopPropagation();
-            handlePayment(btn.dataset.method);
+            handleExpressButtonClick(finalPage, btn.dataset.method);
         });
     });
 }

--- a/checkout.html
+++ b/checkout.html
@@ -629,7 +629,7 @@
                 <input type="radio" name="payment-method" id="pay-paypal" value="paypal">
                 <label for="pay-paypal">
                     <span class="payment-label">PayPal</span>
-                    <span class="payment-logos"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></span>
+                    <span class="payment-logos"><img src="paypal.png" alt="PayPal"></span>
                 </label>
             </div>
             <div class="payment-option shop-pay">
@@ -739,7 +739,7 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
         const paymentRadios = document.querySelectorAll('input[name="payment-method"]');
         paymentRadios.forEach(r => {
             r.addEventListener('change', () => {
-                if (creditRadio.checked) {
+                if (creditRadio.checked || document.getElementById('pay-apple')?.checked) {
                     creditFields.style.display = 'block';
                 } else {
                     creditFields.style.display = 'none';
@@ -800,7 +800,7 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
         const paymentMsg = document.getElementById('payment-message');
 
         const getSelectedPaymentMethod = () => document.querySelector('input[name="payment-method"]:checked')?.value;
-        const requiresContactAndDeliveryDetails = () => getSelectedPaymentMethod() === 'credit';
+        const requiresContactAndDeliveryDetails = () => ['credit', 'apple'].includes(getSelectedPaymentMethod());
 
 
         document.querySelectorAll('input[name="payment-method"]').forEach(input => {
@@ -814,9 +814,12 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
                 switch (input.value) {
                     case 'apple':
                         payBtn.textContent = 'Pay with Apple Pay';
+                        if (paymentMsg) {
+                            paymentMsg.innerHTML = '<div>Use Apple Pay in the secure form below to complete your purchase.</div>';
+                        }
                         break;
                     case 'paypal':
-                        payBtn.innerHTML = 'Pay now with <img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal" class="paypal-inline">';
+                        payBtn.innerHTML = 'Pay now with <img src="paypal.png" alt="PayPal" class="paypal-inline">';
                         if (paymentMsg) {
                             paymentMsg.innerHTML = '<div class="redirect-icon">↗</div>After clicking "Pay with PayPal", you will be redirected to PayPal to complete your purchase securely.';
                         }


### PR DESCRIPTION
### Motivation
- Resolve a missing PayPal image in the checkout UI and stop express Apple Pay from routing users to the generic Stripe Checkout flow instead of the embedded Apple Pay form.
- Make Apple Pay selection behave like the embedded credit-card/Stripe flow on the cart express checkout so required contact/delivery fields and the secure payment form are presented consistently.

### Description
- Replaced external PayPal SVG references with the local `paypal.png` asset in `checkout.html` and in the PayPal CTA markup so the icon loads reliably.
- Treated Apple Pay as an embedded payment method by including it in the contact/delivery requirement check (`requiresContactAndDeliveryDetails`) and by showing the shared `.credit-card-fields` payment element when Apple Pay is selected in `checkout.html`.
- Added a short guidance message when Apple Pay is selected to direct users to the secure embedded form in `checkout.html`.
- Implemented `handleExpressButtonClick` in `cart.js` and wired cart/cart-modal/checkout express buttons to call it so the express Apple Pay button selects the on-page Apple Pay radio and scrolls to the embed instead of immediately invoking the generic redirect path.

### Testing
- Ran `node --check cart.js` to verify there are no JavaScript parse errors and it succeeded.
- Verified the changeset via `git diff` to confirm the modified `checkout.html` and `cart.js` diffs and the intended replacements were applied successfully.
- Ran `git status --short` as a local verification step and observed the expected modified files (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29f2e904083218c689f083cc758de)