### PR TITLE
Link new Stripe price IDs and rename MBNT MickyDz Shirt

### DIFF
--- a/all.html
+++ b/all.html
@@ -482,9 +482,9 @@
 
 <div class="product-item">
     <a href="mbnt-mickey-deez-shirt.html">
-        <img src="mbntmickeydeez.png" alt="MBNT Mickey Deez Shirt">
+        <img src="mbntmickeydeez.png" alt="MBNT MickyDz Shirt">
         <div class="product-info">
-            <p>MBNT Mickey Deez Shirt</p>
+            <p>MBNT MickyDz Shirt</p>
             <p>$33</p>
         </div>
     </a>

--- a/babynot-hoodie-set.html
+++ b/babynot-hoodie-set.html
@@ -222,7 +222,7 @@
     
 </div>
 </header>
-<div class="product-item" data-product="babynot-hoodie-set" data-price="68" data-selected-color="" data-size="">
+<div class="product-item" data-product="babynot-hoodie-set" data-price="68" data-price-id="price_1TSPVv6vAbsTB4QV4OfgJtgs" data-selected-color="" data-size="">
     <div class="image-slider" data-images="babynothoodiesetfront.png,babynothoodiesetback.png">
         <button class="prev" type="button" aria-label="Previous image">&#10094;</button>
         <img id="product-image" src="babynothoodiesetfront.png" alt="BabyNot Hoodie Set">

--- a/babynot-onesie.html
+++ b/babynot-onesie.html
@@ -218,7 +218,7 @@
     
 </div>
 </header>
-<div class="product-item" data-product="babynot-onesie" data-price="38" data-selected-color="" data-size="">
+<div class="product-item" data-product="babynot-onesie" data-price="38" data-price-id="price_1TSPUu6vAbsTB4QVip8obNix" data-selected-color="" data-size="">
     <div class="image-slider">
         <img id="product-image" src="babynotonsie.png" alt="BabyNot Onesie">
     </div>

--- a/babynot-toddler-tee.html
+++ b/babynot-toddler-tee.html
@@ -218,7 +218,7 @@
     
 </div>
 </header>
-<div class="product-item" data-product="babynot-toddler-tee" data-price="34" data-selected-color="" data-size="">
+<div class="product-item" data-product="babynot-toddler-tee" data-price="34" data-price-id="price_1TSPXE6vAbsTB4QVBNxWea2Q" data-selected-color="" data-size="">
     <div class="image-slider">
         <img id="product-image" src="babynotshirt.png" alt="BabyNot Shirt">
     </div>

--- a/mbnt-mickey-deez-shirt.html
+++ b/mbnt-mickey-deez-shirt.html
@@ -218,16 +218,16 @@
     
 </div>
 </header>
-<div class="product-item" data-product="mbnt-mickey-deez-shirt" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_MICKEY_DEEZ_SHIRT" data-selected-color="red" data-size="" data-style="single">
+<div class="product-item" data-product="mbnt-mickey-deez-shirt" data-price="33" data-price-id="price_1TSPU46vAbsTB4QVSo6mSQco" data-selected-color="red" data-size="" data-style="single">
     <div class="image-slider" data-images="mbntmickeydeez.png">
         <button class="prev">&#10094;</button>
-        <img id="product-image" src="mbntmickeydeez.png" alt="MBNT Mickey Deez Shirt">
+        <img id="product-image" src="mbntmickeydeez.png" alt="MBNT MickyDz Shirt">
         <button class="next">&#10095;</button>
     </div>
-    <h1>MBNT Mickey Deez Shirt</h1>
+    <h1>MBNT MickyDz Shirt</h1>
     <p class="dynamic-price">$33</p>
     <div class="color-options">
-        <span class="color-option" data-color="red" data-style="single" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_MICKEY_DEEZ_SHIRT" data-image="mbntmickeydeez.png" data-images="mbntmickeydeez.png" style="background:#c00;border:1px solid #000;" title="Red"></span></div>
+        <span class="color-option" data-color="red" data-style="single" data-price="33" data-price-id="price_1TSPU46vAbsTB4QVSo6mSQco" data-image="mbntmickeydeez.png" data-images="mbntmickeydeez.png" style="background:#c00;border:1px solid #000;" title="Red"></span></div>
     <div class="size-select">
         <select>
             <option value="">Select Size</option>
@@ -245,7 +245,7 @@
         <p>Only national shipping for now.</p>
     </div>
     <button onclick="addToCart(this)">Add to Cart</button>
-    <button disabled aria-disabled="true">Checkout (Stripe ID Pending)</button>
+    <button onclick="checkout(this)">Checkout</button>
 </div>
 
 <!-- Desktop Nav -->

--- a/mbnt-patagucci-shirt.html
+++ b/mbnt-patagucci-shirt.html
@@ -218,7 +218,7 @@
     
 </div>
 </header>
-<div class="product-item" data-product="mbnt-patagucci-shirt" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_PATAGUCCI_SHIRT" data-selected-color="red" data-size="" data-style="single">
+<div class="product-item" data-product="mbnt-patagucci-shirt" data-price="33" data-price-id="price_1TSPSa6vAbsTB4QVawXzIVV1" data-selected-color="red" data-size="" data-style="single">
     <div class="image-slider" data-images="mbntpatagucci.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="mbntpatagucci.png" alt="MBNT Patagucci Shirt">
@@ -227,7 +227,7 @@
     <h1>MBNT Patagucci Shirt</h1>
     <p class="dynamic-price">$33</p>
     <div class="color-options">
-        <span class="color-option" data-color="red" data-style="single" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_PATAGUCCI_SHIRT" data-image="mbntpatagucci.png" data-images="mbntpatagucci.png" style="background:#c00;border:1px solid #000;" title="Red"></span></div>
+        <span class="color-option" data-color="red" data-style="single" data-price="33" data-price-id="price_1TSPSa6vAbsTB4QVawXzIVV1" data-image="mbntpatagucci.png" data-images="mbntpatagucci.png" style="background:#c00;border:1px solid #000;" title="Red"></span></div>
     <div class="size-select">
         <select>
             <option value="">Select Size</option>
@@ -245,7 +245,7 @@
         <p>Only national shipping for now.</p>
     </div>
     <button onclick="addToCart(this)">Add to Cart</button>
-    <button disabled aria-disabled="true">Checkout (Stripe ID Pending)</button>
+    <button onclick="checkout(this)">Checkout</button>
 </div>
 
 <!-- Desktop Nav -->

--- a/mbnt-superior-shirt.html
+++ b/mbnt-superior-shirt.html
@@ -218,7 +218,7 @@
     
 </div>
 </header>
-<div class="product-item" data-product="mbnt-superior-shirt" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_SUPERIOR_RED" data-selected-color="red" data-size="" data-style="single">
+<div class="product-item" data-product="mbnt-superior-shirt" data-price="33" data-price-id="price_1TSPRf6vAbsTB4QVVJgcmtbC" data-selected-color="red" data-size="" data-style="single">
     <div class="image-slider" data-images="mbntsuperior.png,mbntsuperiorblack.png,mbntsuperiorcamo.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="mbntsuperior.png" alt="MBNT Superior Shirt">
@@ -227,9 +227,9 @@
     <h1>MBNT Superior Shirt</h1>
     <p class="dynamic-price">$33</p>
     <div class="color-options">
-        <span class="color-option" data-color="red" data-style="single" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_SUPERIOR_RED" data-image="mbntsuperior.png" data-images="mbntsuperior.png" style="background:#c00;border:1px solid #000;" title="Red"></span>
-        <span class="color-option" data-color="black" data-style="single" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_SUPERIOR_BLACK" data-image="mbntsuperiorblack.png" data-images="mbntsuperiorblack.png" style="background:#000;border:1px solid #000;" title="Black"></span>
-        <span class="color-option" data-color="camo" data-style="single" data-price="33" data-price-id="STRIPE_PRICE_ID_TBD_MBNT_SUPERIOR_CAMO" data-image="mbntsuperiorcamo.png" data-images="mbntsuperiorcamo.png" style="background:linear-gradient(45deg,#5d6d3f,#8b7f47,#2f3a21);border:1px solid #000;" title="Camo"></span></div>
+        <span class="color-option" data-color="red" data-style="single" data-price="33" data-price-id="price_1TSPRf6vAbsTB4QVVJgcmtbC" data-image="mbntsuperior.png" data-images="mbntsuperior.png" style="background:#c00;border:1px solid #000;" title="Red"></span>
+        <span class="color-option" data-color="black" data-style="single" data-price="33" data-price-id="price_1TSPRf6vAbsTB4QVVJgcmtbC" data-image="mbntsuperiorblack.png" data-images="mbntsuperiorblack.png" style="background:#000;border:1px solid #000;" title="Black"></span>
+        <span class="color-option" data-color="camo" data-style="single" data-price="33" data-price-id="price_1TSPRf6vAbsTB4QVVJgcmtbC" data-image="mbntsuperiorcamo.png" data-images="mbntsuperiorcamo.png" style="background:linear-gradient(45deg,#5d6d3f,#8b7f47,#2f3a21);border:1px solid #000;" title="Camo"></span></div>
     <div class="size-select">
         <select>
             <option value="">Select Size</option>
@@ -247,7 +247,7 @@
         <p>Only national shipping for now.</p>
     </div>
     <button onclick="addToCart(this)">Add to Cart</button>
-    <button disabled aria-disabled="true">Checkout (Stripe ID Pending)</button>
+    <button onclick="checkout(this)">Checkout</button>
 </div>
 
 <!-- Desktop Nav -->

--- a/new.html
+++ b/new.html
@@ -481,9 +481,9 @@
 
 <div class="product-item">
     <a href="mbnt-mickey-deez-shirt.html">
-        <img src="mbntmickeydeez.png" alt="MBNT Mickey Deez Shirt">
+        <img src="mbntmickeydeez.png" alt="MBNT MickyDz Shirt">
         <div class="product-info">
-            <p>MBNT Mickey Deez Shirt</p>
+            <p>MBNT MickyDz Shirt</p>
             <p>$33</p>
         </div>
     </a>

--- a/shirts.html
+++ b/shirts.html
@@ -411,9 +411,9 @@
 
 <div class="product-item">
     <a href="mbnt-mickey-deez-shirt.html">
-        <img src="mbntmickeydeez.png" alt="MBNT Mickey Deez Shirt">
+        <img src="mbntmickeydeez.png" alt="MBNT MickyDz Shirt">
         <div class="product-info">
-            <p>MBNT Mickey Deez Shirt</p>
+            <p>MBNT MickyDz Shirt</p>
             <p>$33</p>
         </div>
     </a>

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -421,9 +421,9 @@
 
 <div class="product-item">
     <a href="mbnt-mickey-deez-shirt.html">
-        <img src="mbntmickeydeez.png" alt="MBNT Mickey Deez Shirt">
+        <img src="mbntmickeydeez.png" alt="MBNT MickyDz Shirt">
         <div class="product-info">
-            <p>MBNT Mickey Deez Shirt</p>
+            <p>MBNT MickyDz Shirt</p>
             <p>$33</p>
         </div>
     </a>


### PR DESCRIPTION
### Motivation
- Wire live Stripe `price_...` IDs into the new product pages so checkout can use real prices instead of placeholders. 
- Replace the old product name to the requested brand spelling consistently across detail and listing pages. 
- Keep existing site structure, navigation and checkout flow unchanged while enabling real Stripe checkout for the updated items.

### Description
- Added `data-price-id` attributes with the requested Stripe price IDs to the product markup for: BabyNot Toddler Tee, BabyNot Hoodie Set, BabyNot Onesie, MBNT MickyDz Shirt, MBNT Patagucci Shirt, and MBNT Superior Shirt. 
- Applied the same price ID (`price_1TSPRf6vAbsTB4QVVJgcmtbC`) to all MBNT Superior color variants (Red/Black/Camo) so they share the same Stripe linkage. 
- Replaced placeholder price tokens and disabled placeholder checkout buttons with actionable checkout buttons (`onclick=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52a0c938083218cfc94a517256e4a)