### PR TITLE
Rotate MBNT Superior images on grids and product page

### DIFF
--- a/footer-highlight.js
+++ b/footer-highlight.js
@@ -82,7 +82,8 @@ document.addEventListener('DOMContentLoaded', () => {
     'socks.html': ['blacksocks.png', 'blacksocks2.png'],
     'skateboard1.html': ['skateboard3v2.png'],
     'skateboard2.html': ['skateboard4.png'],
-    'skateboard3.html': ['skateboard1.png']
+    'skateboard3.html': ['skateboard1.png'],
+    'mbnt-superior-shirt.html': ['mbntsuperior.png', 'mbntsuperiorblack.png', 'mbntsuperiorcamo.png']
   };
 
   document.querySelectorAll('.product-grid .product-item a[href]').forEach(link => {

--- a/mbnt-superior-shirt.html
+++ b/mbnt-superior-shirt.html
@@ -219,7 +219,7 @@
 </div>
 </header>
 <div class="product-item" data-product="mbnt-superior-shirt" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_SUPERIOR_RED" data-selected-color="red" data-size="" data-style="single">
-    <div class="image-slider" data-images="mbntsuperior.png">
+    <div class="image-slider" data-images="mbntsuperior.png,mbntsuperiorblack.png,mbntsuperiorcamo.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="mbntsuperior.png" alt="MBNT Superior Shirt">
         <button class="next">&#10095;</button>


### PR DESCRIPTION
### Motivation
- Ensure the MBNT Superior product tile on category/shop grids and the product page slider rotate through all variant images when no specific variant is selected so arrow controls and automatic thumbnail rotation show red/black/camo images.

### Description
- Added the MBNT Superior image set to the `productCarouselImages` map in `footer-highlight.js` and updated the product slider `data-images` in `mbnt-superior-shirt.html` to include `mbntsuperior.png`, `mbntsuperiorblack.png`, and `mbntsuperiorcamo.png`.

### Testing
- Verified the expected changes with `git diff -- footer-highlight.js mbnt-superior-shirt.html` and committed the update with `git commit`, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51b6027dc8321988a87f65b18c5bb)