### PR TITLE
Reorder espresso product carousels to white → espresso → black

### DIFF
--- a/blankhoodie.html
+++ b/blankhoodie.html
@@ -66,18 +66,18 @@
 </div>
 </header>
 <div class="product-item" data-product="blank-hoodie" data-price="60" data-price-id="blank-hoodie" data-selected-color="" data-size="">
-    <div class="image-slider" data-images="blankblackhoodie.png,blankblackhoodieback.png,blankwhitehoodie.png,blankwhitehoodieback.png,blankgrayhoodie.png,blankgrayhoodieback.png,blankespressohoodie.png,blankespressohoodieback.png">
+    <div class="image-slider" data-images="blankwhitehoodie.png,blankwhitehoodieback.png,blankespressohoodie.png,blankespressohoodieback.png,blankblackhoodie.png,blankblackhoodieback.png,blankgrayhoodie.png,blankgrayhoodieback.png">
         <button class="prev">&#10094;</button>
-        <img id="product-image" src="blankblackhoodie.png" alt="Blank Hoodie">
+        <img id="product-image" src="blankwhitehoodie.png" alt="Blank Hoodie">
         <button class="next">&#10095;</button>
     </div>
     <h1>Blank Hoodie</h1>
     <p>$60</p>
     <div class="color-options">
-        <span class="color-option" data-color="black" data-image="blankblackhoodie.png" style="background:#000;"></span>
         <span class="color-option" data-color="white" data-image="blankwhitehoodie.png" style="background:#fff;border:1px solid #000;"></span>
-        <span class="color-option" data-color="gray" data-image="blankgrayhoodie.png" style="background:#808080;"></span>
         <span class="color-option" data-color="espresso" data-image="blankespressohoodie.png" style="background:#4b342a;"></span>
+        <span class="color-option" data-color="black" data-image="blankblackhoodie.png" style="background:#000;"></span>
+        <span class="color-option" data-color="gray" data-image="blankgrayhoodie.png" style="background:#808080;"></span>
     </div>
     <div class="size-select">
         <select>

--- a/hoodie.html
+++ b/hoodie.html
@@ -66,18 +66,18 @@
 </div>
 </header>
 <div class="product-item" data-product="hoodie" data-price="70" data-selected-color="" data-size="">
-    <div class="image-slider" data-images="blackhoodie.png,blackhoodieback.png,whitehoodie.png,whitehoodieback.png,grayhoodie.png,grayhoodieback.png,espressohoodie.png,espressohoodieback.png">
+    <div class="image-slider" data-images="whitehoodie.png,whitehoodieback.png,espressohoodie.png,espressohoodieback.png,blackhoodie.png,blackhoodieback.png,grayhoodie.png,grayhoodieback.png">
         <button class="prev">&#10094;</button>
-        <img id="product-image" src="blackhoodie.png" alt="Hoodie">
+        <img id="product-image" src="whitehoodie.png" alt="Hoodie">
         <button class="next">&#10095;</button>
     </div>
     <h1>Hoodie</h1>
     <p>$70</p>
     <div class="color-options">
-        <span class="color-option" data-color="black" data-image="blackhoodie.png" style="background:#000;"></span>
         <span class="color-option" data-color="white" data-image="whitehoodie.png" style="background:#fff;border:1px solid #000;"></span>
-        <span class="color-option" data-color="gray" data-image="grayhoodie.png" style="background:#808080;"></span>
         <span class="color-option" data-color="espresso" data-image="espressohoodie.png" style="background:#4b342a;"></span>
+        <span class="color-option" data-color="black" data-image="blackhoodie.png" style="background:#000;"></span>
+        <span class="color-option" data-color="gray" data-image="grayhoodie.png" style="background:#808080;"></span>
     </div>
     <div class="size-select">
         <select>

--- a/joggers.html
+++ b/joggers.html
@@ -73,17 +73,17 @@
 
 </header>
 <div class="product-item" data-product="joggers" data-price="60" data-selected-color="" data-size="">
-    <div class="image-slider" data-images="blackjoggers.png,whitejoggers.png,espressojoggers.png">
+    <div class="image-slider" data-images="whitejoggers.png,espressojoggers.png,blackjoggers.png">
         <button class="prev">&#10094;</button>
-        <img src="blackjoggers.png" alt="Joggers">
+        <img src="whitejoggers.png" alt="Joggers">
         <button class="next">&#10095;</button>
     </div>
     <h1>Joggers</h1>
     <p>$60</p>
     <div class="color-options">
-        <span class="color-option" data-color="black" data-image="blackjoggers.png" style="background:#000;"></span>
         <span class="color-option" data-color="white" data-image="whitejoggers.png" style="background:#fff;border:1px solid #000;"></span>
         <span class="color-option" data-color="espresso" data-image="espressojoggers.png" style="background:#4b342a;"></span>
+        <span class="color-option" data-color="black" data-image="blackjoggers.png" style="background:#000;"></span>
     </div>
     <div class="size-select">
         <select>

--- a/shirt.html
+++ b/shirt.html
@@ -168,18 +168,18 @@
 </div>
 </header>
 <div class="product-item" data-product="t-shirt" data-price="30" data-selected-color="" data-size="">
-    <div class="image-slider" data-images="blackshirt.png,blackshirtback.png,whiteshirt.png,whiteshirtback.png,grayshirt.png,grayshirtback.png,espressoshirt.png,espressoshirtback.png">
+    <div class="image-slider" data-images="whiteshirt.png,whiteshirtback.png,espressoshirt.png,espressoshirtback.png,blackshirt.png,blackshirtback.png,grayshirt.png,grayshirtback.png">
         <button class="prev">&#10094;</button>
-        <img id="product-image" src="blackshirt.png" alt="T-Shirt">
+        <img id="product-image" src="whiteshirt.png" alt="T-Shirt">
         <button class="next">&#10095;</button>
     </div>
     <h1>T-Shirt</h1>
     <p>$30</p>
     <div class="color-options">
-        <span class="color-option" data-color="black" data-image="blackshirt.png" style="background:#000;"></span>
         <span class="color-option" data-color="white" data-image="whiteshirt.png" style="background:#fff;border:1px solid #000;"></span>
-        <span class="color-option" data-color="gray" data-image="grayshirt.png" style="background:#808080;"></span>
         <span class="color-option" data-color="espresso" data-image="espressoshirt.png" style="background:#4b342a;"></span>
+        <span class="color-option" data-color="black" data-image="blackshirt.png" style="background:#000;"></span>
+        <span class="color-option" data-color="gray" data-image="grayshirt.png" style="background:#808080;"></span>
     </div>
     <div class="size-select">
         <select>


### PR DESCRIPTION
### Motivation
- Ensure espresso color variants appear immediately after white in product image carousels and thumbnails so the visual order is `white` → `espresso` → `black` for a more intuitive swatch flow.
- Make the initially displayed product image default to white for products that offer espresso so the main image matches the thumbnail ordering.

### Description
- Updated `data-images` ordering in `shirt.html`, `hoodie.html`, `blankhoodie.html`, and `joggers.html` to `white` first, `espresso` immediately after white, then `black` (with gray retained after black where applicable).
- Updated the default displayed image `src` in those files to point to the white image so the carousel starts on white.
- Reordered the `.color-option` swatch spans in the same files to match the new carousel/thumbnail sequence.

### Testing
- Ran `rg -n "data-images=|color-option" shirt.html hoodie.html blankhoodie.html joggers.html` to verify the new `data-images` and swatch ordering and observed the expected results.
- Inspected the updated file regions with `nl -ba` and `sed` to confirm the `data-images` values and default `img` `src` were updated as intended, and those checks passed.
- Performed a working-tree check to confirm the four target files were modified accordingly and the changes are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3e74ef6b883219f50ec1d3697caca)