### PR TITLE
Link BabyNot images and note blank backs for shirt & onesie

### DIFF
--- a/babynot-hoodie-set.html
+++ b/babynot-hoodie-set.html
@@ -219,10 +219,8 @@
 </div>
 </header>
 <div class="product-item" data-product="babynot-hoodie-set" data-price="68" data-selected-color="" data-size="">
-    <div class="image-slider">
-        <div style="display:flex;align-items:center;justify-content:center;width:100%;height:100%;border:1px solid #000;background:#fff;">
-            <span>Image coming soon</span>
-        </div>
+    <div class="image-slider" data-images="babynothoodiesetfront.png,babynothoodiesetback.png">
+        <img id="product-image" src="babynothoodiesetfront.png" alt="BabyNot Hoodie Set">
     </div>
     <h1>BabyNot Hoodie Set</h1>
     <p>$68</p>

--- a/babynot-onesie.html
+++ b/babynot-onesie.html
@@ -220,9 +220,7 @@
 </header>
 <div class="product-item" data-product="babynot-onesie" data-price="38" data-selected-color="" data-size="">
     <div class="image-slider">
-        <div style="display:flex;align-items:center;justify-content:center;width:100%;height:100%;border:1px solid #000;background:#fff;">
-            <span>Image coming soon</span>
-        </div>
+        <img id="product-image" src="babynotonsie.png" alt="BabyNot Onesie">
     </div>
     <h1>BabyNot Onesie</h1>
     <p>$38</p>
@@ -237,7 +235,7 @@
         </select>
     </div>
     <div class="product-details">
-        <p>Soft, comfortable fit for little ones.</p>
+        <p>Soft, comfortable fit for little ones. The back is left blank intentionally.</p>
         <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
         <p>Only national shipping for now.</p>
     </div>

--- a/babynot-toddler-tee.html
+++ b/babynot-toddler-tee.html
@@ -220,9 +220,7 @@
 </header>
 <div class="product-item" data-product="babynot-toddler-tee" data-price="34" data-selected-color="" data-size="">
     <div class="image-slider">
-        <div style="display:flex;align-items:center;justify-content:center;width:100%;height:100%;border:1px solid #000;background:#fff;">
-            <span>Image coming soon</span>
-        </div>
+        <img id="product-image" src="babynotshirt.png" alt="BabyNot Shirt">
     </div>
     <h1>BabyNot Toddler Tee</h1>
     <p>$34</p>
@@ -236,7 +234,7 @@
         </select>
     </div>
     <div class="product-details">
-        <p>Soft, comfortable fit for little ones.</p>
+        <p>Soft, comfortable fit for little ones. The back is left blank intentionally.</p>
         <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
         <p>Only national shipping for now.</p>
     </div>

--- a/babynot.html
+++ b/babynot.html
@@ -410,7 +410,7 @@
         
 <div class="product-item">
     <a href="babynot-onesie.html">
-        <div class="image-placeholder" aria-label="BabyNot Onesie image pending"></div>
+        <img src="babynotonsie.png" alt="BabyNot Onesie">
         <div class="product-info">
             <p>BabyNot Onesie</p>
             <p>$38</p>
@@ -420,7 +420,7 @@
     
 <div class="product-item">
     <a href="babynot-hoodie-set.html">
-        <div class="image-placeholder" aria-label="BabyNot Hoodie Set image pending"></div>
+        <img src="babynothoodiesetfront.png" alt="BabyNot Hoodie Set">
         <div class="product-info">
             <p>BabyNot Hoodie Set</p>
             <p>$68</p>
@@ -430,7 +430,7 @@
 
 <div class="product-item">
     <a href="babynot-toddler-tee.html">
-        <div class="image-placeholder" aria-label="BabyNot Toddler Tee image pending"></div>
+        <img src="babynotshirt.png" alt="BabyNot Shirt">
         <div class="product-info">
             <p>BabyNot Toddler Tee</p>
             <p>$34</p>


### PR DESCRIPTION
### Motivation
- Replace placeholder artwork with the uploaded BabyNot product images and make it explicit that the back of the shirt and onesie are intentionally left blank.

### Description
- Replaced category placeholders in `babynot.html` with the uploaded images `babynotonsie.png`, `babynothoodiesetfront.png`, and `babynotshirt.png`.
- Updated `babynot-hoodie-set.html` to show `babynothoodiesetfront.png` and added `data-images="babynothoodiesetfront.png,babynothoodiesetback.png"` to the image slider.
- Updated `babynot-toddler-tee.html` and `babynot-onesie.html` to use `babynotshirt.png` and `babynotonsie.png` respectively, and changed their description paragraphs to add: "The back is left blank intentionally."
- Committed the changes with the message `Update BabyNot product images and blank-back descriptions`.

### Testing
- Ran `git diff -- babynot.html babynot-hoodie-set.html babynot-toddler-tee.html babynot-onesie.html` to verify the intended diffs, which showed only the expected updates.
- Ran `git status --short` to confirm the modified files were staged, which returned the four updated files.
- Performed `git commit -m "Update BabyNot product images and blank-back descriptions"`, which completed successfully.
- Inspected the modified files with `nl -ba` to validate the inserted `img` tags and updated description text, which matched the intended changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ef847e6c8321af3baae7d121e63c)