### PR TITLE
Fix cart page express checkout mount

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -557,8 +557,10 @@
     <div class="or">OR</div>
     <div class="express-checkout">
   <h3>Express checkout</h3>
-  <div id="express-checkout-element"></div>
-  <div id="express-error" style="color:red; font-size:12px; margin-top:8px;"></div>
+  <div class="express-checkout-container" data-express-context="cart-page">
+    <div class="apple-pay-express-element"></div>
+    <div class="apple-pay-express-error" style="color:red; font-size:12px; margin-top:8px;"></div>
+  </div>
 </div>
     <form id="checkout-form" style="display:none;">
         <h3>Sign up and know first!</h3>

--- a/cart.js
+++ b/cart.js
@@ -559,9 +559,9 @@ async function getExpressCheckoutClientSecret(container = document, options = {}
     return expressCheckoutCache.promise;
 }
 
-function prewarmExpressCheckout(container = document) {
+function prewarmExpressCheckout(container = document, options = {}) {
     if (!cart.length) return;
-    getExpressCheckoutClientSecret(container).catch((err) => console.warn('Express Checkout prewarm skipped:', err.message));
+    getExpressCheckoutClientSecret(container, options).catch((err) => console.warn('Express Checkout prewarm skipped:', err.message));
 }
 
 
@@ -2217,5 +2217,17 @@ document.addEventListener('DOMContentLoaded', () => {
         loadStripeConfig().then(() => loadStripeJs()).then(() => { try { getStripe(); } catch (_) {} });
         prewarmExpressCheckout(document);
         mountExpressCheckout(document);
+
+        const cartPageExpress = document.querySelector('[data-express-context="cart-page"]');
+        const isCartPage = page === 'cart.html';
+        if (cartPageExpress || isCartPage) {
+            prewarmExpressCheckout(document, { context: 'cart-page', forceEstimate: true });
+            requestAnimationFrame(() => {
+                mountExpressCheckout(document, {
+                    context: 'cart-page',
+                    forceEstimate: true
+                });
+            });
+        }
     }, 0);
 });


### PR DESCRIPTION
### Motivation
- Ensure Express Checkout mounts immediately when a user opens `/cart.html` directly so the standalone cart page shows Apple/Google Pay without waiting for the popup or checkout-form flows. 
- Prewarm Stripe/PaymentIntent for the cart-page mount so amounts include estimated tax and shipping (`forceEstimate: true`) while preserving existing popup and checkout-form behavior. 

### Description
- Replace the inline `#express-checkout-element`/`#express-error` in `cart.html` with a dedicated container `<div class="express-checkout-container" data-express-context="cart-page">` containing `.apple-pay-express-element` and `.apple-pay-express-error`. 
- Change `prewarmExpressCheckout` in `cart.js` to accept an `options` parameter and pass it through to `getExpressCheckoutClientSecret` so prewarm can be invoked with `{ context: 'cart-page', forceEstimate: true }`. 
- Add DOMContentLoaded initialization in `cart.js` that detects `data-express-context="cart-page"` or when the page is `cart.html`, then calls `prewarmExpressCheckout(document, { context: 'cart-page', forceEstimate: true })` and mounts via `requestAnimationFrame` using `mountExpressCheckout(document, { context: 'cart-page', forceEstimate: true })`. 
- Preserve context-priority lookup so the requested context is attempted first and existing `checkout-form` and wallet-bottom mounts remain unchanged. 

### Testing
- Ran `node --check cart.js` and it passed. 
- Ran `node --check stripe-checkout-server.mjs` and it passed. 
- Verified with `rg -n "data-express-context=\"cart-page\"|context: \"cart-page\"|context: 'cart-page'|mountExpressCheckout" cart.js cart.html checkout.html` that the new context and mounts are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2bdf64f38832184abe6b831634673)