### PR TITLE
Remove duplicate Babynot links from global navigation

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -411,7 +411,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/all-page2.html
+++ b/all-page2.html
@@ -441,7 +441,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/all.html
+++ b/all.html
@@ -561,7 +561,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/americandenim.html
+++ b/americandenim.html
@@ -253,7 +253,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/babynot-hoodie-set.html
+++ b/babynot-hoodie-set.html
@@ -244,7 +244,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/babynot-onesie.html
+++ b/babynot-onesie.html
@@ -245,7 +245,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/babynot-toddler-tee.html
+++ b/babynot-toddler-tee.html
@@ -244,7 +244,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/babynot.html
+++ b/babynot.html
@@ -441,7 +441,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/backpack.html
+++ b/backpack.html
@@ -222,7 +222,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/bags.html
+++ b/bags.html
@@ -421,7 +421,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/blankhoodie.html
+++ b/blankhoodie.html
@@ -149,7 +149,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/blankshirt.html
+++ b/blankshirt.html
@@ -256,7 +256,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/camohat.html
+++ b/camohat.html
@@ -223,7 +223,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/category_template.html
+++ b/category_template.html
@@ -402,7 +402,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/dufflebag.html
+++ b/dufflebag.html
@@ -207,7 +207,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/gym.html
+++ b/gym.html
@@ -402,7 +402,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/hat.html
+++ b/hat.html
@@ -222,7 +222,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/hats.html
+++ b/hats.html
@@ -441,7 +441,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/hoodie.html
+++ b/hoodie.html
@@ -149,7 +149,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/jackets.html
+++ b/jackets.html
@@ -402,7 +402,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/joggers.html
+++ b/joggers.html
@@ -156,7 +156,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-cancer-shirt.html
+++ b/mbnt-cancer-shirt.html
@@ -248,7 +248,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-moon-landing-shirt.html
+++ b/mbnt-moon-landing-shirt.html
@@ -248,7 +248,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-pro-shops-shirt.html
+++ b/mbnt-pro-shops-shirt.html
@@ -248,7 +248,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/new-page2.html
+++ b/new-page2.html
@@ -414,7 +414,6 @@
     </a>
 </div>
     </div>
-    <li><a href="babynot.html">babynot</a></li>
     <div class="pagination"><a href="new.html" class="pagination-button">Previous Page</a></div>
 </section>
 
@@ -422,7 +421,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="new.html">new</a></li>
+            <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>
@@ -442,7 +441,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/new.html
+++ b/new.html
@@ -561,7 +561,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/pants.html
+++ b/pants.html
@@ -431,7 +431,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/shirt.html
+++ b/shirt.html
@@ -251,7 +251,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/shirts.html
+++ b/shirts.html
@@ -441,7 +441,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/shoes.html
+++ b/shoes.html
@@ -402,7 +402,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/shop.html
+++ b/shop.html
@@ -466,14 +466,12 @@
         <li><a href="gym.html">gym</a></li>
         <li><a href="skate.html">skate</a></li>
         <li><a href="all.html">all</a></li>
-        <li><a href="babynot.html">babynot</a></li>
     </ul>
 </nav>
 
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -488,7 +486,6 @@
         <li><a href="gym.html">gym</a></li>
         <li><a href="skate.html">skate</a></li>
         <li><a href="all.html">all</a></li>
-        <li><a href="babynot.html">babynot</a></li>
     </ul>
 </nav>
 

--- a/shorts.html
+++ b/shorts.html
@@ -155,7 +155,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/skate.html
+++ b/skate.html
@@ -431,7 +431,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/skateboard1.html
+++ b/skateboard1.html
@@ -209,7 +209,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/skateboard2.html
+++ b/skateboard2.html
@@ -209,7 +209,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/skateboard3.html
+++ b/skateboard3.html
@@ -209,7 +209,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/socks.html
+++ b/socks.html
@@ -209,7 +209,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -421,7 +421,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -451,7 +451,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -402,7 +402,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/truckerhat.html
+++ b/truckerhat.html
@@ -222,7 +222,6 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="babynot.html">babynot</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>


### PR DESCRIPTION
### Motivation
- Pages contained duplicate `babynot` navigation entries in desktop, mobile and footer nav blocks which caused the `babynot` link to appear multiple times on the same page. 
- The intent is to have `babynot` appear exactly once as the first item in the main top navigation and nowhere else on the page.

### Description
- Removed secondary `babynot` list items from mobile nav, footer/secondary nav blocks, and stray list items so each page renders a single `babynot` link in the desktop top nav as the first item. 
- Fixed a stray `babynot` list item that was outside the main nav in `new-page2.html` and adjusted the desktop nav insertion there so ordering is correct. 
- Applied the change across all product/category pages and templates so desktop, mobile, sticky, and footer variants are consistent. 
- Changes touched site static HTML nav markup across multiple pages (41 files updated) to enforce a single canonical nav block.

### Testing
- Ran a global search with `rg` and a verification Python script that counts occurrences of `<a href="babynot.html">babynot</a>` and confirmed no page contains more than one occurrence. (passed)
- Inspected representative pages (`shop.html`, `tops-sweaters.html`, `new-page2.html`) to verify `babynot` is the first item in the desktop nav and removed from mobile/footer (passed).
- Re-ran the verification script after the `new-page2.html` fix to confirm the site-wide invariant (single occurrence per page) still holds (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42ca9cd6883219440564f79646983)