### PR TITLE
Cart modal: Make Apple Pay use express-style checkout (no forced contact fields)

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -1522,7 +1522,7 @@ function setupFinalForm(form) {
     const emailWarning = form.querySelector('.email-warning');
     const creditRadio = form.querySelector('input[name="payment-method"][value="credit"]');
     const getSelectedPaymentMethod = () => form.querySelector('input[name="payment-method"]:checked')?.value;
-    const requiresContactAndDeliveryDetails = () => ['credit', 'apple'].includes(getSelectedPaymentMethod());
+    const requiresContactAndDeliveryDetails = () => ['credit'].includes(getSelectedPaymentMethod());
     const addressInputs = form.querySelectorAll('input[name="first_name"], input[name="last_name"], input[name="address"], input[name="city"], input[name="state"], input[name="zip"]');
     const fieldWarnings = {};
     form.querySelectorAll('.field-warning').forEach(p => { fieldWarnings[p.dataset.field] = p; });
@@ -1541,10 +1541,10 @@ function setupFinalForm(form) {
             });
             if (emailWarning) emailWarning.style.display = 'none';
             if (creditFields) {
-                creditFields.style.display = ['credit', 'apple'].includes(input.value) ? 'block' : 'none';
-                if (!['credit', 'apple'].includes(input.value) && cardWarning) cardWarning.style.display = 'none';
+                creditFields.style.display = input.value === 'credit' ? 'block' : 'none';
+                if (input.value !== 'credit' && cardWarning) cardWarning.style.display = 'none';
             }
-            if (['credit', 'apple'].includes(input.value)) {
+            if (input.value === 'credit') {
                 ensureEmbeddedPaymentReady(form).catch(err => {
                     if (cardWarning) {
                         cardWarning.textContent = err.message || 'Unable to load secure payment form.';
@@ -1750,7 +1750,7 @@ function setupFinalForm(form) {
             phoneInput.value = '+1' + phoneInput.value;
         }
         const selectedPayment = form.querySelector('input[name="payment-method"]:checked')?.value || 'credit';
-        if (selectedPayment === 'credit' || selectedPayment === 'apple') {
+        if (selectedPayment === 'credit') {
             submitEmbeddedPayment(form, paymentMsg).catch(err => {
                 if (cardWarning) {
                     cardWarning.textContent = err.message || 'Unable to complete payment.';


### PR DESCRIPTION
### Motivation
- Apple Pay in the cart modal was forcing users to fill contact and shipping fields even when wallet-provided data is available, causing checkout friction.
- The cart modal should behave the same as the existing express checkout on the cart page and allow wallet methods to complete without redundant manual input.

### Description
- Updated `cart.js` so `requiresContactAndDeliveryDetails` only returns true for `credit` payments, not `apple`, removing Apple Pay from contact/address validation.
- Changed the credit UI so the embedded Stripe Payment Element is only shown and initialized when the selected payment method is `credit` (no embedding for Apple Pay).
- Modified submit flow so Apple Pay no longer calls the embedded `submitEmbeddedPayment` path and instead uses the external wallet/redirect payment handler (the same express-style flow used for other wallet methods).
- Applied the changes throughout the cart modal setup and submit handlers in `cart.js` to keep Apple Pay behavior aligned with express checkout.

### Testing
- Ran static syntax check with `node --check cart.js`, which completed successfully.
- No other automated tests were present or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2a12347308321a7ad86eef9411bd5)