### PR TITLE
Always route “full site” to index.html and persist full-site mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,7 +334,13 @@
 <script>
     (function () {
         const params = new URLSearchParams(window.location.search);
-        if (!params.has("fullsite")) {
+        const isFullSiteRequest = params.has("fullsite") || localStorage.getItem("fullSiteMode") === "true";
+
+        if (params.has("fullsite")) {
+            localStorage.setItem("fullSiteMode", "true");
+        }
+
+        if (!isFullSiteRequest) {
             window.location.replace("shop.html");
         }
     })();

--- a/product.js
+++ b/product.js
@@ -375,7 +375,7 @@ document.addEventListener('DOMContentLoaded', () => {
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">
-        <a href="index.html?fullsite=1">full site</a>
+        <a href="index.html" onclick="localStorage.setItem('fullSiteMode', 'true')">full site</a>
     </div>`;
   }
 

--- a/shop.html
+++ b/shop.html
@@ -515,7 +515,7 @@
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">
-        <a href="index.html?fullsite=1">full site</a>
+        <a href="index.html" onclick="localStorage.setItem('fullSiteMode', 'true')">full site</a>
     </div>
 </footer>
 
@@ -597,7 +597,8 @@
             document.addEventListener("touchcancel", cleanup);
             pressTimer = setTimeout(() => {
                 if (startPoint) {
-                    window.location.href = "index.html?fullsite=1";
+                    localStorage.setItem("fullSiteMode", "true");
+                    window.location.href = "index.html";
                 }
                 cleanup();
             }, 600);


### PR DESCRIPTION
### Motivation
- Ensure the footer and logo “full site” controls always navigate directly to `index.html` instead of `index.html?fullsite=1` to match the requested behavior. 
- Prevent `index.html` from immediately redirecting back to `shop.html` after a full-site navigation by preserving the user intent across pages. 
- Make the shop long-press logo and product-injected footer behave the same as other pages when entering full-site mode.

### Description
- Updated `index.html` redirect guard to treat `localStorage.getItem('fullSiteMode') === 'true'` as a valid full-site request and to store the flag when `?fullsite` is present. 
- Replaced `index.html?fullsite=1` footer links with hardcoded `index.html` and added an `onclick` that sets `localStorage.setItem('fullSiteMode','true')` in `shop.html`. 
- Updated the long-press logo handler in `shop.html` to set `fullSiteMode` in `localStorage` before navigating to `index.html`. 
- Updated the injected footer in `product.js` so its “full site” link hardcodes `index.html` and sets the `fullSiteMode` flag.

### Testing
- Ran a repository search with `rg -n "full site|Full Site|fullsite|shop\.HTML|shop\.html|index\.html" /workspace/MBNT` to locate relevant occurrences and validated the targeted files were updated, which succeeded. 
- Inspected the modified file snippets with `nl -ba` and `sed` to confirm the new `localStorage` logic appears in `index.html` and that `shop.html` and `product.js` anchor targets were changed to `index.html`, which succeeded. 
- Verified diffs for `index.html`, `shop.html`, and `product.js` show the intended edits (no remaining `index.html?fullsite=1` occurrences in the edited files), which succeeded. 
- Saved and reviewed the produced diffs showing the combined changes across the three files, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43288104c8321873f55c0bf88c9b1)