### PR TITLE
Mount express checkout above contact section

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -570,7 +570,7 @@
         <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from maybenot.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
         <button type="button" class="signup-btn">Sign Up</button>
         <h3>Express checkout</h3>
-        <div class="express-checkout-container">
+        <div class="express-checkout-container" data-express-context="checkout-form">
           <div class="apple-pay-express-element"></div>
           <div class="apple-pay-express-error" style="color:red; font-size:12px; margin-top:8px;"></div>
         </div>
@@ -587,7 +587,7 @@
             <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from maybenot.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
             <button type="button" class="signup-btn">Sign Up</button>
             <h3>Express checkout</h3>
-        <div class="express-checkout-container">
+        <div class="express-checkout-container" data-express-context="checkout-form">
           <div class="apple-pay-express-element"></div>
           <div class="apple-pay-express-error" style="color:red; font-size:12px; margin-top:8px;"></div>
         </div>

--- a/cart.js
+++ b/cart.js
@@ -566,10 +566,13 @@ function prewarmExpressCheckout(container = document) {
 
 
 async function mountExpressCheckout(container = document, options = {}) {
+    const contextSelector = options.context ? `[data-express-context="${options.context}"]` : '';
     const expressContainer =
+        (contextSelector && container.querySelector(`${contextSelector} .apple-pay-express-element`)) ||
         container.querySelector('.apple-pay-express-element') ||
         container.querySelector('#express-checkout-element');
     const expressError =
+        (contextSelector && container.querySelector(`${contextSelector} .apple-pay-express-error`)) ||
         container.querySelector('.apple-pay-express-error') ||
         container.querySelector('#express-error');
     if (!expressContainer) return;
@@ -1515,8 +1518,9 @@ function showCheckoutForm(root = document.getElementById('cart-modal')) {
     if (header) header.style.display = 'none';
     const count = root.querySelector('.item-count');
     if (count) count.style.display = 'none';
-    root.querySelector('#checkout-form').style.display = 'block';
-    mountExpressCheckout(root, { forceEstimate: true, context: 'cart-popup-precheckout' });
+    const checkoutFormElement = root.querySelector('#checkout-form');
+    checkoutFormElement.style.display = 'block';
+    mountExpressCheckout(checkoutFormElement, { context: 'checkout-form', forceEstimate: true });
     const footer = root.querySelector('.cart-footer');
     if (footer) footer.style.display = 'block';
     const footerLinks = root.querySelector('.footer-links');
@@ -1600,7 +1604,8 @@ function showFinalPage(root = document.getElementById('cart-modal')) {
     const finalPage = root.querySelector('#final-checkout');
     if (finalPage) {
         finalPage.style.display = 'block';
-        mountExpressCheckout(root, { forceEstimate: true, context: 'cart-page-precheckout' });
+        const finalFormElement = finalPage.querySelector('#final-form');
+        mountExpressCheckout(finalFormElement || finalPage, { context: 'checkout-form', forceEstimate: true });
         populateOrderSummary(finalPage);
         const bar = finalPage.querySelector('.order-summary-bar');
         const details = finalPage.querySelector('.order-summary-details.top-summary');

--- a/checkout.html
+++ b/checkout.html
@@ -565,7 +565,7 @@
             <p class="consent-text">By submitting this form, you consent to receive informational (eg, order updates) and/or marketing texts (eg, cart reminders) from maybenot.com including texts sent by autodialer. Consent is not a condition of purchase. Msg & data rates may apply. Msg frequency varies. Unsubscribe at any time by replying STOP or clicking the unsubscribe link (where available). Privacy Policy & Terms.</p>
             <button type="button" class="signup-btn">Sign Up</button>
             <h3>Express checkout</h3>
-        <div class="express-checkout-container">
+        <div class="express-checkout-container" data-express-context="checkout-form">
           <div class="apple-pay-express-element"></div>
           <div class="apple-pay-express-error" style="color:red; font-size:12px; margin-top:8px;"></div>
         </div>


### PR DESCRIPTION
### Motivation
- Ensure the Express Checkout UI is mounted inside the checkout form between the `Express checkout` heading and the `Contact` section so users see wallet buttons in the correct place. 
- Avoid changing any cart/shop behavior or payment logic while making the express mount reliably scoped and run after the DOM is visible.

### Description
- Updated `mountExpressCheckout` to prefer a scoped selector when `options.context` is provided by searching within `[data-express-context="<context>"]` for both the express element and error element. 
- Changed the cart popup checkout flow to show the checkout form first and then call `mountExpressCheckout(checkoutFormElement, { context: 'checkout-form', forceEstimate: true })` so mounting occurs after the container is visible. 
- Updated the final checkout display to mount express inside the final form using `mountExpressCheckout(finalFormElement || finalPage, { context: 'checkout-form', forceEstimate: true })`. 
- Added `data-express-context="checkout-form"` attributes to the express mount containers in `cart.html` and `checkout.html` so the scoped selector targets the correct container without introducing IDs.

### Testing
- Ran `node --check cart.js` and it completed successfully. 
- Ran `node --check stripe-checkout-server.mjs` and it completed successfully. 
- Verified occurrences with `rg -n "data-express-context=\"checkout-form\"|mountExpressCheckout" cart.js cart.html checkout.html` and confirmed updated references.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2bced74f88321bf91a298d8ae5af4)