### PR TITLE
Fix express checkout rendering and Apple Pay action

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -491,7 +491,11 @@ async function mountExpressCheckout(container = document, options = {}) {
     const expressError =
         container.querySelector('.apple-pay-express-error') ||
         container.querySelector('#express-error');
-    if (!expressContainer) return;
+    if (!expressContainer) {
+        console.error("Express Checkout mount target not found.");
+        if (expressError) expressError.textContent = "Express Checkout unavailable: missing mount target.";
+        return;
+    }
     if (expressContainer.dataset.expressMounted === "true") return;
     expressContainer.innerHTML = "";
     expressContainer.dataset.expressMounted = "mounting";
@@ -519,11 +523,31 @@ async function mountExpressCheckout(container = document, options = {}) {
             clientSecret: payload.clientSecret,
             appearance: { theme: "stripe", variables: { colorText: "#000000", fontFamily: "'Courier New', Courier, monospace" } }
         });
-        const expressCheckoutElement = elements.create("expressCheckout", {
+        const expressOptions = {
             buttonHeight: 50,
-            buttonTheme: { applePay: "white-outline", googlePay: "white", link: "default", amazonPay: "gold", klarna: "default" },
-            paymentMethodOrder: ["apple_pay", "google_pay", "link", "amazon_pay", "klarna"]
-        });
+            buttonTheme: {
+                applePay: "white-outline",
+                googlePay: "white",
+                link: "black",
+                amazonPay: "gold",
+                klarna: "light"
+            },
+            paymentMethods: {
+                applePay: "always",
+                googlePay: "always",
+                link: "auto",
+                amazonPay: "auto",
+                klarna: "auto",
+                paypal: "never"
+            }
+        };
+        let expressCheckoutElement;
+        try {
+            expressCheckoutElement = elements.create("expressCheckout", expressOptions);
+        } catch (createError) {
+            console.error("Express Checkout create error:", createError);
+            throw createError;
+        }
         expressCheckoutElement.mount(expressContainer);
         expressContainer.dataset.expressMounted = "true";
         expressCheckoutElement.on("ready", ({ availablePaymentMethods }) => {
@@ -545,6 +569,7 @@ async function mountExpressCheckout(container = document, options = {}) {
     } catch (error) {
         console.error("Express Checkout Error:", error);
         delete expressContainer.dataset.expressMounted;
+        expressContainer.style.display = "none";
         if (expressError) expressError.textContent = error.message || "Unable to load express checkout.";
     }
 }


### PR DESCRIPTION
### Motivation
- Restore Express Checkout UI and Apple Pay "Pay now" behavior by removing invalid Klarna theme and preventing silent failures during express element creation and mounting.

### Description
- Replaced invalid `klarna: "default"` with the safe `klarna: "light"` and applied the provided safe `expressOptions` (buttonTheme + paymentMethods) when creating the Stripe `expressCheckout` element in `cart.js`.
- Replaced the fragile `paymentMethodOrder` usage with explicit `paymentMethods` visibility controls and wrapped `elements.create("expressCheckout", ...)` in a try/catch to surface creation errors.
- Hardened `mountExpressCheckout` to log and display missing mount-target errors, clear and mark mount state, avoid duplicate mounts, hide the container on failure, and show any Stripe error text inside `.apple-pay-express-error` / `#express-error`.
- Preserved existing final-checkout logic that hides the normal Pay Now only when a real Stripe Express Checkout Apple Pay element is mounted, and left unrelated shop/cart/add-to-cart logic untouched.

### Testing
- Ran `rg -n "buttonTheme|klarna.*default|default.*klarna" cart.js checkout.html cart.html` to confirm no lingering `klarna: "default"` occurrences (pass).
- Ran `rg -n "paymentRequest|ApplePaySession|startApplePayPayment|Continuing to Stripe Checkout" .` to confirm no legacy Apple Pay/paymentRequest code remains (no matches found).
- Ran `node --check cart.js` and `node --check stripe-checkout-server.mjs` to validate JS syntax (both succeeded).
- Committed changes with message `Fix express checkout rendering and Apple Pay action`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b27395e88321a9c0bc67b04be980)