### PR TITLE
Add Espresso color variants and 3 Pack Dark Colors

### DIFF
--- a/blankhoodie.html
+++ b/blankhoodie.html
@@ -66,7 +66,7 @@
 </div>
 </header>
 <div class="product-item" data-product="blank-hoodie" data-price="60" data-price-id="blank-hoodie" data-selected-color="" data-size="">
-    <div class="image-slider" data-images="blankblackhoodie.png,blankblackhoodieback.png,blankwhitehoodie.png,blankwhitehoodieback.png,blankgrayhoodie.png,blankgrayhoodieback.png">
+    <div class="image-slider" data-images="blankblackhoodie.png,blankblackhoodieback.png,blankwhitehoodie.png,blankwhitehoodieback.png,blankgrayhoodie.png,blankgrayhoodieback.png,blankespressohoodie.png,blankespressohoodieback.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="blankblackhoodie.png" alt="Blank Hoodie">
         <button class="next">&#10095;</button>
@@ -77,6 +77,7 @@
         <span class="color-option" data-color="black" data-image="blankblackhoodie.png" style="background:#000;"></span>
         <span class="color-option" data-color="white" data-image="blankwhitehoodie.png" style="background:#fff;border:1px solid #000;"></span>
         <span class="color-option" data-color="gray" data-image="blankgrayhoodie.png" style="background:#808080;"></span>
+        <span class="color-option" data-color="espresso" data-image="blankespressohoodie.png" style="background:#4b342a;"></span>
     </div>
     <div class="size-select">
         <select>

--- a/blankshirt.html
+++ b/blankshirt.html
@@ -168,7 +168,7 @@
 </div>
 </header>
 <div class="product-item" data-product="blank-shirt" data-price="15" data-price-id="blank-shirt" data-selected-color="" data-size="" data-style="single">
-    <div class="image-slider" data-images="blankblackshirt.png,blankwhiteshirt.png,blankgrayshirt.png,blankblackshirtback.png,blankwhiteshirtback.png,blankgrayshirtback.png,3packblackshirts.png,3packwhiteshirts.png,3packgrayshirts.png,3packcomboshirts.png">
+    <div class="image-slider" data-images="blankblackshirt.png,blankwhiteshirt.png,blankgrayshirt.png,blankespressoshirt.png,blankblackshirtback.png,blankwhiteshirtback.png,blankgrayshirtback.png,blankespressoshirtback.png,3packblackshirts.png,3packwhiteshirts.png,3packgrayshirts.png,3packcomboshirts.png,3packespressodarkshirts.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="blankblackshirt.png" alt="Blank T-Shirt">
         <button class="next">&#10095;</button>
@@ -179,10 +179,12 @@
         <span class="color-option" data-color="black" data-style="single" data-price="15" data-price-id="blank-shirt" data-image="blankblackshirt.png" data-images="blankblackshirt.png,blankblackshirtback.png" style="background:#000;" title="Single Black"></span>
         <span class="color-option" data-color="white" data-style="single" data-price="15" data-price-id="blank-shirt" data-image="blankwhiteshirt.png" data-images="blankwhiteshirt.png,blankwhiteshirtback.png" style="background:#fff;border:1px solid #000;" title="Single White"></span>
         <span class="color-option" data-color="gray" data-style="single" data-price="15" data-price-id="blank-shirt" data-image="blankgrayshirt.png" data-images="blankgrayshirt.png,blankgrayshirtback.png" style="background:#808080;" title="Single Gray"></span>
+        <span class="color-option" data-color="espresso" data-style="single" data-price="15" data-price-id="blank-shirt" data-image="blankespressoshirt.png" data-images="blankespressoshirt.png,blankespressoshirtback.png" style="background:#4b342a;" title="Single Espresso"></span>
         <span class="color-option" data-color="3pack-black" data-style="3-pack" data-price="30" data-price-id="blank-shirt-3pack" data-image="3packblackshirts.png" style="width:auto;padding:0 8px;line-height:15px;background:#111;color:#fff;font-size:10px;">3PK BLK</span>
         <span class="color-option" data-color="3pack-white" data-style="3-pack" data-price="30" data-price-id="blank-shirt-3pack" data-image="3packwhiteshirts.png" style="width:auto;padding:0 8px;line-height:15px;background:#f5f5f5;color:#000;border:1px solid #000;font-size:10px;">3PK WHT</span>
         <span class="color-option" data-color="3pack-gray" data-style="3-pack" data-price="30" data-price-id="blank-shirt-3pack" data-image="3packgrayshirts.png" style="width:auto;padding:0 8px;line-height:15px;background:#888;color:#fff;font-size:10px;">3PK GRY</span>
         <span class="color-option" data-color="3pack-combo" data-style="3-pack" data-price="30" data-price-id="blank-shirt-3pack" data-image="3packcomboshirts.png" style="width:auto;padding:0 8px;line-height:15px;background:linear-gradient(90deg,#111 0%,#f5f5f5 50%,#888 100%);color:#000;border:1px solid #000;font-size:10px;">3PK MIX</span>
+        <span class="color-option" data-color="3 Pack Dark Colors" data-style="3-pack" data-price="30" data-price-id="blank-shirt-3pack" data-image="3packespressodarkshirts.png" style="width:auto;padding:0 8px;line-height:15px;background:linear-gradient(90deg,#111 0%,#888 50%,#4b342a 100%);color:#fff;border:1px solid #000;font-size:10px;" title="3 Pack Dark Colors (Black, Gray, Espresso)">3PK DRK</span>
     </div>
     <div class="size-select">
         <select>

--- a/hoodie.html
+++ b/hoodie.html
@@ -66,7 +66,7 @@
 </div>
 </header>
 <div class="product-item" data-product="hoodie" data-price="70" data-selected-color="" data-size="">
-    <div class="image-slider" data-images="blackhoodie.png,blackhoodieback.png,whitehoodie.png,whitehoodieback.png,grayhoodie.png,grayhoodieback.png">
+    <div class="image-slider" data-images="blackhoodie.png,blackhoodieback.png,whitehoodie.png,whitehoodieback.png,grayhoodie.png,grayhoodieback.png,espressohoodie.png,espressohoodieback.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="blackhoodie.png" alt="Hoodie">
         <button class="next">&#10095;</button>
@@ -77,6 +77,7 @@
         <span class="color-option" data-color="black" data-image="blackhoodie.png" style="background:#000;"></span>
         <span class="color-option" data-color="white" data-image="whitehoodie.png" style="background:#fff;border:1px solid #000;"></span>
         <span class="color-option" data-color="gray" data-image="grayhoodie.png" style="background:#808080;"></span>
+        <span class="color-option" data-color="espresso" data-image="espressohoodie.png" style="background:#4b342a;"></span>
     </div>
     <div class="size-select">
         <select>

--- a/joggers.html
+++ b/joggers.html
@@ -73,7 +73,7 @@
 
 </header>
 <div class="product-item" data-product="joggers" data-price="60" data-selected-color="" data-size="">
-    <div class="image-slider" data-images="blackjoggers.png,whitejoggers.png">
+    <div class="image-slider" data-images="blackjoggers.png,whitejoggers.png,espressojoggers.png">
         <button class="prev">&#10094;</button>
         <img src="blackjoggers.png" alt="Joggers">
         <button class="next">&#10095;</button>
@@ -83,6 +83,7 @@
     <div class="color-options">
         <span class="color-option" data-color="black" data-image="blackjoggers.png" style="background:#000;"></span>
         <span class="color-option" data-color="white" data-image="whitejoggers.png" style="background:#fff;border:1px solid #000;"></span>
+        <span class="color-option" data-color="espresso" data-image="espressojoggers.png" style="background:#4b342a;"></span>
     </div>
     <div class="size-select">
         <select>

--- a/shirt.html
+++ b/shirt.html
@@ -168,7 +168,7 @@
 </div>
 </header>
 <div class="product-item" data-product="t-shirt" data-price="30" data-selected-color="" data-size="">
-    <div class="image-slider" data-images="blackshirt.png,blackshirtback.png,whiteshirt.png,whiteshirtback.png,grayshirt.png,grayshirtback.png">
+    <div class="image-slider" data-images="blackshirt.png,blackshirtback.png,whiteshirt.png,whiteshirtback.png,grayshirt.png,grayshirtback.png,espressoshirt.png,espressoshirtback.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="blackshirt.png" alt="T-Shirt">
         <button class="next">&#10095;</button>
@@ -179,6 +179,7 @@
         <span class="color-option" data-color="black" data-image="blackshirt.png" style="background:#000;"></span>
         <span class="color-option" data-color="white" data-image="whiteshirt.png" style="background:#fff;border:1px solid #000;"></span>
         <span class="color-option" data-color="gray" data-image="grayshirt.png" style="background:#808080;"></span>
+        <span class="color-option" data-color="espresso" data-image="espressoshirt.png" style="background:#4b342a;"></span>
     </div>
     <div class="size-select">
         <select>


### PR DESCRIPTION
### Motivation

- Introduce an Espresso colorway across apparel so customers can select Espresso for T‑Shirt, Blank T‑Shirt, Hoodie, Blank Hoodie, and Joggers, and add a new 3‑pack dark option (Black, Gray, Espresso) for blank tees.

### Description

- Added Espresso front/back images into each product slider and added matching `<span class="color-option" ...>` entries that set `data-image`/`data-images` for `shirt.html`, `blankshirt.html`, `hoodie.html`, `blankhoodie.html`, and `joggers.html`.
- Added a new blank tee 3‑pack option labeled `3 Pack Dark Colors` that uses `3packespressodarkshirts.png` and reuses the existing `blank-shirt-3pack` price mapping.
- Ensured image filenames used match uploaded assets (`espressoshirt.png`, `espressoshirtback.png`, `blankespressoshirt.png`, `blankespressoshirtback.png`, `espressohoodie.png`, `espressohoodieback.png`, `blankespressohoodie.png`, `blankespressohoodieback.png`, `espressojoggers.png`, `whitejoggers.png`, `blackjoggers.png`).
- No changes were made to existing Stripe price keys or price identifiers; existing price lookup logic in `cart.js` is reused for the new 3‑pack.

### Testing

- Ran repository text searches with `rg` to confirm new `espresso` occurrences and the joggers `data-images` update in the five product pages, and the search results matched the expected files and lines (succeeded). 
- Executed and reviewed the automated update script that applied the replacements and verified the updated `data-images` and `color-option` entries via `nl`/`sed` snippets (succeeded). 
- Verified `cart.js` price lookup still includes the existing `blank-shirt-3pack` key so the new 3‑pack reuses the same Stripe mapping (succeeded). 
- Sanity-checked that the site JS already updates product images from selected variant `data-image`/`data-images` (so product card, variant selector, and cart image behaviors are supported by existing code) (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3e5c918988321b0373688a46cc6e3)