### PR TITLE
Tighten logo/time stacking on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,16 @@
             z-index: 2;
         }
 
+        .logo-time-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: flex-start;
+            gap: 2px;
+            margin-top: 100px;
+            width: 100%;
+        }
+
         .logo-overlay {
             position: absolute;
             top: 0;
@@ -57,7 +67,7 @@
         }
 
         .time {
-            margin-top: 8px;
+            margin-top: 0;
             font-size: 0.7rem;
             text-align: center;
             font-weight: 600; /* Semi-bold for time */
@@ -205,9 +215,12 @@
             .container {
                 padding-top: 20px; /* Shift content down slightly on mobile */
             }
+            .logo-time-container {
+                margin-top: 0;
+            }
             .logo-container {
-            position: relative;
-                margin-top: -80px; /* Reduced top margin for mobile */
+                position: relative;
+                margin-top: 0;
                 width: 90vw;
             }
 
@@ -237,12 +250,12 @@
         /* Desktop-Specific Adjustments */
         @media (min-width: 769px) {
             .logo-container {
-            position: relative;
-                margin-top: 100px; /* Raise logo slightly on desktop */
+                position: relative;
+                margin-top: 0;
             }
 
             .time {
-                margin-top: 12px;
+                margin-top: 0;
             }
 
         .social-icons {
@@ -263,12 +276,13 @@
 </div>
 
 <div class="container">
-    <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
-        <div class="logo-overlay"></div>
+    <div class="logo-time-container">
+        <div class="logo-container">
+            <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+            <div class="logo-overlay"></div>
+        </div>
+        <div class="time" id="current-time"></div>
     </div>
-
-    <div class="time" id="current-time"></div>
 
     <!-- Desktop Nav -->
     <nav class="desktop-nav">


### PR DESCRIPTION
### Motivation
- The logo and the Chicago time were visually disconnected due to independent spacing and breakpoint offsets, causing the timestamp to sit too far below the logo on some devices.
- The goal is to keep the logo and time together as a single unit so they remain tightly stacked and never overlap across responsive breakpoints.

### Description
- Added a new wrapper `logo-time-container` and converted it to a vertical flex stack so the logo and time are grouped and stacked tightly with a small gap using `display: flex; flex-direction: column; gap: 2px`.
- Moved the time element into the new wrapper in the HTML so both the iframe logo and `#current-time` share the same container flow.
- Removed per-breakpoint top margins on the logo and time and normalized `margin-top` values to `0` so layout drift between mobile and desktop is eliminated.
- Kept existing responsive sizing for the logo iframe and preserved the `logo-overlay` behavior while adjusting container spacing.

### Testing
- No automated tests were configured or run for this static layout change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41d78d9ec8321ad1be879161836ef)