### PR TITLE
Add premium "Vintage" nav link between Babynot and New sitewide

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -391,6 +415,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -412,7 +437,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/all-page2.html
+++ b/all-page2.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -421,6 +445,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -442,7 +467,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/all.html
+++ b/all.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -541,6 +565,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -562,7 +587,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/americandenim.html
+++ b/americandenim.html
@@ -94,7 +94,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -233,6 +257,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -254,7 +279,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/babynot-hoodie-set.html
+++ b/babynot-hoodie-set.html
@@ -125,7 +125,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -224,6 +248,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -245,7 +270,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/babynot-onesie.html
+++ b/babynot-onesie.html
@@ -125,7 +125,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -225,6 +249,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -246,7 +271,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/babynot-toddler-tee.html
+++ b/babynot-toddler-tee.html
@@ -125,7 +125,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -224,6 +248,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -245,7 +270,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/babynot.html
+++ b/babynot.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -421,6 +445,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -442,7 +467,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/backpack.html
+++ b/backpack.html
@@ -95,7 +95,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -202,6 +226,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -223,7 +248,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/bags.html
+++ b/bags.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -401,6 +425,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -422,7 +447,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/blankhoodie.html
+++ b/blankhoodie.html
@@ -43,7 +43,31 @@
         .desktop-nav ul { list-style-type:none; padding:0; margin:0; }
         .desktop-nav ul li { margin:4px 0; }
         .desktop-nav ul li a { color:#000; text-decoration:none; display:inline-block; padding:5px 0; width:100%; font-weight:600; }
-        .desktop-nav ul li a:hover, .desktop-nav ul li a:focus, .desktop-nav ul li a:active { border:2px solid red; color:red; background-color:white; }
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover, .desktop-nav ul li a:focus, .desktop-nav ul li a:active { border:2px solid red; color:red; background-color:white; }
         .product-item { margin-top:20px; display:flex; flex-direction:column; align-items:center; }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
@@ -129,6 +153,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -150,7 +175,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/blankshirt.html
+++ b/blankshirt.html
@@ -125,7 +125,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -236,6 +260,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -257,7 +282,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/camohat.html
+++ b/camohat.html
@@ -95,7 +95,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -203,6 +227,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -224,7 +249,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/category_template.html
+++ b/category_template.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -382,6 +406,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -403,7 +428,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/dufflebag.html
+++ b/dufflebag.html
@@ -95,7 +95,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -187,6 +211,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -208,7 +233,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/gym.html
+++ b/gym.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -382,6 +406,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -403,7 +428,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/hat.html
+++ b/hat.html
@@ -95,7 +95,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -202,6 +226,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -223,7 +248,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/hats.html
+++ b/hats.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -421,6 +445,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -442,7 +467,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/hoodie.html
+++ b/hoodie.html
@@ -43,7 +43,31 @@
         .desktop-nav ul { list-style-type:none; padding:0; margin:0; }
         .desktop-nav ul li { margin:4px 0; }
         .desktop-nav ul li a { color:#000; text-decoration:none; display:inline-block; padding:5px 0; width:100%; font-weight:600; }
-        .desktop-nav ul li a:hover, .desktop-nav ul li a:focus, .desktop-nav ul li a:active { border:2px solid red; color:red; background-color:white; }
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover, .desktop-nav ul li a:focus, .desktop-nav ul li a:active { border:2px solid red; color:red; background-color:white; }
         .product-item { margin-top:20px; display:flex; flex-direction:column; align-items:center; }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
@@ -129,6 +153,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -150,7 +175,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/jackets.html
+++ b/jackets.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -382,6 +406,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -403,7 +428,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/joggers.html
+++ b/joggers.html
@@ -43,7 +43,31 @@
         .desktop-nav ul { list-style-type:none; padding:0; margin:0; }
         .desktop-nav ul li { margin:4px 0; }
         .desktop-nav ul li a { color:#000; text-decoration:none; display:inline-block; padding:5px 0; width:100%; font-weight:600; }
-        .desktop-nav ul li a:hover, .desktop-nav ul li a:focus, .desktop-nav ul li a:active { border:2px solid red; color:red; background-color:white; }
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover, .desktop-nav ul li a:focus, .desktop-nav ul li a:active { border:2px solid red; color:red; background-color:white; }
         .product-item { margin-top:20px; display:flex; flex-direction:column; align-items:center; text-align:center; }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; object-position:center; }
@@ -136,6 +160,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -157,7 +182,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/mbnt-cancer-shirt.html
+++ b/mbnt-cancer-shirt.html
@@ -125,7 +125,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -228,6 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -249,7 +274,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/mbnt-moon-landing-shirt.html
+++ b/mbnt-moon-landing-shirt.html
@@ -125,7 +125,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -228,6 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -249,7 +274,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/mbnt-pro-shops-shirt.html
+++ b/mbnt-pro-shops-shirt.html
@@ -125,7 +125,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -228,6 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -249,7 +274,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/new-page2.html
+++ b/new-page2.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -421,7 +445,8 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-            <li><a href="new.html">new</a></li>
+            <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>
@@ -442,7 +467,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/new.html
+++ b/new.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -541,6 +565,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -562,7 +587,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/pants.html
+++ b/pants.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -411,6 +435,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -432,7 +457,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/shirt.html
+++ b/shirt.html
@@ -125,7 +125,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -231,6 +255,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -252,7 +277,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/shirts.html
+++ b/shirts.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -421,6 +445,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -442,7 +467,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/shoes.html
+++ b/shoes.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -382,6 +406,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -403,7 +428,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/shop.html
+++ b/shop.html
@@ -148,7 +148,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -452,6 +476,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -473,7 +498,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/shorts.html
+++ b/shorts.html
@@ -43,7 +43,31 @@
         .desktop-nav ul { list-style-type:none; padding:0; margin:0; }
         .desktop-nav ul li { margin:4px 0; }
         .desktop-nav ul li a { color:#000; text-decoration:none; display:inline-block; padding:5px 0; width:100%; font-weight:600; }
-        .desktop-nav ul li a:hover, .desktop-nav ul li a:focus, .desktop-nav ul li a:active { border:2px solid red; color:red; background-color:white; }
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover, .desktop-nav ul li a:focus, .desktop-nav ul li a:active { border:2px solid red; color:red; background-color:white; }
         .product-item { margin-top:20px; display:flex; flex-direction:column; align-items:center; text-align:center; }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:contain; }
@@ -135,6 +159,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -156,7 +181,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/skate.html
+++ b/skate.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -411,6 +435,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -432,7 +457,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/skateboard1.html
+++ b/skateboard1.html
@@ -95,7 +95,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -189,6 +213,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -210,7 +235,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/skateboard2.html
+++ b/skateboard2.html
@@ -95,7 +95,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -189,6 +213,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -210,7 +235,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/skateboard3.html
+++ b/skateboard3.html
@@ -95,7 +95,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -189,6 +213,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -210,7 +235,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/socks.html
+++ b/socks.html
@@ -95,7 +95,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -189,6 +213,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -210,7 +235,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -401,6 +425,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -422,7 +447,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -431,6 +455,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -452,7 +477,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -139,7 +139,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -382,6 +406,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -403,7 +428,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>

--- a/truckerhat.html
+++ b/truckerhat.html
@@ -95,7 +95,31 @@
             font-weight: 600;
         }
 
-        .desktop-nav ul li a:hover,
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
         .desktop-nav ul li a:focus,
         .desktop-nav ul li a:active {
             border: 2px solid red;
@@ -202,6 +226,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -223,7 +248,8 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="new.html">new</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
         <li><a href="tops-sweaters.html">tops/sweaters</a></li>


### PR DESCRIPTION
### Motivation
- Introduce a premium navigation item called "Vintage" that redirects visitors to the Whatnot profile and appears as a prominent, single entry between the existing "babynot" and "new" links across the site.
- Keep the design minimal and coherent with existing nav while giving Vintage a subtle, premium hover/underline treatment so it feels like a special drop/category.

### Description
- Inserted an external Vintage nav entry (`<a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a>`) immediately after `babynot` and before `new` in both `.desktop-nav` and `.mobile-nav` across pages and templates, including `category_template.html` so generated category pages inherit the order.
- Added a scoped CSS rule `.vintage-link` with a subtle underline reveal using a `::after` pseudo-element and a short transition on hover/focus so only the Vintage link gets the premium hover treatment without changing other nav behavior.
- Applied changes to the shared/category template and 41 HTML pages so the sitewide order is consistently: `Babynot` → `Vintage` → `New`, and no local `vintage.html` page was created.

### Testing
- Ran a Python insertion/validation script that updated nav blocks and then scanned every `desktop-nav`/`mobile-nav` block to confirm the sequence `babynot.html` → `https://whatnot.com/user/maybenot` → `new.html`, which reported zero failures (all navs match the required order). — succeeded.
- Performed an automated `rg`/grep-based scan for the `class="vintage-link"` occurrences to verify the new link was added where expected and appears once per nav list; results matched the intended updates (files updated: 41). — succeeded.
- Executed an automated check to ensure no local `vintage.html` was created and that existing local category links were not replaced; the check passed. — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4cfda217483219e3fb2d56c01daf4)