### PR TITLE
Wire MBNT shirt pages to Stripe Price IDs

### DIFF
--- a/mbnt-cancer-shirt.html
+++ b/mbnt-cancer-shirt.html
@@ -167,7 +167,7 @@
     
 </div>
 </header>
-<div class="product-item" data-product="mbnt-cancer-shirt" data-price="33" data-price-id="mbnt-cancer-shirt" data-selected-color="white" data-size="" data-style="single">
+<div class="product-item" data-product="mbnt-cancer-shirt" data-price="33" data-price-id="price_1TS7FD6vAbsTB4QVESOzZ0uu" data-selected-color="white" data-size="" data-style="single">
     <div class="image-slider" data-images="MBNTCANCER.png,blankwhiteshirtback.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="MBNTCANCER.png" alt="MBNT Cancer Shirt">
@@ -176,7 +176,7 @@
     <h1>MBNT Cancer Shirt</h1>
     <p class="dynamic-price">$33</p>
     <div class="color-options">
-        <span class="color-option" data-color="white" data-style="single" data-price="33" data-price-id="mbnt-cancer-shirt" data-image="MBNTCANCER.png" data-images="MBNTCANCER.png,blankwhiteshirtback.png" style="background:#fff;border:1px solid #000;" title="Single White"></span>
+        <span class="color-option" data-color="white" data-style="single" data-price="33" data-price-id="price_1TS7FD6vAbsTB4QVESOzZ0uu" data-image="MBNTCANCER.png" data-images="MBNTCANCER.png,blankwhiteshirtback.png" style="background:#fff;border:1px solid #000;" title="Single White"></span>
     </div>
     <div class="size-select">
         <select>

--- a/mbnt-moon-landing-shirt.html
+++ b/mbnt-moon-landing-shirt.html
@@ -167,7 +167,7 @@
     
 </div>
 </header>
-<div class="product-item" data-product="mbnt-moon-landing-shirt" data-price="33" data-price-id="mbnt-moon-landing-shirt" data-selected-color="white" data-size="" data-style="single">
+<div class="product-item" data-product="mbnt-moon-landing-shirt" data-price="33" data-price-id="price_1TS7Dd6vAbsTB4QVIUD5Udk4" data-selected-color="white" data-size="" data-style="single">
     <div class="image-slider" data-images="MBNTMOONLANDING.png,blankwhiteshirtback.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="MBNTMOONLANDING.png" alt="MBNT Moon Landing Shirt">
@@ -176,7 +176,7 @@
     <h1>MBNT Moon Landing Shirt</h1>
     <p class="dynamic-price">$33</p>
     <div class="color-options">
-        <span class="color-option" data-color="white" data-style="single" data-price="33" data-price-id="mbnt-moon-landing-shirt" data-image="MBNTMOONLANDING.png" data-images="MBNTMOONLANDING.png,blankwhiteshirtback.png" style="background:#fff;border:1px solid #000;" title="Single White"></span>
+        <span class="color-option" data-color="white" data-style="single" data-price="33" data-price-id="price_1TS7Dd6vAbsTB4QVIUD5Udk4" data-image="MBNTMOONLANDING.png" data-images="MBNTMOONLANDING.png,blankwhiteshirtback.png" style="background:#fff;border:1px solid #000;" title="Single White"></span>
     </div>
     <div class="size-select">
         <select>

--- a/mbnt-pro-shops-shirt.html
+++ b/mbnt-pro-shops-shirt.html
@@ -167,7 +167,7 @@
     
 </div>
 </header>
-<div class="product-item" data-product="mbnt-pro-shops-shirt" data-price="33" data-price-id="mbnt-pro-shops-shirt" data-selected-color="white" data-size="" data-style="single">
+<div class="product-item" data-product="mbnt-pro-shops-shirt" data-price="33" data-price-id="price_1TS7EX6vAbsTB4QV2bjSjwHv" data-selected-color="white" data-size="" data-style="single">
     <div class="image-slider" data-images="MBNTPROSHOPS.png,blankwhiteshirtback.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="MBNTPROSHOPS.png" alt="MBNT Pro Shops Shirt">
@@ -176,7 +176,7 @@
     <h1>MBNT Pro Shops Shirt</h1>
     <p class="dynamic-price">$33</p>
     <div class="color-options">
-        <span class="color-option" data-color="white" data-style="single" data-price="33" data-price-id="mbnt-pro-shops-shirt" data-image="MBNTPROSHOPS.png" data-images="MBNTPROSHOPS.png,blankwhiteshirtback.png" style="background:#fff;border:1px solid #000;" title="Single White"></span>
+        <span class="color-option" data-color="white" data-style="single" data-price="33" data-price-id="price_1TS7EX6vAbsTB4QV2bjSjwHv" data-image="MBNTPROSHOPS.png" data-images="MBNTPROSHOPS.png,blankwhiteshirtback.png" style="background:#fff;border:1px solid #000;" title="Single White"></span>
     </div>
     <div class="size-select">
         <select>


### PR DESCRIPTION
### Motivation
- Ensure the three new MBNT shirts use the exact Stripe `price_...` IDs for checkout/cart integration while preserving the existing product layout, images, single-color variant, sizing, and responsive behavior.
- Keep the Baby Not page unchanged and make the new products available on the `New` and `T-Shirts` listing pages.

### Description
- Updated `mbnt-cancer-shirt.html`, `mbnt-pro-shops-shirt.html`, and `mbnt-moon-landing-shirt.html` to replace the product-level `data-price-id` and the single color variant `data-price-id` with the provided Stripe Price IDs (`price_1TS7FD6vAbsTB4QVESOzZ0uu`, `price_1TS7EX6vAbsTB4QV2bjSjwHv`, and `price_1TS7Dd6vAbsTB4QVIUD5Udk4` respectively).
- Left all layout, styling, variant structure, sizing, image handling (front image + `blankwhiteshirtback.png` back), and displayed price (`$33`) unchanged from the existing Blank T-Shirt page structure.
- Verified the three product cards link from `new.html` and `t-shirts.html` to their matching product pages and did not modify `babynot.html`.

### Testing
- Ran `rg -n "mbnt-(cancer|pro-shops|moon-landing)-shirt|price_1TS7" new.html t-shirts.html mbnt-*.html` to confirm presence of pages and price IDs and the command succeeded.
- Executed a small `python` replacement script to inject the `price_...` IDs into the three product HTML files and the script completed successfully.
- Inspected the modified files with `nl -ba <file> | sed -n '165,185p'` to verify the exact `data-price-id` values are present and the checks passed.
- Verified the product cards on `new.html` and `t-shirts.html` include links and show `$33` for each new product and that no edits were made to the Baby Not page; these verifications succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f416e3b1e08321ae07f3f9c43879d8)