### PR TITLE
Add BabyNot products to all.html under Blank T-Shirt

### DIFF
--- a/all.html
+++ b/all.html
@@ -448,6 +448,37 @@
     </a>
 </div>
 
+
+<div class="product-item">
+    <a href="babynot-onesie.html">
+        <img src="babynotonsie.png" alt="BabyNot Onesie">
+        <div class="product-info">
+            <p>BabyNot Onesie</p>
+            <p>$38</p>
+        </div>
+    </a>
+</div>
+
+<div class="product-item">
+    <a href="babynot-hoodie-set.html">
+        <img src="babynothoodiesetfront.png" alt="BabyNot Hoodie Set">
+        <div class="product-info">
+            <p>BabyNot Hoodie Set</p>
+            <p>$68</p>
+        </div>
+    </a>
+</div>
+
+<div class="product-item">
+    <a href="babynot-toddler-tee.html">
+        <img src="babynotshirt.png" alt="BabyNot Toddler Tee">
+        <div class="product-info">
+            <p>BabyNot Toddler Tee</p>
+            <p>$28</p>
+        </div>
+    </a>
+</div>
+
 <div class="product-item">
     <a href="mbnt-moon-landing-shirt.html">
         <img src="MBNTMOONLANDING.png" alt="MBNT Moon Landing Shirt">


### PR DESCRIPTION
### Motivation
- Keep the site product listings consistent by adding the new BabyNot items to `all.html` in the same order and with the same images used on `new.html` so the catalog matches across pages.

### Description
- Inserted three `div.product-item` blocks into `all.html` immediately after the `blankespressoshirt.png`/Blank T-Shirt block to add `babynotonsie.png` (BabyNot Onesie), `babynothoodiesetfront.png` (BabyNot Hoodie Set), and `babynotshirt.png` (BabyNot Toddler Tee) following the `new.html` image/order.

### Testing
- Verified the insertion and file contents by running `sed`/`nl` to inspect the region, compared changes with `git diff`, applied the edit with a small Python script, and committed with `git commit`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f26914608321be7b7eb406848bdf)