### PR TITLE
Fix cart icon click after add to cart

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -1032,6 +1032,7 @@ function addToCart(button) {
     localStorage.setItem('cart', JSON.stringify(cart));
     // TODO: sync with store server for inventory management
     updateCartCounter();
+    ensureCartTriggerBound();
     animateStar(button);
 }
 
@@ -2251,6 +2252,24 @@ function updateCartCounter() {
     }
 }
 
+function ensureCartTriggerBound() {
+    if (window.__mbntCartTriggerBound) return;
+    window.__mbntCartTriggerBound = true;
+
+    document.addEventListener('click', (event) => {
+        const cartTrigger = event.target.closest(
+            '#cart-icon, .cart-icon, [data-cart-trigger], .shopping-cart, .cart-link, .cart-counter'
+        );
+
+        if (!cartTrigger) return;
+        if (cartTrigger.closest('#cart-modal .cart-content')) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+        openCart();
+    });
+}
+
 function ensureCartCounter() {
     let counter = document.getElementById('cart-count')?.closest('.cart-counter');
     if (!counter) {
@@ -2281,7 +2300,7 @@ function ensureCartCounter() {
         }
     }
     counter.style.marginTop = '5px';
-    counter.addEventListener('click', () => openCart());
+    ensureCartTriggerBound();
 
     updateCartCounter();
 
@@ -2295,6 +2314,7 @@ function ensureCartCounter() {
 
 document.addEventListener('DOMContentLoaded', () => {
     initCart();
+    ensureCartTriggerBound();
     preloadStripe().catch(() => {});
     prewarmExpressCheckout(document, { context: 'cart-page', forceEstimate: true }).catch(() => {});
     const page = window.location.pathname.split('/').pop();


### PR DESCRIPTION
### Motivation

- The cart icon became unclickable after the first add-to-cart because the click handler was bound directly to a DOM node that can be replaced or moved during cart/header updates, causing the handler to be lost.

### Description

- Added `ensureCartTriggerBound()` which installs a one-time delegated `document` click listener to detect cart triggers using the selector `#cart-icon, .cart-icon, [data-cart-trigger], .shopping-cart, .cart-link, .cart-counter` and then calls `openCart()`; the guard `window.__mbntCartTriggerBound` prevents duplicate installs.
- Replaced the fragile per-node `counter.addEventListener('click', ...)` binding by calling `ensureCartTriggerBound()` from `ensureCartCounter()`, from `DOMContentLoaded`, and after cart mutations inside `addToCart()` so the handler survives DOM re-renders.
- The delegated handler ignores clicks that originate inside the existing cart modal (`#cart-modal .cart-content`) and uses `event.preventDefault()` and `event.stopPropagation()` before opening the cart to avoid interference.
- No changes were made to Express Checkout, Stripe/payment flows, tax/shipping, PaymentIntent logic, or product/pricing data; the fix is scoped only to cart trigger binding and robustness.

### Testing

- Ran `node --check cart.js` which completed successfully and shows the updated `cart.js` with `ensureCartTriggerBound()` present.
- Verified the change compiles with no syntax errors after integrating the delegated handler into `ensureCartCounter()`, `addToCart()`, and on `DOMContentLoaded`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39ca062108321983f49a0b81bc8e8)