### PR TITLE
Make full-site opt-in via `?fullsite=1` and keep root redirecting to `shop.html`

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,11 +334,7 @@
 <script>
     (function () {
         const params = new URLSearchParams(window.location.search);
-        const isFullSiteRequest = params.has("fullsite") || localStorage.getItem("fullSiteMode") === "true";
-
-        if (params.has("fullsite")) {
-            localStorage.setItem("fullSiteMode", "true");
-        }
+        const isFullSiteRequest = params.has("fullsite");
 
         if (!isFullSiteRequest) {
             window.location.replace("shop.html");

--- a/product.js
+++ b/product.js
@@ -375,7 +375,7 @@ document.addEventListener('DOMContentLoaded', () => {
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">
-        <a href="index.html" onclick="localStorage.setItem('fullSiteMode', 'true')">full site</a>
+        <a href="index.html?fullsite=1">full site</a>
     </div>`;
   }
 

--- a/shop.html
+++ b/shop.html
@@ -541,7 +541,7 @@
         </div>
     </div>
     <div class="full-site-link" id="full-site-link">
-        <a href="index.html" onclick="localStorage.setItem('fullSiteMode', 'true')">full site</a>
+        <a href="index.html?fullsite=1">full site</a>
     </div>
 </footer>
 
@@ -623,8 +623,7 @@
             document.addEventListener("touchcancel", cleanup);
             pressTimer = setTimeout(() => {
                 if (startPoint) {
-                    localStorage.setItem("fullSiteMode", "true");
-                    window.location.href = "index.html";
+                    window.location.href = "index.html?fullsite=1";
                 }
                 cleanup();
             }, 600);


### PR DESCRIPTION
### Motivation
- Ensure `maybenot.com` continues to default to the shop experience instead of persistently sending users to the marketing homepage. 
- Prevent a persistent `localStorage` flag from forcing subsequent visits to `index.html` after a single opt-in action.

### Description
- Change the root guard in `index.html` to only render the full site when the `?fullsite` query parameter is present by using `params.has("fullsite")` and remove the `localStorage`-based `fullSiteMode` check. 
- Update the "full site" links in `shop.html` and the shared footer in `product.js` to point to `index.html?fullsite=1` instead of setting `localStorage`. 
- Update the logo long-press handler on `shop.html` to navigate to `index.html?fullsite=1` without persisting a mode flag.

### Testing
- Ran targeted searches with `rg -n "fullSiteMode|fullsite"` and `rg -n "fullSiteMode|fullsite|index.html\?fullsite=1" index.html shop.html product.js` to confirm only the query-param flow remains, and the checks returned the expected updated locations. 
- Verified modified snippets in `index.html`, `shop.html`, and `product.js` using `sed`/`nl` file excerpts to ensure the redirect guard and link targets match the intended `?fullsite=1` behavior. 
- Executed the scripted replacements used to update the files and confirmed the changes are present and consistent across the three modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f570a5beb88321812a6bcce8158eda)