### PR TITLE
Annotate MBNT shirt block on listing pages

### DIFF
--- a/all.html
+++ b/all.html
@@ -480,6 +480,8 @@
 </div>
 
 
+<!-- New MBNT shirt additions -->
+
 <div class="product-item">
     <a href="mbnt-mickey-deez-shirt.html">
         <img src="mbntmickeydeez.png" alt="MBNT Mickey Deez Shirt">

--- a/new.html
+++ b/new.html
@@ -479,6 +479,8 @@
 </div>
 
 
+<!-- New MBNT shirt additions -->
+
 <div class="product-item">
     <a href="mbnt-mickey-deez-shirt.html">
         <img src="mbntmickeydeez.png" alt="MBNT Mickey Deez Shirt">

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -419,6 +419,8 @@
 </div>
 
 
+<!-- New MBNT shirt additions -->
+
 <div class="product-item">
     <a href="mbnt-mickey-deez-shirt.html">
         <img src="mbntmickeydeez.png" alt="MBNT Mickey Deez Shirt">


### PR DESCRIPTION
### Motivation
- Make the three new MBNT shirts a clearly identifiable block across listing pages so their placement (after BabyNot items and before the MBNT Moon Landing Shirt) is explicit and easy to maintain. 
- Provide a stable insertion marker to simplify future updates or automated edits of this specific product group.

### Description
- Inserted a `<!-- New MBNT shirt additions -->` HTML comment immediately before the MBNT Mickey Deez / MBNT Patagucci / MBNT Superior product item block in `t-shirts.html`, `new.html`, and `all.html`. 
- Did not change any product markup, links, prices, or the existing order of product cards, and the three product items remain in the required order: Mickey Deez → Patagucci → Superior. 
- No product cards were duplicated or removed and layout/styling were left intact to preserve desktop and mobile behavior.

### Testing
- Verified presence and order of the relevant product lines with `rg` searches for the product names and confirmed the three-product block exists in each target file. 
- Inspected the surrounding file regions with `nl`/`sed` to confirm the marker was inserted directly after BabyNot items and directly before the MBNT Moon Landing Shirt. 
- Ran the insertion script with `python` to apply the change and confirmed the files were written and the checks above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f510de03748321a89dcec1e45ddecd)