### PR TITLE
Fix direct cart page express checkout loading

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -567,22 +567,25 @@ function prewarmExpressCheckout(container = document, options = {}) {
 
 async function mountExpressCheckout(container = document, options = {}) {
     const contextSelector = options.context ? `[data-express-context="${options.context}"]` : '';
-    const expressContainer =
-        (contextSelector && container.querySelector(`${contextSelector} .apple-pay-express-element`)) ||
-        container.querySelector('.apple-pay-express-element') ||
-        container.querySelector('#express-checkout-element');
-    const expressError =
-        (contextSelector && container.querySelector(`${contextSelector} .apple-pay-express-error`)) ||
-        container.querySelector('.apple-pay-express-error') ||
-        container.querySelector('#express-error');
+    const isCartPageContext = options.context === 'cart-page';
+    const expressContainer = isCartPageContext
+        ? container.querySelector('[data-express-context="cart-page"] .apple-pay-express-element')
+        : ((contextSelector && container.querySelector(`${contextSelector} .apple-pay-express-element`)) ||
+            container.querySelector('.apple-pay-express-element') ||
+            container.querySelector('#express-checkout-element'));
+    const expressError = isCartPageContext
+        ? container.querySelector('[data-express-context="cart-page"] .apple-pay-express-error')
+        : ((contextSelector && container.querySelector(`${contextSelector} .apple-pay-express-error`)) ||
+            container.querySelector('.apple-pay-express-error') ||
+            container.querySelector('#express-error'));
     if (!expressContainer) return;
-    expressContainer.innerHTML = '<div style="font-size:12px;color:#666;padding:6px 0;">Loading express checkout…</div>';
+    expressContainer.innerHTML = '<div style="font-size:12px;color:#666;padding:6px 0;">Loading express checkout...</div>';
     if (expressError) expressError.textContent = '';
     if (!cart.length) {
         expressContainer.style.display = 'none';
         return;
     }
-    if (!isElementVisible(expressContainer)) {
+    if (!isCartPageContext && !isElementVisible(expressContainer)) {
         requestAnimationFrame(() => mountExpressCheckout(container, options));
         return;
     }
@@ -2213,21 +2216,26 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     setupCartPage();
     setupCheckoutPage();
+    const cartPageExpress = document.querySelector('[data-express-context="cart-page"]');
+    if (cartPageExpress) {
+        mountExpressCheckout(document, {
+            context: 'cart-page',
+            forceEstimate: true
+        }).catch((error) => {
+            const cartExpressError = document.querySelector('[data-express-context="cart-page"] .apple-pay-express-error');
+            if (cartExpressError) cartExpressError.textContent = error.message || 'Unable to load express checkout.';
+            console.error('Cart page Express Checkout mount failed:', error);
+        });
+        setTimeout(() => {
+            loadStripeConfig().then(() => loadStripeJs()).then(() => { try { getStripe(); } catch (_) {} });
+            prewarmExpressCheckout(document, { context: 'cart-page', forceEstimate: true });
+        }, 0);
+        return;
+    }
+
     setTimeout(() => {
         loadStripeConfig().then(() => loadStripeJs()).then(() => { try { getStripe(); } catch (_) {} });
         prewarmExpressCheckout(document);
         mountExpressCheckout(document);
-
-        const cartPageExpress = document.querySelector('[data-express-context="cart-page"]');
-        const isCartPage = page === 'cart.html';
-        if (cartPageExpress || isCartPage) {
-            prewarmExpressCheckout(document, { context: 'cart-page', forceEstimate: true });
-            requestAnimationFrame(() => {
-                mountExpressCheckout(document, {
-                    context: 'cart-page',
-                    forceEstimate: true
-                });
-            });
-        }
     }, 0);
 });


### PR DESCRIPTION
### Motivation
- The cart page Express Checkout was slow or not appearing when opening `/cart.html` due to prewarm/requestAnimationFrame delays and duplicate/racing mount attempts that could target the wrong container.
- The goal was to make the cart-page express buttons appear immediately under “Express checkout” without changing unrelated cart/checkout behavior.

### Description
- Scoped `mountExpressCheckout` so `context: 'cart-page'` only selects `[data-express-context="cart-page"] .apple-pay-express-element` and its corresponding `.apple-pay-express-error` to avoid mounting into other containers.
- Show immediate loading feedback by placing `Loading express checkout...` in the express container before mount and surface errors into `.apple-pay-express-error` when mounting fails.
- Skip the `requestAnimationFrame` visibility wait for the `cart-page` context so the mount runs immediately, and prevent duplicate/racing cart-page mount calls by invoking a single immediate mount on DOMContentLoaded.
- Change the DOMContentLoaded initialization to mount the cart-page express checkout immediately with `forceEstimate: true` and run `prewarmExpressCheckout` / Stripe config load in the background so prewarm does not block rendering.
- All changes are limited to `cart.js` and do not modify the checkout-form or wallet-bottom express flows.

### Testing
- Ran `node --check cart.js`, which completed successfully.
- Ran `node --check stripe-checkout-server.mjs`, which completed successfully.
- Searched for related patterns with `rg -n "data-express-context=\"cart-page\"|context: \"cart-page\"|context: 'cart-page'|prewarmExpressCheckout|mountExpressCheckout" cart.js cart.html checkout.html` to validate mount/prewarm locations and found expected occurrences.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2c65780848321ad614cd51d39ef9d)