### PR TITLE
Add sitewide SEO metadata and update About/Home headings

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="About MaybeNot">
-    <title>About MaybeNot</title>
+    <title>About MaybeNot — Chicago Streetwear Brand Founded 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; }
@@ -30,6 +29,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">
@@ -41,6 +68,8 @@
 <div class="header-line"></div>
 </header>
 <main>
+    <h1>MaybeNot: Chicago Streetwear Brand, Est. 2016</h1>
+    <p>MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side, creating athlete-driven apparel rooted in community, sustainability, and Chicago street culture.</p>
     <h1>about</h1>
     <p>Founded in 2016 on Chicago’s North Side, Maybe Not was born from the city’s underground culture, industrial grit, and everyday hustle. Athlete-driven at its core, the brand carries a spirit of discipline, resilience, and performance shaped by sport and city life. Our roots in Chicago’s neighborhoods foster a deep sense of community, where clothing is more than fabric—it’s connection.</p>
     <p>Blending performance and comfort with the edge of street culture, we create apparel for everyday wear that’s built to last and rooted in sustainability. Locally sourced, locally made—Maybe Not is where athletic spirit, community, and Chicago heritage meet the future.</p>

--- a/accessibility.html
+++ b/accessibility.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Accessibility - MaybeNot</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; }
@@ -30,6 +30,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/accessories.html
+++ b/accessories.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop Accessories">
-    <title>MaybeNot Shop - Accessories</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -328,6 +327,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/all-page2.html
+++ b/all-page2.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop All">
-    <title>MaybeNot Shop - All</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -328,6 +327,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/all.html
+++ b/all.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop All">
-    <title>MaybeNot Shop - All</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -338,6 +337,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/americandenim.html
+++ b/americandenim.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="American Denim Jeans product page">
-    <title>American Denim Jeans - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -156,6 +155,34 @@
             display: inline-block;
         }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/babynot-hoodie-set.html
+++ b/babynot-hoodie-set.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="BabyNot Hoodie Set product page">
-    <title>BabyNot Hoodie Set - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -153,6 +152,34 @@
             display: inline-block;
         }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/babynot-onesie.html
+++ b/babynot-onesie.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="BabyNot Onesie product page">
-    <title>BabyNot Onesie - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -153,6 +152,34 @@
             display: inline-block;
         }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/babynot-toddler-tee.html
+++ b/babynot-toddler-tee.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="BabyNot Toddler Tee product page">
-    <title>BabyNot Toddler Tee - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -153,6 +152,34 @@
             display: inline-block;
         }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/babynot.html
+++ b/babynot.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop BabyNot">
-    <title>MaybeNot Shop - BabyNot</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -338,6 +337,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/backpack.html
+++ b/backpack.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Backpack product page">
-    <title>Backpack - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -130,6 +129,34 @@
             display: inline-block;
         }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/bags.html
+++ b/bags.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop Bags">
-    <title>MaybeNot Shop - Bags</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -328,6 +327,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/blankhoodie.html
+++ b/blankhoodie.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Blank Hoodie product page">
-    <title>Blank Hoodie - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -51,6 +50,34 @@
         .color-options { display:flex; gap:5px; margin:5px 0; }
         .color-option { width:15px; height:15px; cursor:pointer; display:inline-block; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/blankshirt.html
+++ b/blankshirt.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Blank T-Shirt product page">
-    <title>Blank T-Shirt - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -153,6 +152,34 @@
             display: inline-block;
         }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/camohat.html
+++ b/camohat.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Camo Hat product page">
-    <title>Camo Hat - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -130,6 +129,34 @@
             display: inline-block;
         }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/cart.html
+++ b/cart.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-    <title>Cart</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -531,6 +531,34 @@
     .logo-container { height: 10vh; }
     .time { margin-top: -5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/category_template.html
+++ b/category_template.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop {{TITLE}}">
-    <title>MaybeNot Shop - {{TITLE}}</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -328,6 +327,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/checkout.html
+++ b/checkout.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-    <title>Checkout</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -530,6 +530,34 @@
             }
         }
     </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
     <header class="header-container">

--- a/contact.html
+++ b/contact.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Contact MaybeNot">
-    <title>Contact MaybeNot</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; }
@@ -35,6 +34,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/dufflebag.html
+++ b/dufflebag.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Duffle Bag product page">
-    <title>Duffle Bag - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -119,6 +118,34 @@
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/faq.html
+++ b/faq.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>FAQ - MaybeNot</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; }
@@ -31,6 +31,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/gym.html
+++ b/gym.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop Gym">
-    <title>MaybeNot Shop - Gym</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -328,6 +327,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/hat.html
+++ b/hat.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Baseball Cap product page">
-    <title>Baseball Cap - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -130,6 +129,34 @@
             display: inline-block;
         }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/hats.html
+++ b/hats.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop Hats">
-    <title>MaybeNot Shop - Hats</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -338,6 +337,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/hoodie.html
+++ b/hoodie.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Hoodie product page">
-    <title>Hoodie - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -51,6 +50,34 @@
         .color-options { display:flex; gap:5px; margin:5px 0; }
         .color-option { width:15px; height:15px; cursor:pointer; display:inline-block; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/index.html
+++ b/index.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot. The official website of MaybeNot. EST 2016. CHICAGO.">
-    <title>MaybeNot</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         html,
@@ -340,8 +339,37 @@
         }
     })();
 </script>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body class="index-page home-page">
+    <h1 style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);">MaybeNot — Chicago Streetwear Brand Since 2016</h1>
 <main>
 
 <div class="cookie-banner" id="cookie-banner">

--- a/jackets.html
+++ b/jackets.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop Jackets">
-    <title>MaybeNot Shop - Jackets</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -328,6 +327,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/joggers.html
+++ b/joggers.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Joggers product page">
-    <title>Joggers - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -58,6 +57,34 @@
         .product-item button { background:#000; color:#fff; border:2px solid #000; font-family:'Courier New', Courier, monospace; cursor:pointer; margin-top:5px; }
         .product-item button:hover, .product-item button:active, .product-item button:focus { background:#fff; color:red; border-color:red; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/mailinglist.html
+++ b/mailinglist.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Mailing List">
-    <title>MaybeNot Mailing List</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; }
@@ -41,6 +40,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/mbnt-cancer-shirt.html
+++ b/mbnt-cancer-shirt.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MBNT Cancer Shirt product page">
-    <title>MBNT Cancer Shirt - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -153,6 +152,34 @@
             display: inline-block;
         }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/mbnt-moon-landing-shirt.html
+++ b/mbnt-moon-landing-shirt.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MBNT Moon Landing Shirt product page">
-    <title>MBNT Moon Landing Shirt - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -153,6 +152,34 @@
             display: inline-block;
         }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/mbnt-pro-shops-shirt.html
+++ b/mbnt-pro-shops-shirt.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MBNT Pro Shops Shirt product page">
-    <title>MBNT Pro Shops Shirt - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -153,6 +152,34 @@
             display: inline-block;
         }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/new-page2.html
+++ b/new-page2.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop New">
-    <title>MaybeNot Shop - New</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -328,6 +327,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/new.html
+++ b/new.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop New">
-    <title>MaybeNot Shop - New</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -338,6 +337,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/news.html
+++ b/news.html
@@ -4,8 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot News">
-    <title>MaybeNot News</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; }
@@ -33,6 +32,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/pants.html
+++ b/pants.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop Pants">
-    <title>MaybeNot Shop - Pants</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -328,6 +327,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/privacy.html
+++ b/privacy.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Privacy - MaybeNot</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; }
@@ -34,6 +34,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/random.html
+++ b/random.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Random">
-    <title>MaybeNot Random</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; }
@@ -31,6 +30,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/shirt.html
+++ b/shirt.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="T-Shirt product page">
-    <title>T-Shirt - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -153,6 +152,34 @@
             display: inline-block;
         }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/shirts.html
+++ b/shirts.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop Shirts">
-    <title>MaybeNot Shop - Shirts</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -328,6 +327,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/shoes.html
+++ b/shoes.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop Shoes">
-    <title>MaybeNot Shop - Shoes</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -328,6 +327,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/shop.html
+++ b/shop.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop">
-    <title>MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -401,6 +400,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/shorts.html
+++ b/shorts.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Shorts product page">
-    <title>Shorts - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -58,6 +57,34 @@
         .product-item button { background:#000; color:#fff; border:2px solid #000; font-family:'Courier New', Courier, monospace; cursor:pointer; margin-top:5px; }
         .product-item button:hover, .product-item button:active, .product-item button:focus { background:#fff; color:red; border-color:red; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/skate.html
+++ b/skate.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop Skate">
-    <title>MaybeNot Shop - Skate</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -328,6 +327,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/skateboard1.html
+++ b/skateboard1.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Skateboard 1 product page">
-    <title>Skateboard 1 - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -119,6 +118,34 @@
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/skateboard2.html
+++ b/skateboard2.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Skateboard 2 product page">
-    <title>Skateboard 2 - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -119,6 +118,34 @@
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/skateboard3.html
+++ b/skateboard3.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Skateboard 3 product page">
-    <title>Skateboard 3 - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -119,6 +118,34 @@
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/socks.html
+++ b/socks.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Socks product page">
-    <title>Socks - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -119,6 +118,34 @@
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/soon.html
+++ b/soon.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop">
-    <title>MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -313,6 +312,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/stores.html
+++ b/stores.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Stores">
-    <title>MaybeNot Stores</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; }
@@ -31,6 +30,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/success.html
+++ b/success.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Order Confirmed</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -68,6 +68,34 @@
             margin: 20px 0 30px;
         }
     </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
     <header class="header-container">

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop Sweatshirts">
-    <title>MaybeNot Shop - Sweatshirts</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -328,6 +327,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop T-Shirts">
-    <title>MaybeNot Shop - T-Shirts</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -328,6 +327,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/terms.html
+++ b/terms.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Terms - MaybeNot</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html { margin:0; padding:0; font-family:'Courier New', Courier, monospace; background-color:#f7f7f7; color:#000; }
@@ -30,6 +30,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="MaybeNot Shop Tops/Sweaters">
-    <title>MaybeNot Shop - Tops/Sweaters</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -328,6 +327,34 @@
     .time { margin-top: -5px; }
     .cart-counter { margin-top: 5px; }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 

--- a/truckerhat.html
+++ b/truckerhat.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Trucker Hat product page">
-    <title>Trucker Hat - MaybeNot Shop</title>
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
     <style>
         body, html {
@@ -130,6 +129,34 @@
             display: inline-block;
         }
 </style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
 </head>
 <body>
 <header class="header-container">


### PR DESCRIPTION
### Motivation
- Standardize SEO across all HTML pages to improve search engine and social sharing metadata.
- Provide structured data so crawlers can better understand the site as a clothing retailer.
- Ensure the About page and homepage include the requested SEO-first heading and intro content for improved relevance.

### Description
- Added standardized SEO block to the `<head>` of every `.html` file including a sitewide `<title>` (`MaybeNot | Chicago Streetwear Since 2016`), a `meta` description, Open Graph tags (`og:title`, `og:description`, `og:url`, `og:type`), and a JSON-LD `ClothingStore` schema with `sameAs` links to social profiles.
- Replaced the About page `<title>` with `About MaybeNot — Chicago Streetwear Brand Founded 2016` and inserted the requested first `<h1>` and the requested first sentence paragraph before the existing body copy in `about.html`.
- Inserted a visually hidden `<h1>` into `index.html` when no other `<h1>` existed to provide an SEO-friendly homepage heading without changing the visible layout.
- Changes were applied across 56 HTML files; only metadata and the specified heading/intro text were added or replaced without modifying visual styles or layout logic.

### Testing
- Ran a bulk update script (`python - <<'PY' ...`) to apply changes across `*.html` files and it reported `updated 56` files successfully.
- Verified presence of new tags with `rg` searches for `og:title`, `application/ld+json`, and the hidden homepage heading, which returned expected matches in `index.html`, `shop.html`, and others.
- Confirmed updated `<title>` tags with `rg` and counted occurrences; post-change count matched the number of modified pages (`56`).
- Added and committed the changes with `git add *.html && git commit -m "Update sitewide SEO metadata and about/homepage headings"`, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42a73e3d08321a6822376eec473fe)