### PR TITLE
Add three MBNT shirt product pages and update listings

### DIFF
--- a/all.html
+++ b/all.html
@@ -479,6 +479,36 @@
     </a>
 </div>
 
+
+<div class="product-item">
+    <a href="mbnt-mickey-deez-shirt.html">
+        <img src="mbntmickeydeez.png" alt="MBNT Mickey Deez Shirt">
+        <div class="product-info">
+            <p>MBNT Mickey Deez Shirt</p>
+            <p>$33</p>
+        </div>
+    </a>
+</div>
+
+<div class="product-item">
+    <a href="mbnt-patagucci-shirt.html">
+        <img src="mbntpatagucci.png" alt="MBNT Patagucci Shirt">
+        <div class="product-info">
+            <p>MBNT Patagucci Shirt</p>
+            <p>$33</p>
+        </div>
+    </a>
+</div>
+
+<div class="product-item">
+    <a href="mbnt-superior-shirt.html">
+        <img src="mbntsuperior.png" alt="MBNT Superior Shirt">
+        <div class="product-info">
+            <p>MBNT Superior Shirt</p>
+            <p>$33</p>
+        </div>
+    </a>
+</div>
 <div class="product-item">
     <a href="mbnt-moon-landing-shirt.html">
         <img src="MBNTMOONLANDING.png" alt="MBNT Moon Landing Shirt">

--- a/mbnt-mickey-deez-shirt.html
+++ b/mbnt-mickey-deez-shirt.html
@@ -1,0 +1,342 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+    <style>
+        body, html {
+            margin: 0;
+            padding: 0;
+            font-family: 'Courier New', Courier, monospace;
+            background-color: #f7f7f7;
+            color: #000;
+            /* Allow normal document flow so the header can stick */
+            min-height: 100%;
+        }
+        .header-container {
+            width: 100%;
+            padding: 0 10px 10px;
+            background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+        }
+        .logo-container {
+            position: relative;
+            width: 20vw;
+            height: 10vh;
+            margin-top: 0;
+        }
+        .logo-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            cursor: pointer;
+            z-index: 10;
+        }
+        iframe {
+            width: 100%;
+            height: 100%;
+            border: none;
+        }
+        .time {
+            font-size: 0.7rem;
+            text-align: center;
+            margin-top: -5px;
+            font-weight: 600;
+        }
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 5px;
+            width: 100%;
+        }
+        .cart-counter {
+            margin-top: 5px;
+            font-size: 0.7rem;
+            text-align: center;
+            font-weight: 600;
+        }
+        /* Mobile Navigation */
+        .mobile-nav {
+            display: block;
+            width: 100%;
+            margin-top: 20px;
+        }
+
+        nav.mobile-nav ul {
+            list-style-type: none;
+            padding: 0;
+            margin: 0;
+            width: 100%;
+        }
+
+        nav.mobile-nav ul li {
+            margin: 0;
+            padding: 10px 20px;
+            text-align: left;
+            border-bottom: 1px solid #e0e0e0;
+        }
+
+        nav.mobile-nav ul li a {
+            display: block;
+            text-decoration: none;
+            color: #000;
+            padding: 10px;
+        }
+
+        nav.mobile-nav ul li a:hover,
+        nav.mobile-nav ul li a:focus,
+        nav.mobile-nav ul li a:active {
+            background-color: red;
+            color: white;
+        }
+
+        /* Desktop Navigation */
+        .desktop-nav {
+            display: none;
+            width: 100%;
+            text-align: center;
+            margin-top: 0;
+        }
+
+        .desktop-nav ul {
+            list-style-type: none;
+            padding: 0;
+            margin: 0;
+        }
+
+        .desktop-nav ul li {
+            margin: 4px 0;
+        }
+
+        .desktop-nav ul li a {
+            color: #000;
+            text-decoration: none;
+            display: inline-block;
+            padding: 5px 0;
+            width: 100%;
+            font-weight: 600;
+        }
+
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
+        .desktop-nav ul li a:focus,
+        .desktop-nav ul li a:active {
+            border: 2px solid red;
+            color: red;
+            background-color: white;
+        }
+        .product-item {
+            margin-top: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
+        .image-slider img { width:100%; height:100%; object-fit:cover; }
+        .color-options {
+            display: flex;
+            gap: 5px;
+            margin: 5px 0;
+        }
+        .color-option {
+            width: 15px;
+            height: 15px;
+            cursor: pointer;
+            display: inline-block;
+        }
+</style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
+</head>
+<body>
+<header class="header-container">
+    <div class="logo-container">
+        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <div class="logo-overlay"></div>
+    </div>
+    <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
+<div class="cart-counter">
+        <span class="cart-icon">🛒</span><span id="cart-count">0</span>
+    
+</div>
+</header>
+<div class="product-item" data-product="mbnt-mickey-deez-shirt" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_MICKEY_DEEZ_SHIRT" data-selected-color="red" data-size="" data-style="single">
+    <div class="image-slider" data-images="mbntmickeydeez.png">
+        <button class="prev">&#10094;</button>
+        <img id="product-image" src="mbntmickeydeez.png" alt="MBNT Mickey Deez Shirt">
+        <button class="next">&#10095;</button>
+    </div>
+    <h1>MBNT Mickey Deez Shirt</h1>
+    <p class="dynamic-price">$33</p>
+    <div class="color-options">
+        <span class="color-option" data-color="red" data-style="single" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_MICKEY_DEEZ_SHIRT" data-image="mbntmickeydeez.png" data-images="mbntmickeydeez.png" style="background:#c00;border:1px solid #000;" title="Red"></span></div>
+    <div class="size-select">
+        <select>
+            <option value="">Select Size</option>
+            <option value="S">Small</option>
+            <option value="M">Medium</option>
+            <option value="L">Large</option>
+            <option value="XL">X-Large</option>
+            <option value="XXL">XX-Large</option>
+        </select>
+    </div>
+    <div class="product-details">
+        <p>Signature MBNT tee featuring original front artwork.</p>
+        <p>Back left blank intentionally.</p>
+        <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
+        <p>Only national shipping for now.</p>
+    </div>
+    <button onclick="addToCart(this)">Add to Cart</button>
+    <button disabled aria-disabled="true">Checkout (Stripe ID Pending)</button>
+</div>
+
+<!-- Desktop Nav -->
+<nav class="desktop-nav">
+    <ul>
+        <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
+        <li><a href="jackets.html">jackets</a></li>
+        <li><a href="shirts.html">shirts</a></li>
+        <li><a href="tops-sweaters.html">tops/sweaters</a></li>
+        <li><a href="sweatshirts.html">sweatshirts</a></li>
+        <li><a href="pants.html">pants</a></li>
+        <li><a href="t-shirts.html">t-shirts</a></li>
+        <li><a href="hats.html">hats</a></li>
+        <li><a href="bags.html">bags</a></li>
+        <li><a href="accessories.html">accessories</a></li>
+        <li><a href="shoes.html">shoes</a></li>
+        <li><a href="gym.html">gym</a></li>
+        <li><a href="skate.html">skate</a></li>
+        <li><a href="all.html">all</a></li>
+    </ul>
+</nav>
+
+<!-- Mobile Nav -->
+<nav class="mobile-nav">
+    <ul>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
+        <li><a href="jackets.html">jackets</a></li>
+        <li><a href="shirts.html">shirts</a></li>
+        <li><a href="tops-sweaters.html">tops/sweaters</a></li>
+        <li><a href="sweatshirts.html">sweatshirts</a></li>
+        <li><a href="pants.html">pants</a></li>
+        <li><a href="t-shirts.html">t-shirts</a></li>
+        <li><a href="hats.html">hats</a></li>
+        <li><a href="bags.html">bags</a></li>
+        <li><a href="accessories.html">accessories</a></li>
+        <li><a href="shoes.html">shoes</a></li>
+        <li><a href="gym.html">gym</a></li>
+        <li><a href="skate.html">skate</a></li>
+        <li><a href="all.html">all</a></li>
+    </ul>
+</nav>
+<footer>
+        <div class="footer-links">
+        <div class="footer-line extra-padding">
+            <a href="shop.html">shop</a>
+            <a href="all.html">view all</a>
+            <a href="soon.html">preview</a>
+            <a href="soon.html">lookbook</a>
+            <a href="news.html">news</a>
+        </div>
+        <br>
+        <br>
+        <div class="footer-line">
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
+            <a href="soon.html">sizing</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
+        </div>
+        <div class="footer-line less-padding">
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
+        </div>
+    </div>
+</footer>
+<script src="cart.js"></script>
+<script src="product.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const item = document.querySelector('.product-item[data-product="blank-shirt"]');
+    if (!item) return;
+    const priceEl = item.querySelector('.dynamic-price');
+    item.querySelectorAll('.color-option').forEach((opt) => {
+        opt.addEventListener('click', () => {
+        const nextPrice = opt.dataset.price || '15';
+        item.dataset.price = nextPrice;
+        item.dataset.style = opt.dataset.style || '';
+        item.dataset.priceId = opt.dataset.priceId || 'blank-shirt';
+        if (priceEl) priceEl.textContent = `$${nextPrice}`;
+      });
+    });
+  });
+</script>
+
+<script src="footer-highlight.js"></script>
+</body>
+</html>

--- a/mbnt-patagucci-shirt.html
+++ b/mbnt-patagucci-shirt.html
@@ -1,0 +1,342 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+    <style>
+        body, html {
+            margin: 0;
+            padding: 0;
+            font-family: 'Courier New', Courier, monospace;
+            background-color: #f7f7f7;
+            color: #000;
+            /* Allow normal document flow so the header can stick */
+            min-height: 100%;
+        }
+        .header-container {
+            width: 100%;
+            padding: 0 10px 10px;
+            background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+        }
+        .logo-container {
+            position: relative;
+            width: 20vw;
+            height: 10vh;
+            margin-top: 0;
+        }
+        .logo-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            cursor: pointer;
+            z-index: 10;
+        }
+        iframe {
+            width: 100%;
+            height: 100%;
+            border: none;
+        }
+        .time {
+            font-size: 0.7rem;
+            text-align: center;
+            margin-top: -5px;
+            font-weight: 600;
+        }
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 5px;
+            width: 100%;
+        }
+        .cart-counter {
+            margin-top: 5px;
+            font-size: 0.7rem;
+            text-align: center;
+            font-weight: 600;
+        }
+        /* Mobile Navigation */
+        .mobile-nav {
+            display: block;
+            width: 100%;
+            margin-top: 20px;
+        }
+
+        nav.mobile-nav ul {
+            list-style-type: none;
+            padding: 0;
+            margin: 0;
+            width: 100%;
+        }
+
+        nav.mobile-nav ul li {
+            margin: 0;
+            padding: 10px 20px;
+            text-align: left;
+            border-bottom: 1px solid #e0e0e0;
+        }
+
+        nav.mobile-nav ul li a {
+            display: block;
+            text-decoration: none;
+            color: #000;
+            padding: 10px;
+        }
+
+        nav.mobile-nav ul li a:hover,
+        nav.mobile-nav ul li a:focus,
+        nav.mobile-nav ul li a:active {
+            background-color: red;
+            color: white;
+        }
+
+        /* Desktop Navigation */
+        .desktop-nav {
+            display: none;
+            width: 100%;
+            text-align: center;
+            margin-top: 0;
+        }
+
+        .desktop-nav ul {
+            list-style-type: none;
+            padding: 0;
+            margin: 0;
+        }
+
+        .desktop-nav ul li {
+            margin: 4px 0;
+        }
+
+        .desktop-nav ul li a {
+            color: #000;
+            text-decoration: none;
+            display: inline-block;
+            padding: 5px 0;
+            width: 100%;
+            font-weight: 600;
+        }
+
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
+        .desktop-nav ul li a:focus,
+        .desktop-nav ul li a:active {
+            border: 2px solid red;
+            color: red;
+            background-color: white;
+        }
+        .product-item {
+            margin-top: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
+        .image-slider img { width:100%; height:100%; object-fit:cover; }
+        .color-options {
+            display: flex;
+            gap: 5px;
+            margin: 5px 0;
+        }
+        .color-option {
+            width: 15px;
+            height: 15px;
+            cursor: pointer;
+            display: inline-block;
+        }
+</style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
+</head>
+<body>
+<header class="header-container">
+    <div class="logo-container">
+        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <div class="logo-overlay"></div>
+    </div>
+    <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
+<div class="cart-counter">
+        <span class="cart-icon">🛒</span><span id="cart-count">0</span>
+    
+</div>
+</header>
+<div class="product-item" data-product="mbnt-patagucci-shirt" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_PATAGUCCI_SHIRT" data-selected-color="red" data-size="" data-style="single">
+    <div class="image-slider" data-images="mbntpatagucci.png">
+        <button class="prev">&#10094;</button>
+        <img id="product-image" src="mbntpatagucci.png" alt="MBNT Patagucci Shirt">
+        <button class="next">&#10095;</button>
+    </div>
+    <h1>MBNT Patagucci Shirt</h1>
+    <p class="dynamic-price">$33</p>
+    <div class="color-options">
+        <span class="color-option" data-color="red" data-style="single" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_PATAGUCCI_SHIRT" data-image="mbntpatagucci.png" data-images="mbntpatagucci.png" style="background:#c00;border:1px solid #000;" title="Red"></span></div>
+    <div class="size-select">
+        <select>
+            <option value="">Select Size</option>
+            <option value="S">Small</option>
+            <option value="M">Medium</option>
+            <option value="L">Large</option>
+            <option value="XL">X-Large</option>
+            <option value="XXL">XX-Large</option>
+        </select>
+    </div>
+    <div class="product-details">
+        <p>Signature MBNT tee featuring original front artwork.</p>
+        <p>Back left blank intentionally.</p>
+        <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
+        <p>Only national shipping for now.</p>
+    </div>
+    <button onclick="addToCart(this)">Add to Cart</button>
+    <button disabled aria-disabled="true">Checkout (Stripe ID Pending)</button>
+</div>
+
+<!-- Desktop Nav -->
+<nav class="desktop-nav">
+    <ul>
+        <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
+        <li><a href="jackets.html">jackets</a></li>
+        <li><a href="shirts.html">shirts</a></li>
+        <li><a href="tops-sweaters.html">tops/sweaters</a></li>
+        <li><a href="sweatshirts.html">sweatshirts</a></li>
+        <li><a href="pants.html">pants</a></li>
+        <li><a href="t-shirts.html">t-shirts</a></li>
+        <li><a href="hats.html">hats</a></li>
+        <li><a href="bags.html">bags</a></li>
+        <li><a href="accessories.html">accessories</a></li>
+        <li><a href="shoes.html">shoes</a></li>
+        <li><a href="gym.html">gym</a></li>
+        <li><a href="skate.html">skate</a></li>
+        <li><a href="all.html">all</a></li>
+    </ul>
+</nav>
+
+<!-- Mobile Nav -->
+<nav class="mobile-nav">
+    <ul>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
+        <li><a href="jackets.html">jackets</a></li>
+        <li><a href="shirts.html">shirts</a></li>
+        <li><a href="tops-sweaters.html">tops/sweaters</a></li>
+        <li><a href="sweatshirts.html">sweatshirts</a></li>
+        <li><a href="pants.html">pants</a></li>
+        <li><a href="t-shirts.html">t-shirts</a></li>
+        <li><a href="hats.html">hats</a></li>
+        <li><a href="bags.html">bags</a></li>
+        <li><a href="accessories.html">accessories</a></li>
+        <li><a href="shoes.html">shoes</a></li>
+        <li><a href="gym.html">gym</a></li>
+        <li><a href="skate.html">skate</a></li>
+        <li><a href="all.html">all</a></li>
+    </ul>
+</nav>
+<footer>
+        <div class="footer-links">
+        <div class="footer-line extra-padding">
+            <a href="shop.html">shop</a>
+            <a href="all.html">view all</a>
+            <a href="soon.html">preview</a>
+            <a href="soon.html">lookbook</a>
+            <a href="news.html">news</a>
+        </div>
+        <br>
+        <br>
+        <div class="footer-line">
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
+            <a href="soon.html">sizing</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
+        </div>
+        <div class="footer-line less-padding">
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
+        </div>
+    </div>
+</footer>
+<script src="cart.js"></script>
+<script src="product.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const item = document.querySelector('.product-item[data-product="blank-shirt"]');
+    if (!item) return;
+    const priceEl = item.querySelector('.dynamic-price');
+    item.querySelectorAll('.color-option').forEach((opt) => {
+        opt.addEventListener('click', () => {
+        const nextPrice = opt.dataset.price || '15';
+        item.dataset.price = nextPrice;
+        item.dataset.style = opt.dataset.style || '';
+        item.dataset.priceId = opt.dataset.priceId || 'blank-shirt';
+        if (priceEl) priceEl.textContent = `$${nextPrice}`;
+      });
+    });
+  });
+</script>
+
+<script src="footer-highlight.js"></script>
+</body>
+</html>

--- a/mbnt-superior-shirt.html
+++ b/mbnt-superior-shirt.html
@@ -1,0 +1,344 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>MaybeNot | Chicago Streetwear Since 2016</title>
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="196x196">
+    <style>
+        body, html {
+            margin: 0;
+            padding: 0;
+            font-family: 'Courier New', Courier, monospace;
+            background-color: #f7f7f7;
+            color: #000;
+            /* Allow normal document flow so the header can stick */
+            min-height: 100%;
+        }
+        .header-container {
+            width: 100%;
+            padding: 0 10px 10px;
+            background-color: #f7f7f7;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+        }
+        .logo-container {
+            position: relative;
+            width: 20vw;
+            height: 10vh;
+            margin-top: 0;
+        }
+        .logo-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            cursor: pointer;
+            z-index: 10;
+        }
+        iframe {
+            width: 100%;
+            height: 100%;
+            border: none;
+        }
+        .time {
+            font-size: 0.7rem;
+            text-align: center;
+            margin-top: -5px;
+            font-weight: 600;
+        }
+        .header-line {
+            border-top: 1px solid #000;
+            margin-top: 5px;
+            width: 100%;
+        }
+        .cart-counter {
+            margin-top: 5px;
+            font-size: 0.7rem;
+            text-align: center;
+            font-weight: 600;
+        }
+        /* Mobile Navigation */
+        .mobile-nav {
+            display: block;
+            width: 100%;
+            margin-top: 20px;
+        }
+
+        nav.mobile-nav ul {
+            list-style-type: none;
+            padding: 0;
+            margin: 0;
+            width: 100%;
+        }
+
+        nav.mobile-nav ul li {
+            margin: 0;
+            padding: 10px 20px;
+            text-align: left;
+            border-bottom: 1px solid #e0e0e0;
+        }
+
+        nav.mobile-nav ul li a {
+            display: block;
+            text-decoration: none;
+            color: #000;
+            padding: 10px;
+        }
+
+        nav.mobile-nav ul li a:hover,
+        nav.mobile-nav ul li a:focus,
+        nav.mobile-nav ul li a:active {
+            background-color: red;
+            color: white;
+        }
+
+        /* Desktop Navigation */
+        .desktop-nav {
+            display: none;
+            width: 100%;
+            text-align: center;
+            margin-top: 0;
+        }
+
+        .desktop-nav ul {
+            list-style-type: none;
+            padding: 0;
+            margin: 0;
+        }
+
+        .desktop-nav ul li {
+            margin: 4px 0;
+        }
+
+        .desktop-nav ul li a {
+            color: #000;
+            text-decoration: none;
+            display: inline-block;
+            padding: 5px 0;
+            width: 100%;
+            font-weight: 600;
+        }
+
+        
+        .vintage-link {
+            position: relative;
+            display: inline-block;
+        }
+
+        .vintage-link::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            bottom: 2px;
+            width: 100%;
+            height: 1px;
+            background: currentColor;
+            transform: scaleX(0);
+            transform-origin: left center;
+            transition: transform 0.2s ease;
+            opacity: 0.8;
+        }
+
+        .vintage-link:hover::after,
+        .vintage-link:focus::after {
+            transform: scaleX(1);
+        }
+.desktop-nav ul li a:hover,
+        .desktop-nav ul li a:focus,
+        .desktop-nav ul li a:active {
+            border: 2px solid red;
+            color: red;
+            background-color: white;
+        }
+        .product-item {
+            margin-top: 20px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .image-slider { position:relative; display:flex; justify-content:center; align-items:center; width:80%; max-width:400px; aspect-ratio:1/1; margin:0 auto; overflow:hidden; }
+        .image-slider img { width:100%; height:100%; object-fit:cover; }
+        .color-options {
+            display: flex;
+            gap: 5px;
+            margin: 5px 0;
+        }
+        .color-option {
+            width: 15px;
+            height: 15px;
+            cursor: pointer;
+            display: inline-block;
+        }
+</style>
+    <meta name="description" content="MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.">
+
+    <meta property="og:title" content="MaybeNot — Chicago Streetwear Since 2016">
+    <meta property="og:description" content="Athlete-driven streetwear rooted in Chicago's North Side. Performance, community, and street culture — locally sourced, locally made.">
+    <meta property="og:url" content="https://maybenot.com">
+    <meta property="og:type" content="website">
+
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ClothingStore",
+  "name": "MaybeNot",
+  "alternateName": "MBNT",
+  "url": "https://maybenot.com",
+  "foundingDate": "2016",
+  "foundingLocation": {
+    "@type": "Place",
+    "name": "Chicago's North Side, Chicago, Illinois"
+  },
+  "description": "MaybeNot is an independent streetwear brand founded in 2016 on Chicago's North Side. Athlete-driven apparel built from Chicago's underground culture, industrial grit, and everyday hustle. Locally sourced, locally made.",
+  "sameAs": [
+    "https://www.instagram.com/maybenotreality/",
+    "https://x.com/MaybeNotReality",
+    "https://www.youtube.com/MaybeNotReality",
+    "https://www.facebook.com/MaybeNotReality"
+  ]
+}
+</script>
+</head>
+<body>
+<header class="header-container">
+    <div class="logo-container">
+        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <div class="logo-overlay"></div>
+    </div>
+    <div class="time" id="current-time"></div>
+    <div class="header-line"></div>
+<div class="cart-counter">
+        <span class="cart-icon">🛒</span><span id="cart-count">0</span>
+    
+</div>
+</header>
+<div class="product-item" data-product="mbnt-superior-shirt" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_SUPERIOR_RED" data-selected-color="red" data-size="" data-style="single">
+    <div class="image-slider" data-images="mbntsuperior.png">
+        <button class="prev">&#10094;</button>
+        <img id="product-image" src="mbntsuperior.png" alt="MBNT Superior Shirt">
+        <button class="next">&#10095;</button>
+    </div>
+    <h1>MBNT Superior Shirt</h1>
+    <p class="dynamic-price">$33</p>
+    <div class="color-options">
+        <span class="color-option" data-color="red" data-style="single" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_SUPERIOR_RED" data-image="mbntsuperior.png" data-images="mbntsuperior.png" style="background:#c00;border:1px solid #000;" title="Red"></span>
+        <span class="color-option" data-color="black" data-style="single" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_SUPERIOR_BLACK" data-image="mbntsuperiorblack.png" data-images="mbntsuperiorblack.png" style="background:#000;border:1px solid #000;" title="Black"></span>
+        <span class="color-option" data-color="camo" data-style="single" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_SUPERIOR_CAMO" data-image="mbntsuperiorcamo.png" data-images="mbntsuperiorcamo.png" style="background:linear-gradient(45deg,#5d6d3f,#8b7f47,#2f3a21);border:1px solid #000;" title="Camo"></span></div>
+    <div class="size-select">
+        <select>
+            <option value="">Select Size</option>
+            <option value="S">Small</option>
+            <option value="M">Medium</option>
+            <option value="L">Large</option>
+            <option value="XL">X-Large</option>
+            <option value="XXL">XX-Large</option>
+        </select>
+    </div>
+    <div class="product-details">
+        <p>Signature MBNT tee featuring original front artwork.</p>
+        <p>Back left blank intentionally.</p>
+        <p>All American made cut and sew in house: vertical integration process all American sourcing and printing locally.</p>
+        <p>Only national shipping for now.</p>
+    </div>
+    <button onclick="addToCart(this)">Add to Cart</button>
+    <button disabled aria-disabled="true">Checkout (Stripe ID Pending)</button>
+</div>
+
+<!-- Desktop Nav -->
+<nav class="desktop-nav">
+    <ul>
+        <li><a href="babynot.html">babynot</a></li>
+        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
+        <li><a href="jackets.html">jackets</a></li>
+        <li><a href="shirts.html">shirts</a></li>
+        <li><a href="tops-sweaters.html">tops/sweaters</a></li>
+        <li><a href="sweatshirts.html">sweatshirts</a></li>
+        <li><a href="pants.html">pants</a></li>
+        <li><a href="t-shirts.html">t-shirts</a></li>
+        <li><a href="hats.html">hats</a></li>
+        <li><a href="bags.html">bags</a></li>
+        <li><a href="accessories.html">accessories</a></li>
+        <li><a href="shoes.html">shoes</a></li>
+        <li><a href="gym.html">gym</a></li>
+        <li><a href="skate.html">skate</a></li>
+        <li><a href="all.html">all</a></li>
+    </ul>
+</nav>
+
+<!-- Mobile Nav -->
+<nav class="mobile-nav">
+    <ul>
+        
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="new.html">new</a></li>
+        <li><a href="jackets.html">jackets</a></li>
+        <li><a href="shirts.html">shirts</a></li>
+        <li><a href="tops-sweaters.html">tops/sweaters</a></li>
+        <li><a href="sweatshirts.html">sweatshirts</a></li>
+        <li><a href="pants.html">pants</a></li>
+        <li><a href="t-shirts.html">t-shirts</a></li>
+        <li><a href="hats.html">hats</a></li>
+        <li><a href="bags.html">bags</a></li>
+        <li><a href="accessories.html">accessories</a></li>
+        <li><a href="shoes.html">shoes</a></li>
+        <li><a href="gym.html">gym</a></li>
+        <li><a href="skate.html">skate</a></li>
+        <li><a href="all.html">all</a></li>
+    </ul>
+</nav>
+<footer>
+        <div class="footer-links">
+        <div class="footer-line extra-padding">
+            <a href="shop.html">shop</a>
+            <a href="all.html">view all</a>
+            <a href="soon.html">preview</a>
+            <a href="soon.html">lookbook</a>
+            <a href="news.html">news</a>
+        </div>
+        <br>
+        <br>
+        <div class="footer-line">
+            <a href="random.html">random</a>
+            <a href="about.html">about</a>
+            <a href="stores.html">stores</a>
+            <a href="soon.html">sizing</a>
+            <a href="faq.html">f.a.q.</a>
+            <a href="contact.html">contact</a>
+        </div>
+        <div class="footer-line less-padding">
+            <a href="terms.html">terms</a>
+            <a href="privacy.html">privacy</a>
+            <a href="accessibility.html">accessibility</a>
+            <a href="mailinglist.html">mailing list</a>
+        </div>
+    </div>
+</footer>
+<script src="cart.js"></script>
+<script src="product.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const item = document.querySelector('.product-item[data-product="blank-shirt"]');
+    if (!item) return;
+    const priceEl = item.querySelector('.dynamic-price');
+    item.querySelectorAll('.color-option').forEach((opt) => {
+        opt.addEventListener('click', () => {
+        const nextPrice = opt.dataset.price || '15';
+        item.dataset.price = nextPrice;
+        item.dataset.style = opt.dataset.style || '';
+        item.dataset.priceId = opt.dataset.priceId || 'blank-shirt';
+        if (priceEl) priceEl.textContent = `$${nextPrice}`;
+      });
+    });
+  });
+</script>
+
+<script src="footer-highlight.js"></script>
+</body>
+</html>

--- a/new.html
+++ b/new.html
@@ -478,6 +478,36 @@
     </a>
 </div>
 
+
+<div class="product-item">
+    <a href="mbnt-mickey-deez-shirt.html">
+        <img src="mbntmickeydeez.png" alt="MBNT Mickey Deez Shirt">
+        <div class="product-info">
+            <p>MBNT Mickey Deez Shirt</p>
+            <p>$33</p>
+        </div>
+    </a>
+</div>
+
+<div class="product-item">
+    <a href="mbnt-patagucci-shirt.html">
+        <img src="mbntpatagucci.png" alt="MBNT Patagucci Shirt">
+        <div class="product-info">
+            <p>MBNT Patagucci Shirt</p>
+            <p>$33</p>
+        </div>
+    </a>
+</div>
+
+<div class="product-item">
+    <a href="mbnt-superior-shirt.html">
+        <img src="mbntsuperior.png" alt="MBNT Superior Shirt">
+        <div class="product-info">
+            <p>MBNT Superior Shirt</p>
+            <p>$33</p>
+        </div>
+    </a>
+</div>
 <div class="product-item">
     <a href="mbnt-moon-landing-shirt.html">
         <img src="MBNTMOONLANDING.png" alt="MBNT Moon Landing Shirt">

--- a/shirts.html
+++ b/shirts.html
@@ -408,6 +408,36 @@
     </a>
 </div>
 
+
+<div class="product-item">
+    <a href="mbnt-mickey-deez-shirt.html">
+        <img src="mbntmickeydeez.png" alt="MBNT Mickey Deez Shirt">
+        <div class="product-info">
+            <p>MBNT Mickey Deez Shirt</p>
+            <p>$33</p>
+        </div>
+    </a>
+</div>
+
+<div class="product-item">
+    <a href="mbnt-patagucci-shirt.html">
+        <img src="mbntpatagucci.png" alt="MBNT Patagucci Shirt">
+        <div class="product-info">
+            <p>MBNT Patagucci Shirt</p>
+            <p>$33</p>
+        </div>
+    </a>
+</div>
+
+<div class="product-item">
+    <a href="mbnt-superior-shirt.html">
+        <img src="mbntsuperior.png" alt="MBNT Superior Shirt">
+        <div class="product-info">
+            <p>MBNT Superior Shirt</p>
+            <p>$33</p>
+        </div>
+    </a>
+</div>
 <div class="product-item">
     <a href="mbnt-moon-landing-shirt.html">
         <img src="MBNTMOONLANDING.png" alt="MBNT Moon Landing Shirt">

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -418,6 +418,36 @@
     </a>
 </div>
 
+
+<div class="product-item">
+    <a href="mbnt-mickey-deez-shirt.html">
+        <img src="mbntmickeydeez.png" alt="MBNT Mickey Deez Shirt">
+        <div class="product-info">
+            <p>MBNT Mickey Deez Shirt</p>
+            <p>$33</p>
+        </div>
+    </a>
+</div>
+
+<div class="product-item">
+    <a href="mbnt-patagucci-shirt.html">
+        <img src="mbntpatagucci.png" alt="MBNT Patagucci Shirt">
+        <div class="product-info">
+            <p>MBNT Patagucci Shirt</p>
+            <p>$33</p>
+        </div>
+    </a>
+</div>
+
+<div class="product-item">
+    <a href="mbnt-superior-shirt.html">
+        <img src="mbntsuperior.png" alt="MBNT Superior Shirt">
+        <div class="product-info">
+            <p>MBNT Superior Shirt</p>
+            <p>$33</p>
+        </div>
+    </a>
+</div>
 <div class="product-item">
     <a href="mbnt-moon-landing-shirt.html">
         <img src="MBNTMOONLANDING.png" alt="MBNT Moon Landing Shirt">


### PR DESCRIPTION
### Motivation
- Add three new shirt SKUs with full product pages that match existing page layout and behavior while avoiding live Stripe links until IDs are available. 
- Ensure MBNT Superior supports three rectangle color variants (Red, Black, Camo) and that none of the new shirts include a back-side image slot. 
- Surface the new shirts in the normal listing grids so they appear in the same places as other recently added shirts. 

### Description
- Added three new product pages: `mbnt-mickey-deez-shirt.html`, `mbnt-patagucci-shirt.html`, and `mbnt-superior-shirt.html`, each cloned from the existing shirt page template and adapted for the new artwork and text. 
- For each product page the checkout button is disabled and placeholder Stripe identifiers are used as `STRIPE_PRICE_ID_TBD_*` to avoid adding live Stripe links until real IDs are provided. 
- Inserted the exact required line `“Back left blank intentionally.”` into each product description and removed any back-image gallery entries so all three are front-only. 
- Wired MBNT Superior to three color swatches with correct variant image filenames and data attributes: `mbntsuperior.png` (Red), `mbntsuperiorblack.png` (Black), and `mbntsuperiorcamo.png` (Camo). 
- Added product cards linking to the new pages into the standard listing grids: `new.html`, `t-shirts.html`, `shirts.html`, and `all.html`, using the same card layout and responsive structure as existing products. 

### Testing
- Ran targeted text searches with `rg` to confirm the new pages and markers are present, including `Back left blank intentionally.` and `STRIPE_PRICE_ID_TBD_*`, and those searches returned the expected hits. 
- Inspected the generated HTML (via `sed`/`nl`) to verify each product page contains the correct `data-product`, `data-images`, `data-price-id` attributes and that MBNT Superior contains three color-option elements referencing the correct image filenames. 
- Verified the new product cards appear and link to their respective pages in `new.html`, `t-shirts.html`, `shirts.html`, and `all.html` by locating the inserted blocks in those files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50ff8e9fc8321b2d5331b2f303af4)