### PR TITLE
Restore 'babynot' as first mobile nav link on product & shop pages

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -411,7 +411,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/all-page2.html
+++ b/all-page2.html
@@ -441,7 +441,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/all.html
+++ b/all.html
@@ -561,7 +561,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/americandenim.html
+++ b/americandenim.html
@@ -253,7 +253,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/babynot-hoodie-set.html
+++ b/babynot-hoodie-set.html
@@ -244,7 +244,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/babynot-onesie.html
+++ b/babynot-onesie.html
@@ -245,7 +245,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/babynot-toddler-tee.html
+++ b/babynot-toddler-tee.html
@@ -244,7 +244,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/babynot.html
+++ b/babynot.html
@@ -441,7 +441,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/backpack.html
+++ b/backpack.html
@@ -222,7 +222,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/bags.html
+++ b/bags.html
@@ -421,7 +421,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/blankhoodie.html
+++ b/blankhoodie.html
@@ -149,7 +149,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/blankshirt.html
+++ b/blankshirt.html
@@ -256,7 +256,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/camohat.html
+++ b/camohat.html
@@ -223,7 +223,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/category_template.html
+++ b/category_template.html
@@ -402,7 +402,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/dufflebag.html
+++ b/dufflebag.html
@@ -207,7 +207,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/gym.html
+++ b/gym.html
@@ -402,7 +402,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/hat.html
+++ b/hat.html
@@ -222,7 +222,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/hats.html
+++ b/hats.html
@@ -441,7 +441,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/hoodie.html
+++ b/hoodie.html
@@ -149,7 +149,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/jackets.html
+++ b/jackets.html
@@ -402,7 +402,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/joggers.html
+++ b/joggers.html
@@ -156,7 +156,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/mbnt-cancer-shirt.html
+++ b/mbnt-cancer-shirt.html
@@ -248,7 +248,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/mbnt-moon-landing-shirt.html
+++ b/mbnt-moon-landing-shirt.html
@@ -248,7 +248,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/mbnt-pro-shops-shirt.html
+++ b/mbnt-pro-shops-shirt.html
@@ -248,7 +248,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/new-page2.html
+++ b/new-page2.html
@@ -441,7 +441,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/new.html
+++ b/new.html
@@ -561,7 +561,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/pants.html
+++ b/pants.html
@@ -431,7 +431,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/shirt.html
+++ b/shirt.html
@@ -251,7 +251,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/shirts.html
+++ b/shirts.html
@@ -441,7 +441,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/shoes.html
+++ b/shoes.html
@@ -402,7 +402,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/shop.html
+++ b/shop.html
@@ -472,7 +472,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/shorts.html
+++ b/shorts.html
@@ -155,7 +155,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/skate.html
+++ b/skate.html
@@ -431,7 +431,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/skateboard1.html
+++ b/skateboard1.html
@@ -209,7 +209,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/skateboard2.html
+++ b/skateboard2.html
@@ -209,7 +209,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/skateboard3.html
+++ b/skateboard3.html
@@ -209,7 +209,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/socks.html
+++ b/socks.html
@@ -209,7 +209,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -421,7 +421,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -451,7 +451,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -402,7 +402,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/truckerhat.html
+++ b/truckerhat.html
@@ -222,7 +222,8 @@
 <!-- Mobile Nav -->
 <nav class="mobile-nav">
     <ul>
-        <li><a href="new.html">new</a></li>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>


### PR DESCRIPTION
### Motivation
- The mobile navigation on product/category pages and `shop.html` had `babynot` removed or not listed first, which breaks expected site navigation order. 
- The goal is to restore `babynot` and ensure it is always the first item in the mobile nav list for product and shop pages.

### Description
- Inserted `<li><a href="babynot.html">babynot</a></li>` as the first `<li>` inside every `<nav class="mobile-nav">` `<ul>` for product/category pages and `shop.html`. 
- Applied the change across 41 HTML files that render the desktop+mobile navigation pattern, leaving desktop nav ordering unchanged where it already contained `babynot`. 
- Changes are targeted to the mobile navigation block only and preserve existing markup/formatting for the rest of each page. 
- One outstanding desktop-nav ordering issue was detected on `index.html` which was not modified by this change set.

### Testing
- Ran a Python verification script (`python - <<'PY' ...`) to scan HTML files for nav menus and confirm `babynot.html` is present and first in each mobile nav, which reported the updated files and left only `index.html` as an outstanding desktop nav case; the script completed successfully. 
- Used `rg` checks (for example `rg -n "<nav class=\"mobile-nav\">|babynot\.html" shop.html mbnt-pro-shops-shirt.html`) to validate `shop.html` and representative product pages now include `babynot` as the first mobile link, and these checks passed. 
- Performed a repository status check after edits to confirm the expected files were modified, and the check reported the 41 updated HTML files as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42fc575e08321abce62966a20e4c7)