### PR TITLE
Fix final checkout Apple Pay button and tax total

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -485,7 +485,7 @@ function buildPaymentIntentEndpoint(checkoutEndpoint) {
     }
 }
 
-async function mountExpressCheckout(container = document) {
+async function mountExpressCheckout(container = document, options = {}) {
     const expressContainer =
         container.querySelector('.apple-pay-express-element') ||
         container.querySelector('#express-checkout-element');
@@ -512,7 +512,7 @@ async function mountExpressCheckout(container = document) {
         const response = await fetch(paymentIntentEndpoint, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ lineItems, cart })
+            body: JSON.stringify({ lineItems, cart, orderAmountCents: options.orderAmountCents, totals: options.totals })
         });
         const payload = await response.json().catch(() => ({}));
         if (!response.ok || !payload.clientSecret) throw new Error(payload.error || "Unable to initialize express checkout.");
@@ -1125,6 +1125,10 @@ ALL SALES FINAL. NO EXCHANGES OR RETURNS</p>
                             <div><strong>Total</strong><strong class="total">$0.00</strong></div>
                         </div>
                     </div>
+                    <div class="apple-pay-bottom-action" style="display:none;">
+  <div class="apple-pay-express-element"></div>
+  <div class="apple-pay-express-error" style="color:red; font-size:12px; margin-top:8px;"></div>
+</div>
                     <button id="final-order-submit" type="submit">Pay now</button>
                     <p id="remember-message" style="display:none;">Your info will be saved to a Shop account. By continuing, you agree to Shop’s <a href="https://shop.app/terms-of-service" target="_blank" style="color:red;">Terms of Service</a> and acknowledge the <a href="https://www.shopify.com/legal/privacy/consumers" target="_blank" style="color:red;">Privacy Policy</a>.</p>
                 </form>
@@ -1531,6 +1535,27 @@ function ensureStarStyles() {
     document.head.appendChild(style);
 }
 
+
+function parseCurrencyToNumber(value) {
+    if (!value) return 0;
+    const cleaned = String(value).replace(/[^0-9.\-]/g, '');
+    const amount = Number.parseFloat(cleaned);
+    return Number.isFinite(amount) ? amount : 0;
+}
+
+function getCheckoutTotalsFromForm(form) {
+    if (!form) return null;
+    const checkout = form.closest('#final-checkout');
+    if (!checkout) return null;
+    const summary = checkout.querySelector('.order-summary-details.bottom-summary') || checkout.querySelector('.order-summary-details');
+    if (!summary) return null;
+    const subtotal = parseCurrencyToNumber(summary.querySelector('.subtotal')?.textContent);
+    const tax = parseCurrencyToNumber(summary.querySelector('.tax')?.textContent);
+    const shipping = parseCurrencyToNumber(summary.querySelector('.shipping')?.textContent);
+    const total = subtotal + tax + shipping;
+    return { subtotal, tax, shipping, total };
+}
+
 function setupFinalForm(form) {
     if (!form) return;
     const payBtn = form.querySelector('#final-order-submit');
@@ -1565,8 +1590,12 @@ function setupFinalForm(form) {
             }
             const finalCheckout = form.closest('#final-checkout');
             const applePayExpressWrapper = finalCheckout ? finalCheckout.querySelector('.apple-pay-express-wrapper') : null;
+            const applePayBottomAction = finalCheckout ? finalCheckout.querySelector('.apple-pay-bottom-action') : null;
             if (applePayExpressWrapper) {
                 applePayExpressWrapper.style.display = input.value === 'apple' ? 'block' : 'none';
+            }
+            if (applePayBottomAction) {
+                applePayBottomAction.style.display = input.value === 'apple' ? 'block' : 'none';
             }
             if (input.value === 'credit') {
                 ensureEmbeddedPaymentReady(form).catch(err => {
@@ -1579,7 +1608,11 @@ function setupFinalForm(form) {
             switch (input.value) {
                 case 'apple':
                     payBtn.style.display = 'none';
-                    mountExpressCheckout(form.closest('#final-checkout') || form);
+                    {
+                        const totals = getCheckoutTotalsFromForm(form);
+                        const orderAmountCents = totals ? Math.round(totals.total * 100) : undefined;
+                        mountExpressCheckout(form.closest('#final-checkout') || form, { orderAmountCents, totals });
+                    }
                     break;
                 case 'paypal':
                     payBtn.innerHTML = 'Pay now with <img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal" class="paypal-inline">';
@@ -1703,6 +1736,8 @@ function setupFinalForm(form) {
     if (finalCheckoutContainer) {
         const applePayExpressWrapper = finalCheckoutContainer.querySelector('.apple-pay-express-wrapper');
         if (applePayExpressWrapper) applePayExpressWrapper.style.display = 'none';
+        const applePayBottomAction = finalCheckoutContainer.querySelector('.apple-pay-bottom-action');
+        if (applePayBottomAction) applePayBottomAction.style.display = 'none';
     }
 
     const remember = form.querySelector('#remember-me');

--- a/stripe-checkout-server.mjs
+++ b/stripe-checkout-server.mjs
@@ -298,6 +298,12 @@ async function handleCreatePaymentIntent(req, res) {
     );
   }
   const customerEmail = typeof body.customerEmail === 'string' ? body.customerEmail.trim().toLowerCase() : '';
+  const providedAmount = body.orderAmountCents ?? body.amountCents;
+  const hasProvidedAmount = providedAmount !== undefined && providedAmount !== null && providedAmount !== '';
+  const normalizedProvidedAmount = hasProvidedAmount ? Number(providedAmount) : null;
+  if (hasProvidedAmount && (!Number.isInteger(normalizedProvidedAmount) || normalizedProvidedAmount <= 0)) {
+    return jsonResponse(res, 400, { error: 'orderAmountCents must be a positive integer.' }, requestOrigin);
+  }
 
   try {
     const priceCache = new Map();
@@ -327,14 +333,26 @@ async function handleCreatePaymentIntent(req, res) {
       throw new Error('Unable to calculate payment amount from Stripe prices.');
     }
 
+    const finalAmount = hasProvidedAmount ? normalizedProvidedAmount : amount;
+
     const params = new URLSearchParams();
-    params.set('amount', String(amount));
+    params.set('amount', String(finalAmount));
     params.set('currency', currency);
     params.set('automatic_payment_methods[enabled]', 'true');
     if (customerEmail) {
       params.set('receipt_email', customerEmail);
       params.set('metadata[customer_email]', customerEmail);
     }
+    const totals = body && typeof body.totals === 'object' && body.totals ? body.totals : {};
+    const subtotal = Number(totals.subtotal);
+    const tax = Number(totals.tax);
+    const shipping = Number(totals.shipping);
+    const total = Number(totals.total);
+    if (Number.isFinite(subtotal)) params.set('metadata[subtotal]', subtotal.toFixed(2));
+    if (Number.isFinite(tax)) params.set('metadata[tax]', tax.toFixed(2));
+    if (Number.isFinite(shipping)) params.set('metadata[shipping]', shipping.toFixed(2));
+    if (Number.isFinite(total)) params.set('metadata[total]', total.toFixed(2));
+    if (Array.isArray(body.cart)) params.set('metadata[cart]', JSON.stringify(body.cart).slice(0, 450));
 
     const paymentIntent = await stripeApiRequest('/v1/payment_intents', {
       method: 'POST',


### PR DESCRIPTION
### Motivation
- Final checkout Apple Pay was missing the bottom Pay action and showed the wrong amount in the wallet because PaymentIntents were only using line-item price sums (excluded tax/shipping). The goal was to reuse the working Express Checkout Apple Pay button at the bottom and ensure the wallet amount matches the displayed checkout total.

### Description
- Added a bottom Apple Pay action container in the final checkout form (`.apple-pay-bottom-action` with `.apple-pay-express-element` and `.apple-pay-express-error`) and left all shop/cart rendering and localStorage logic untouched. (changes in `cart.js`).
- Reused the existing Stripe Express Checkout element by updating `mountExpressCheckout` to accept `options` and posting `orderAmountCents` and `totals` when mounting the express element so the same working Apple Pay button can be mounted in the bottom container. (changes in `cart.js`).
- Added helpers to extract displayed checkout totals (`parseCurrencyToNumber`, `getCheckoutTotalsFromForm`) and wired the Apple Pay payment-method selection to hide the normal Pay Now button, show the bottom Apple Pay action, mount the express element there, and avoid running normal form validation/submit for Apple Pay. (changes in `cart.js`).
- Updated the server `create-payment-intent` handler to accept an optional `orderAmountCents`/`amountCents`, validate it as a positive integer, use it as the PaymentIntent amount when provided (fallback to existing Stripe price calculation), and include subtotal/tax/shipping/total/cart metadata when present. (changes in `stripe-checkout-server.mjs`).

### Testing
- Ran `node --check cart.js` and it passed successfully.
- Searched for legacy Apple Pay flows with `rg -n "paymentRequest|ApplePaySession|startApplePayPayment|Continuing to Stripe Checkout"` and found no matches.
- Verified only intended files were changed (`cart.js`, `stripe-checkout-server.mjs`) and committed the changes.

Notes: shop/cart behavior, product rendering, add-to-cart and cart modal open/close code were intentionally not modified; credit-card flow continues to use the embedded Payment Element and normal Pay Now button; Apple Pay express mount now receives `orderAmountCents = Math.round(total * 100)` so the wallet amount includes subtotal + tax + shipping and matches the displayed checkout total.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2aabdba248321ac3baced0d7ddf68)