### PR TITLE
Add image carousel controls for BabyNot products and add listings to new page

### DIFF
--- a/babynot-hoodie-set.html
+++ b/babynot-hoodie-set.html
@@ -164,6 +164,10 @@
         }
         .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
         .image-slider img { width:100%; height:100%; object-fit:cover; }
+        .image-slider button { position:absolute; top:50%; transform:translateY(-50%); background:transparent; border:2px solid transparent; font-size:2rem; cursor:pointer; color:red; z-index:1; }
+        .image-slider button:hover, .image-slider button:focus, .image-slider button:active { background:white; border:2px solid red; }
+        .image-slider .prev { left:0; }
+        .image-slider .next { right:0; }
         .color-options {
             display: flex;
             gap: 5px;
@@ -220,7 +224,9 @@
 </header>
 <div class="product-item" data-product="babynot-hoodie-set" data-price="68" data-selected-color="" data-size="">
     <div class="image-slider" data-images="babynothoodiesetfront.png,babynothoodiesetback.png">
+        <button class="prev" type="button" aria-label="Previous image">&#10094;</button>
         <img id="product-image" src="babynothoodiesetfront.png" alt="BabyNot Hoodie Set">
+        <button class="next" type="button" aria-label="Next image">&#10095;</button>
     </div>
     <h1>BabyNot Hoodie Set</h1>
     <p>$68</p>

--- a/babynot.html
+++ b/babynot.html
@@ -408,7 +408,7 @@
 <section class="product-section">
     <div class="product-grid">
         
-<div class="product-item">
+<div class="product-item" data-images="babynotonsie.png">
     <a href="babynot-onesie.html">
         <img src="babynotonsie.png" alt="BabyNot Onesie">
         <div class="product-info">
@@ -418,7 +418,7 @@
     </a>
 </div>
     
-<div class="product-item">
+<div class="product-item" data-images="babynothoodiesetfront.png,babynothoodiesetback.png">
     <a href="babynot-hoodie-set.html">
         <img src="babynothoodiesetfront.png" alt="BabyNot Hoodie Set">
         <div class="product-info">
@@ -428,7 +428,7 @@
     </a>
 </div>
 
-<div class="product-item">
+<div class="product-item" data-images="babynotshirt.png">
     <a href="babynot-toddler-tee.html">
         <img src="babynotshirt.png" alt="BabyNot Shirt">
         <div class="product-info">
@@ -579,6 +579,47 @@
         logoOverlay.addEventListener("mousedown", startPress);
         logoOverlay.addEventListener("touchstart", startPress);
     }
+</script>
+
+<script>
+    function initProductGridCarousels() {
+        document.querySelectorAll('.product-grid .product-item[data-images]').forEach((item) => {
+            const link = item.querySelector('a');
+            const image = item.querySelector('img');
+            if (!link || !image) return;
+
+            const images = (item.dataset.images || '')
+                .split(',')
+                .map((src) => src.trim())
+                .filter(Boolean);
+
+            if (images.length <= 1) return;
+
+            let index = 0;
+
+            const createButton = (direction) => {
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.className = `product-carousel-control ${direction}`;
+                button.setAttribute('aria-label', direction === 'prev' ? 'Previous image' : 'Next image');
+                button.innerHTML = direction === 'prev' ? '&#10094;' : '&#10095;';
+                button.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    index = direction === 'prev'
+                        ? (index - 1 + images.length) % images.length
+                        : (index + 1) % images.length;
+                    image.src = images[index];
+                });
+                return button;
+            };
+
+            link.appendChild(createButton('prev'));
+            link.appendChild(createButton('next'));
+        });
+    }
+
+    initProductGridCarousels();
 </script>
 
 <script src="cart.js"></script>

--- a/new.html
+++ b/new.html
@@ -449,6 +449,36 @@
 </div>
 
 <div class="product-item">
+    <a href="babynot-onesie.html">
+        <img src="babynotonsie.png" alt="BabyNot Onesie">
+        <div class="product-info">
+            <p>BabyNot Onesie</p>
+            <p>$38</p>
+        </div>
+    </a>
+</div>
+
+<div class="product-item">
+    <a href="babynot-hoodie-set.html">
+        <img src="babynothoodiesetfront.png" alt="BabyNot Hoodie Set">
+        <div class="product-info">
+            <p>BabyNot Hoodie Set</p>
+            <p>$68</p>
+        </div>
+    </a>
+</div>
+
+<div class="product-item">
+    <a href="babynot-toddler-tee.html">
+        <img src="babynotshirt.png" alt="BabyNot Toddler Tee">
+        <div class="product-info">
+            <p>BabyNot Toddler Tee</p>
+            <p>$28</p>
+        </div>
+    </a>
+</div>
+
+<div class="product-item">
     <a href="mbnt-moon-landing-shirt.html">
         <img src="MBNTMOONLANDING.png" alt="MBNT Moon Landing Shirt">
         <div class="product-info">


### PR DESCRIPTION
### Motivation
- Ensure users can view both front and back images of the BabyNot hoodie set and navigate images like other products. 
- Make the BabyNot category page behave consistently with other product pages by enabling per-card image switching. 
- Surface the new BabyNot products on the `new.html` listing under the Blank T-Shirt entry for discoverability.

### Description
- Added prev/next arrow buttons and accompanying CSS to the `image-slider` in `babynot-hoodie-set.html` so the front/back images are navigable using the same controls as other product sliders. 
- Updated `babynot.html` product cards to include `data-images` attributes and injected a small script that creates per-card carousel controls (`product-carousel-control` buttons) and cycles images without breaking the product link. 
- Inserted three BabyNot product entries (onesie, hoodie set, toddler tee) into `new.html` immediately after the Blank T-Shirt card. 
- Committed the changes to the repository (files changed: `babynot-hoodie-set.html`, `babynot.html`, `new.html`).

### Testing
- Verified presence of new controls and attributes using `rg` searches for `product-carousel-control`, `data-images`, and related strings, which returned the updated files successfully. 
- Confirmed the modified files were staged and committed using `git status --short` and `git commit`, which reported a successful commit. 
- Programmatically inspected file fragments with `nl`/`sed` to confirm the new buttons, CSS, and the `initProductGridCarousels()` script were injected as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f0f461ec832192ee547388374d28)