### PR TITLE
Show all MBNT Superior Shirt variants in listing carousels

### DIFF
--- a/all.html
+++ b/all.html
@@ -500,7 +500,7 @@
     </a>
 </div>
 
-<div class="product-item">
+<div class="product-item" data-images="mbntsuperior.png,mbntsuperiorblack.png,mbntsuperiorcamo.png">
     <a href="mbnt-superior-shirt.html">
         <img src="mbntsuperior.png" alt="MBNT Superior Shirt">
         <div class="product-info">

--- a/new.html
+++ b/new.html
@@ -499,7 +499,7 @@
     </a>
 </div>
 
-<div class="product-item">
+<div class="product-item" data-images="mbntsuperior.png,mbntsuperiorblack.png,mbntsuperiorcamo.png">
     <a href="mbnt-superior-shirt.html">
         <img src="mbntsuperior.png" alt="MBNT Superior Shirt">
         <div class="product-info">

--- a/shirts.html
+++ b/shirts.html
@@ -429,7 +429,7 @@
     </a>
 </div>
 
-<div class="product-item">
+<div class="product-item" data-images="mbntsuperior.png,mbntsuperiorblack.png,mbntsuperiorcamo.png">
     <a href="mbnt-superior-shirt.html">
         <img src="mbntsuperior.png" alt="MBNT Superior Shirt">
         <div class="product-info">

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -439,7 +439,7 @@
     </a>
 </div>
 
-<div class="product-item">
+<div class="product-item" data-images="mbntsuperior.png,mbntsuperiorblack.png,mbntsuperiorcamo.png">
     <a href="mbnt-superior-shirt.html">
         <img src="mbntsuperior.png" alt="MBNT Superior Shirt">
         <div class="product-info">


### PR DESCRIPTION
### Motivation
- Ensure the MBNT Superior Shirt product tiles in listing grids expose every variant image so the site-wide carousel can cycle through red, black, and camo automatically.
- Prevent single-image thumbnails in product grids from hiding available variant artwork when the carousel behavior is enabled.

### Description
- Added `data-images="mbntsuperior.png,mbntsuperiorblack.png,mbntsuperiorcamo.png"` to the MBNT Superior Shirt product tile on `shirts.html`.
- Applied the same `data-images` attribute to the MBNT Superior Shirt tiles in `t-shirts.html`, `new.html`, and `all.html` so all listing locations include variants.
- Changes are limited to updating the product-item markup in the product grids to include the full comma-separated image list used by the carousel.

### Testing
- Ran a small automated patch script to insert the `data-images` value and it reported updates for `shirts.html`, `t-shirts.html`, `new.html`, and `all.html`.
- Verified the presence of the new attribute with `rg -n "mbnt-superior-shirt|data-images=\"mbntsuperior"` which returned matches on all four files.
- Inspected the updated lines with `nl -ba <file>` and confirmed the `data-images="mbntsuperior.png,mbntsuperiorblack.png,mbntsuperiorcamo.png"` attribute appears on each MBNT Superior Shirt tile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f511ad45f883218c910650de87f383)