### PR TITLE
Route root to `shop.html`, add cookie banner to shop, and gate full-site access

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,6 +332,14 @@
         }
     }
     </style>
+<script>
+    (function () {
+        const params = new URLSearchParams(window.location.search);
+        if (!params.has("fullsite")) {
+            window.location.replace("shop.html");
+        }
+    })();
+</script>
 </head>
 <body class="index-page home-page">
 <main>

--- a/shop.html
+++ b/shop.html
@@ -203,6 +203,36 @@
             background-color: white;
         }
 
+        /* Cookie banner styling */
+        .cookie-banner {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            box-sizing: border-box;
+            background: rgba(128, 128, 128, 0.8);
+            padding: 10px 40px 10px 10px;
+            color: #000;
+            font-size: 0.8rem;
+            z-index: 2000;
+            text-align: center;
+        }
+
+        .cookie-banner a {
+            color: #000;
+            text-decoration: underline;
+            font-weight: 600;
+        }
+
+        .cookie-banner .cookie-close {
+            position: absolute;
+            top: 5px;
+            right: 10px;
+            cursor: pointer;
+            font-size: 1.2rem;
+            color: #fff;
+        }
+
         /* Mobile-Specific Nav and Footer */
         @media (max-width: 768px) {
             .header-container {
@@ -374,6 +404,10 @@
 </head>
 <body>
 
+<div class="cookie-banner" id="cookie-banner">
+    This site uses cookies to improve your experience. By continuing to browse, you agree to the use of cookies. Read the <a href="privacy.html">Privacy Policy</a> here.<span class="cookie-close" onclick="closeCookieBanner()">✖</span>
+</div>
+
 <header class="header-container">
     <div class="logo-container">
         <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
@@ -456,7 +490,7 @@
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">
-        <a href="index.html">full site</a>
+        <a href="index.html?fullsite=1">full site</a>
     </div>
 </footer>
 
@@ -486,48 +520,66 @@
 
     // Full-site link is now always visible; no scroll handler needed
 
-                const logoOverlay = document.querySelector(".logo-overlay");
+    // Cookie banner persistence logic
+    function closeCookieBanner() {
+        document.getElementById('cookie-banner').style.display = 'none';
+        localStorage.setItem('cookieBannerClosed', 'true');
+    }
+
+    if (localStorage.getItem('cookieBannerClosed') === 'true') {
+        document.getElementById('cookie-banner').style.display = 'none';
+    }
+
+    const logoOverlay = document.querySelector(".logo-overlay");
     if (logoOverlay) {
         let pressTimer;
-        let moved = false;
+        let startPoint = null;
 
-        const restoreOverlay = () => {
-            logoOverlay.style.display = "block";
+        const getPoint = (event) => {
+            if (event.touches && event.touches[0]) {
+                return { x: event.touches[0].clientX, y: event.touches[0].clientY };
+            }
+            if (event.changedTouches && event.changedTouches[0]) {
+                return { x: event.changedTouches[0].clientX, y: event.changedTouches[0].clientY };
+            }
+            return { x: event.clientX, y: event.clientY };
         };
 
-        const cancel = () => {
+        const cleanup = () => {
             clearTimeout(pressTimer);
+            startPoint = null;
             document.removeEventListener("mousemove", moveHandler);
             document.removeEventListener("touchmove", moveHandler);
-            document.removeEventListener("mouseup", cancel);
-            document.removeEventListener("touchend", cancel);
-            document.removeEventListener("touchcancel", cancel);
-            logoOverlay.style.display = "none";
-            setTimeout(restoreOverlay, 1000);
+            document.removeEventListener("mouseup", cleanup);
+            document.removeEventListener("touchend", cleanup);
+            document.removeEventListener("touchcancel", cleanup);
         };
 
-        const moveHandler = () => {
-            moved = true;
-            cancel();
+        const moveHandler = (event) => {
+            if (!startPoint) return;
+            const current = getPoint(event);
+            if (current.x !== startPoint.x || current.y !== startPoint.y) {
+                cleanup();
+            }
         };
 
-        const startPress = () => {
-            moved = false;
+        const startPress = (event) => {
+            startPoint = getPoint(event);
             document.addEventListener("mousemove", moveHandler);
-            document.addEventListener("touchmove", moveHandler);
-            document.addEventListener("mouseup", cancel);
-            document.addEventListener("touchend", cancel);
-            document.addEventListener("touchcancel", cancel);
+            document.addEventListener("touchmove", moveHandler, { passive: true });
+            document.addEventListener("mouseup", cleanup);
+            document.addEventListener("touchend", cleanup);
+            document.addEventListener("touchcancel", cleanup);
             pressTimer = setTimeout(() => {
-                if (!moved) {
-                    window.location.href = "index.html";
+                if (startPoint) {
+                    window.location.href = "index.html?fullsite=1";
                 }
-                cancel();
+                cleanup();
             }, 600);
         };
 
         logoOverlay.addEventListener("mousedown", startPress);
-        logoOverlay.addEventListener("touchstart", startPress);
+        logoOverlay.addEventListener("touchstart", startPress, { passive: true });
     }
 </script>
 


### PR DESCRIPTION
### Motivation
- Serve `shop.html` as the effective landing page for the site while preserving controlled access to the full site UX. 
- Keep the existing `index.html` full-site experience available only via the “full site” link or a deliberate logo-hold gesture. 
- Reuse the existing cookie banner behavior so both entry pages show the same notice and dismissal persistence. 

### Description
- Added a small redirect gate to `index.html` that sends users to `shop.html` unless the URL contains the `fullsite` query parameter (`index.html` now contains a script that runs `window.location.replace('shop.html')` when `fullsite` is absent). 
- Copied the cookie banner markup, CSS, and dismissal/localStorage logic from `index.html` into `shop.html` so the same banner and close behavior appear on both pages. 
- Updated the shop footer “full site” link to point to `index.html?fullsite=1` so it bypasses the redirect gate. 
- Tightened the logo hold interaction on `shop.html` so the existing 600ms hold still triggers navigation but the action is cancelled immediately if the pointer/finger moves at all (mouse and touch), and the logo hold now navigates to `index.html?fullsite=1`. 

### Testing
- Ran a code search with `rg -n "fullsite|cookie-banner|logo-overlay|window.location.replace(" index.html shop.html` to verify the new strings exist on the expected files, and the search returned the expected matches. 
- Inspected the output diff for `index.html` and `shop.html` with `git diff -- index.html shop.html` to confirm the redirect, cookie banner additions, footer link change, and hold-logic changes are present. 
- Printed file regions with line-numbered output (`nl`/`sed`) to confirm the redirect script is inserted into `index.html` and the cookie-banner and updated hold logic are present in `shop.html`; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4276ca0988321921e9b65948ca3b6)