### PR TITLE
Fix Stripe config loading and restore wallet buttons

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -649,10 +649,17 @@
                 </label>
             </div>
             <div class="payment-option">
-                <input type="radio" name="payment-method" id="cart2-pay-paypal" value="paypal">
-                <label for="cart2-pay-paypal">
-                    <span class="payment-label">PayPal</span>
-                    <span class="payment-logos"><img src="https://upload.wikimedia.org/wikipedia/commons/b/b5/PayPal.svg" alt="PayPal"></span>
+                <input type="radio" name="payment-method" id="cart2-pay-google" value="google">
+                <label for="cart2-pay-google">
+                    <span class="payment-label">Google Pay</span>
+                    <span class="payment-logos"><img src="gpay.png" alt="Google Pay"></span>
+                </label>
+            </div>
+            <div class="payment-option">
+                <input type="radio" name="payment-method" id="cart2-pay-amazon" value="amazon">
+                <label for="cart2-pay-amazon">
+                    <span class="payment-label">Amazon Pay</span>
+                    <span class="payment-logos"><img src="amazonpay.png" alt="Amazon Pay"></span>
                 </label>
             </div>
             <div class="payment-option shop-pay">
@@ -698,6 +705,10 @@
                     <div><span>Shipping</span><span class="shipping">Select shipping method</span></div>
                     <div><strong>Total</strong><strong class="total">$0.00</strong></div>
                 </div>
+            </div>
+            <div class="wallet-bottom-action" style="display:none;">
+                <div class="wallet-express-element"></div>
+                <div class="wallet-express-error" style="color:red; font-size:12px; margin-top:8px;"></div>
             </div>
             <button id="final-order-submit" type="submit">Pay now</button>
             <p id="remember-message" style="display:none;">Your info will be saved to a Shop account. By continuing, you agree to Shop’s <a href="https://shop.app/terms-of-service" target="_blank" style="color:red;">Terms of Service</a> and acknowledge the <a href="https://www.shopify.com/legal/privacy/consumers" target="_blank" style="color:red;">Privacy Policy</a>.</p>

--- a/cart.js
+++ b/cart.js
@@ -593,6 +593,7 @@ async function mountExpressCheckout(container = document, options = {}) {
     if (expressContainer.dataset.expressMounted === 'true' && expressContainer.dataset.expressSignature === signature) return;
     expressContainer.dataset.expressMounted = 'mounting';
     try {
+        await loadStripeConfig();
         const stripe = await getStripe();
         const clientSecret = await getExpressCheckoutClientSecret(container, options);
         const elements = stripe.elements({ clientSecret, appearance: { theme: 'stripe', variables: { colorText: '#000000', fontFamily: "'Courier New', Courier, monospace" } } });
@@ -637,6 +638,7 @@ async function mountWalletExpressCheckout(form, wallet = 'apple') {
     expressContainer.innerHTML = '';
     if (expressError) expressError.textContent = '';
     try {
+        await loadStripeConfig();
         const stripe = await getStripe();
         const clientSecret = await getExpressCheckoutClientSecret(form, { wallet, context: 'wallet-bottom' });
         const elements = stripe.elements({ clientSecret, appearance: { theme: 'stripe', variables: { colorText: '#000000', fontFamily: "'Courier New', Courier, monospace" } } });
@@ -656,6 +658,45 @@ async function mountWalletExpressCheckout(form, wallet = 'apple') {
         if (expressError) expressError.textContent = error.message || 'Unable to load wallet checkout.';
         return false;
     }
+}
+
+function updatePaymentMethodUI(form) {
+    const selected = form.querySelector('input[name="payment-method"]:checked')?.value;
+    const submitButton = form.querySelector('#final-order-submit');
+    const creditFields = form.querySelector('.credit-card-fields');
+    const walletAction = form.querySelector('.wallet-bottom-action');
+
+    const walletMap = {
+        apple: 'apple',
+        google: 'google',
+        amazon: 'amazon'
+    };
+
+    const selectedWallet = walletMap[selected];
+
+    if (selectedWallet) {
+        if (submitButton) submitButton.style.display = 'none';
+        if (creditFields) creditFields.style.display = 'none';
+        if (walletAction) walletAction.style.display = 'block';
+
+        mountWalletExpressCheckout(form, selectedWallet).catch((error) => {
+            console.error('Wallet button mount failed:', error);
+            const err = form.querySelector('.wallet-express-error');
+            if (err) err.textContent = error.message || 'Unable to load wallet button.';
+        });
+        return;
+    }
+
+    if (walletAction) walletAction.style.display = 'none';
+
+    if (selected === 'credit') {
+        if (submitButton) submitButton.style.display = 'block';
+        if (creditFields) creditFields.style.display = 'block';
+        return;
+    }
+
+    if (submitButton) submitButton.style.display = 'block';
+    if (creditFields) creditFields.style.display = 'none';
 }
 
 const stripeEmbeddedState = {
@@ -1722,10 +1763,7 @@ function setupFinalForm(form) {
                 field.required = requiresContactAndDeliveryDetails();
             });
             if (emailWarning) emailWarning.style.display = 'none';
-            if (creditFields) {
-                creditFields.style.display = input.value === 'credit' ? 'block' : 'none';
-                if (input.value !== 'credit' && cardWarning) cardWarning.style.display = 'none';
-            }
+            if (input.value !== 'credit' && cardWarning) cardWarning.style.display = 'none';
             if (input.value === 'credit') {
                 ensureEmbeddedPaymentReady(form).catch(err => {
                     if (cardWarning) {
@@ -1734,16 +1772,12 @@ function setupFinalForm(form) {
                     }
                 });
             }
-            if (walletBottomAction) walletBottomAction.style.display = 'none';
-            payBtn.style.display = 'block';
             payBtn.textContent = 'Pay now';
-            if (['apple', 'google', 'amazon'].includes(input.value)) {
-                mountWalletExpressCheckout(form, input.value).then((mounted) => {
-                    if (mounted) payBtn.style.display = 'none';
-                }).catch(() => {
-                    payBtn.style.display = 'block';
-                });
+            if (walletBottomAction) {
+                const err = walletBottomAction.querySelector('.wallet-express-error');
+                if (err) err.textContent = '';
             }
+            updatePaymentMethodUI(form);
         });
     });
 
@@ -1771,6 +1805,7 @@ function setupFinalForm(form) {
             if (emailWarning) emailWarning.style.display = 'none';
         });
     }
+    updatePaymentMethodUI(form);
     if (signupBtn && signupPhone && emailInput) {
         signupBtn.addEventListener('click', () => {
             const phone = signupPhone.value.trim();
@@ -2218,6 +2253,10 @@ document.addEventListener('DOMContentLoaded', () => {
     setupCheckoutPage();
     const cartPageExpress = document.querySelector('[data-express-context="cart-page"]');
     if (cartPageExpress) {
+        const cartExpressEl = document.querySelector('[data-express-context="cart-page"] .apple-pay-express-element');
+        if (cartExpressEl) {
+            cartExpressEl.innerHTML = '<div style="font-size:12px;color:#666;padding:6px 0;">Loading express checkout...</div>';
+        }
         mountExpressCheckout(document, {
             context: 'cart-page',
             forceEstimate: true
@@ -2227,14 +2266,14 @@ document.addEventListener('DOMContentLoaded', () => {
             console.error('Cart page Express Checkout mount failed:', error);
         });
         setTimeout(() => {
-            loadStripeConfig().then(() => loadStripeJs()).then(() => { try { getStripe(); } catch (_) {} });
+            loadStripeConfig().then(() => loadStripeJs()).then(() => getStripe()).catch(console.warn);
             prewarmExpressCheckout(document, { context: 'cart-page', forceEstimate: true });
         }, 0);
         return;
     }
 
     setTimeout(() => {
-        loadStripeConfig().then(() => loadStripeJs()).then(() => { try { getStripe(); } catch (_) {} });
+        loadStripeConfig().then(() => loadStripeJs()).then(() => getStripe()).catch(console.warn);
         prewarmExpressCheckout(document);
         mountExpressCheckout(document);
     }, 0);


### PR DESCRIPTION
### Motivation
- Cart express checkout was attempting to use Stripe before `stripe-config.json` was fully loaded which produced spurious “Stripe is not configured” messages on `/cart.html` and prevented express checkout from mounting reliably. 
- Final checkout UI regressed so selecting Apple/Google/Amazon Pay showed the normal “Pay now” flow instead of a wallet-specific button and bottom action. 
- The change restores deterministic init ordering and the previous wallet-specific UX while avoiding unrelated areas (add-to-cart, cart icon, storage, product rendering, credit-card flow internals). 

### Description
- Ensure Stripe config is loaded before `getStripe()` by awaiting `loadStripeConfig()` in `mountExpressCheckout` and `mountWalletExpressCheckout`, and update the DOMContentLoaded preload chain to `loadStripeConfig().then(() => loadStripeJs()).then(() => getStripe()).catch(console.warn)`. 
- Show an immediate loading placeholder for cart-page express checkout (`Loading express checkout...`) and only show the “Stripe is not configured” type errors when config actually fails. 
- Restore wallet-specific final-checkout behavior by adding `updatePaymentMethodUI(form)`, invoking it on payment-method changes and on init, and wiring wallet behavior so credit shows the embedded payment element and wallets show `.wallet-bottom-action`. 
- Add wallet markup and radios in `cart.html` (add `google` and `amazon` radios, add `.wallet-bottom-action .wallet-express-element` and `.wallet-express-error`) and make `mountWalletExpressCheckout` mount into `.wallet-bottom-action .wallet-express-element` while filtering `paymentMethods` to the selected wallet + optional `link` and never include PayPal. 

### Testing
- Ran `node --check cart.js` which completed successfully. 
- Ran `node --check stripe-checkout-server.mjs` which completed successfully. 
- Ran repository searches for deprecated wallet shims (`paymentRequest|ApplePaySession|startApplePayPayment|Continuing to Stripe Checkout`) which returned no matches. 
- Searched for relevant wiring (`wallet-bottom-action|wallet-express-element|mountWalletExpressCheckout|updatePaymentMethodUI|data-express-context="cart-page"|loadStripeConfig|getStripe`) in `cart.js`, `cart.html`, and `checkout.html` to verify changes were applied and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2c95c09508321bee91edb3df6217e)