### PR TITLE
Fix product-page full site footer link target

### DIFF
--- a/product.js
+++ b/product.js
@@ -375,7 +375,7 @@ document.addEventListener('DOMContentLoaded', () => {
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">
-        <a href="index.html">full site</a>
+        <a href="index.html?fullsite=1">full site</a>
     </div>`;
   }
 


### PR DESCRIPTION
### Motivation
- Product pages’ footer "full site" link pointed to `index.html` which caused `index.html` to redirect users to `shop.html` unless a `fullsite` query parameter was present, so the link should include the parameter to reach the true full site.

### Description
- Changed the injected footer in `product.js` to use `index.html?fullsite=1` instead of `index.html` for the "full site" anchor to ensure product pages navigate to the real index full site.

### Testing
- Verified the updated href via `rg -n "fullsite=1" product.js` and inspected the lines with `nl -ba product.js | sed -n '368,386p'`, and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42df6a6cc83218d2cfa0e7277f984)