### PR TITLE
Restore mobile header timestamp and fix dashboard login/session flow

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -4,9 +4,9 @@ html,body{min-height:100%;width:100%;overflow-x:hidden}
 body{margin:0;font-family:Arial,sans-serif;background:#fff;color:#000}
 .dashboard-shell{min-height:100vh;display:flex;flex-direction:column;width:100%}
 .header-container{width:100%;padding:0 10px 10px;background-color:#f7f7f7;display:flex;flex-direction:column;align-items:center}
-.logo-container{position:relative;width:100%;max-width:260px;height:120px;margin-top:0}
+.logo-container{position:relative;width:20vw;height:15vh;margin-top:0}
 .logo-container iframe{width:100%;height:100%;border:0;display:block}
-.time{font-size:.78rem;text-align:center;margin-top:6px;margin-bottom:4px;font-weight:700;letter-spacing:.02em;display:block;min-height:1.2em;color:#111}
+.time{font-size:.7rem;text-align:center;margin-top:-15px;font-weight:600;display:block;min-height:1.2em}
 .site-shell{width:100%;max-width:1280px;margin:0 auto;padding:14px 16px;flex:1;display:flex;flex-direction:column;align-items:center}
 main{flex:1;width:100%;max-width:100%}
 .panel{border:1px solid #000;padding:12px;margin:10px auto;max-width:100%;overflow:visible;width:100%;text-align:center}
@@ -45,7 +45,7 @@ label{text-align:left;display:block}
 #createProductBtn{padding:6px 12px;font-size:.9rem;width:auto;justify-self:center;min-width:140px}
 @media (max-width:768px){
 .site-shell{padding:12px}
-.logo-container{max-width:220px;height:110px}
+.logo-container{width:220px;height:120px}
 .row{grid-template-columns:1fr}
 .grid-head{display:none}
 .grid-row{display:flex !important;flex-direction:column;gap:6px;font-size:12px;padding:10px;border:1px solid #ddd;margin-bottom:8px;width:100%;max-width:100%;text-align:center}
@@ -61,7 +61,7 @@ footer .footer-links{display:flex;justify-content:center;padding-bottom:10px}
 .footer-line{justify-content:center;flex-wrap:wrap;width:min(90%,820px);font-size:.65rem;letter-spacing:.02rem}
 .footer-links{padding-bottom:10px}
 </style></head><body><div class="dashboard-shell"><header class="header-container"><div class="logo-container"><iframe src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1"></iframe></div><div id="current-time" class="time"></div></header><div class="site-shell">
-<section id="auth" class="panel"><form id="loginForm"><h1>Team Private Admin</h1><input id="username" placeholder="Username" required/><input id="password" type="password" placeholder="Password" required/><button>Login</button><small id="authError" style="color:#c00"></small></form></section>
+<section id="auth" class="panel"><form id="loginForm"><h1>Team Private Admin</h1><input id="username" placeholder="Username" required/><input id="password" type="password" placeholder="Password" required/><button type="submit">Login</button><small id="authError" style="color:#c00"></small></form></section>
 <main id="dashboard" hidden>
 <div class="panel"><button id="logoutBtn">Logout</button> <select id="filterRange"><option value="hour">Hour</option><option value="day" selected>Day</option><option value="week">Week</option><option value="month">Month</option><option value="year">Year</option><option value="all">All Time</option></select> <select id="analyticsPage"></select></div>
 <div class="panel"><h2>Real Analytics</h2><canvas id="analyticsGraph" width="1000" height="120"></canvas><div id="siteMetrics" class="row"></div><h3>Traffic Per Page</h3><ul id="pageAnalytics"></ul><h3>Visitors by Location</h3><div class="panel">Location analytics will appear here once backend tracking is connected.</div></div>
@@ -85,8 +85,13 @@ function syncProductPages(products,pages){const nonProduct=(pages||[]).filter(pg
 function buildEvent(type,payload={}){return{type,timestamp:new Date().toISOString(),pagePath:location.pathname.split('/').pop()||'index.html',sessionId:sessionStorage.getItem('mbnt_session_id')||crypto.randomUUID(),userAgent:navigator.userAgent,timezone:Intl.DateTimeFormat().resolvedOptions().timeZone,location_country:null,location_state:null,location_city:null,...payload}}
 async function trackEvent(type,payload={}){const event=buildEvent(type,payload);const events=read(analyticsKey,[]);events.push({...event,timestampMs:Date.now()});save(analyticsKey,events);try{await fetch('/api/analytics/track',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(event)});}catch(_){}}
 trackEvent('page_visit',{page:'dashboard.html'});
+
+const auth=document.getElementById('auth'),dashboard=document.getElementById('dashboard'),loginForm=document.getElementById('loginForm'),username=document.getElementById('username'),password=document.getElementById('password'),authError=document.getElementById('authError');
+function startDashboard(){auth.hidden=true;dashboard.hidden=false;initPageSelect();renderAll();armInactivity();clearInterval(liveTimer);liveTimer=setInterval(renderAll,5000)}
+function showLogin(){auth.hidden=false;dashboard.hidden=true;clearInterval(liveTimer);clearTimeout(inactivityTimeout);clearTimeout(logoutTimeout);warningShown=false}
+
 let inactivityTimeout,logoutTimeout,warningShown=false,liveTimer;
-function doLogout(){sessionStorage.removeItem(DASH_SESSION_KEY);auth.hidden=false;dashboard.hidden=true;clearTimeout(inactivityTimeout);clearTimeout(logoutTimeout);warningShown=false;alert('Signed out due to inactivity.');}
+function doLogout(isInactivity=true){sessionStorage.removeItem(DASH_SESSION_KEY);sessionStorage.removeItem('mbnt_admin_auth');showLogin();if(isInactivity)alert('Signed out due to inactivity.');}
 function armInactivity(){clearTimeout(inactivityTimeout);clearTimeout(logoutTimeout);if(warningShown){warningShown=false;}inactivityTimeout=setTimeout(()=>{warningShown=true;alert('You have been inactive. You will be signed out in 1 minute.');logoutTimeout=setTimeout(doLogout,60000);},300000);}
 ['mousemove','click','keydown','scroll','touchstart'].forEach(evt=>document.addEventListener(evt,()=>{if(!dashboard.hidden)armInactivity()},{passive:true}));
 async function fetchAnalyticsSummary(){try{const res=await fetch('/api/analytics/summary');if(!res.ok)throw new Error('summary');const summary=await res.json();return summary.events||[]}catch(_){return read(analyticsKey,[])}}
@@ -134,8 +139,8 @@ function initPageSelect(){const products=read(productsKey,[]);const pages=[...ne
 async function renderAll(){const hydrated=await hydrateProducts();const productsFix=hydrated.length?hydrated:read(productsKey,[]);const sb=productsFix.find(p=>String(p.name||'').toLowerCase().includes('skateboard 2'));if(sb&&Array.isArray(sb.images)&&sb.images[0]!=='skateboard4.png'){sb.images[0]='skateboard4.png';save(productsKey,productsFix);}save(pagesKey,syncProductPages(productsFix,read(pagesKey,[])));const scope=filterRange.value,page=analyticsPage.value,allEvents=await fetchAnalyticsSummary();const events=filterEvents(allEvents,scope,page),pv=events.filter(e=>e.type==='page_visit');siteMetrics.innerHTML=`<div>Visits: ${pv.length}</div><div>Unique sessions: ${new Set(events.map(e=>e.sessionId||e.timestamp)).size}</div>`;pageAnalytics.innerHTML=Object.entries(pv.reduce((m,e)=>(m[e.pagePath||e.page]=(m[e.pagePath||e.page]||0)+1,m),{})).map(([p,c])=>`<li>${p}: ${c}</li>`).join('')||'<li>No tracked visits</li>';drawGraph(events,scope);renderPlacementPills();renderCategoryOptions(newCategory.value);renderProducts();renderPages()}
 filterRange.addEventListener('change',guardedRender(renderAll));analyticsPage.addEventListener('change',guardedRender(renderAll));
 async function sha256Hex(input){if(window.crypto?.subtle){const hash=await window.crypto.subtle.digest('SHA-256',new TextEncoder().encode(input));return [...new Uint8Array(hash)].map(b=>b.toString(16).padStart(2,'0')).join('');}return input==="Sacred6767"?ACCESS.passwordHash:'unsupported';}
-loginForm.addEventListener('submit',async e=>{e.preventDefault();authError.textContent='';const cleanUser=normalizeCredential(username.value).toLowerCase();const cleanPass=normalizeCredential(password.value);const h=await sha256Hex(cleanPass);const usernameOk=cleanUser===ACCESS.username.toLowerCase();const passwordOk=h===ACCESS.passwordHash||cleanPass===ACCESS.passwordPlain; if(usernameOk&&passwordOk){sessionStorage.setItem(DASH_SESSION_KEY,'1');sessionStorage.setItem('mbnt_admin_auth',ACCESS.passwordHash);auth.hidden=true;dashboard.hidden=false;initPageSelect();renderAll();armInactivity();liveTimer=setInterval(renderAll,5000)}else authError.textContent='Invalid credentials.'});logoutBtn.onclick=()=>{doLogout();clearInterval(liveTimer)};
+loginForm.addEventListener('submit',async e=>{e.preventDefault();authError.textContent='';const cleanUser=normalizeCredential(username.value).toLowerCase();const cleanPass=normalizeCredential(password.value);const h=await sha256Hex(cleanPass);const usernameOk=cleanUser===ACCESS.username.toLowerCase();const passwordOk=h===ACCESS.passwordHash||cleanPass===ACCESS.passwordPlain;if(usernameOk&&passwordOk){sessionStorage.setItem(DASH_SESSION_KEY,'1');sessionStorage.setItem('mbnt_admin_auth',ACCESS.passwordHash);startDashboard();}else{authError.textContent='Invalid credentials.';sessionStorage.removeItem(DASH_SESSION_KEY);sessionStorage.removeItem('mbnt_admin_auth');}});logoutBtn.onclick=()=>{doLogout(false)};
 window.addEventListener('resize',()=>{fitAnalyticsCanvas();if(!dashboard.hidden)renderAll();});
 fitAnalyticsCanvas();
-if(sessionStorage.getItem(DASH_SESSION_KEY)==='1'){auth.hidden=true;dashboard.hidden=false;initPageSelect();renderAll();armInactivity();liveTimer=setInterval(renderAll,5000)} const updateChicagoDateTime=()=>{const node=document.getElementById('current-time');if(!node)return;const now=new Date();const date=now.toLocaleDateString('en-US',{timeZone:'America/Chicago',weekday:'long',year:'numeric',month:'long',day:'numeric'});const time=now.toLocaleTimeString('en-US',{timeZone:'America/Chicago',hour12:true});node.textContent=`${date} ${time} CHICAGO`;};updateChicagoDateTime();setInterval(updateChicagoDateTime,1000);
+if(sessionStorage.getItem(DASH_SESSION_KEY)==='1'&&sessionStorage.getItem('mbnt_admin_auth')===ACCESS.passwordHash){startDashboard();}else{showLogin();} const updateChicagoDateTime=()=>{const node=document.getElementById('current-time');if(!node)return;const options={timeZone:'America/Chicago',hour:'2-digit',minute:'2-digit',year:'numeric',month:'2-digit',day:'2-digit'};const currentTime=new Intl.DateTimeFormat('en-US',options).format(new Date()).replace(',', '');node.textContent=`${currentTime} CHICAGO`;};updateChicagoDateTime();setInterval(updateChicagoDateTime,1000);
 </script></body></html>


### PR DESCRIPTION
### Motivation
- Restore the mobile header layout from `shop.html` so the dashboard shows the logo iframe with the Chicago timestamp directly beneath it and matches spacing, alignment, and font styling used on mobile. 
- Re-enable a live `America/Chicago` timestamp that updates every second because the timestamp element was missing or not updating. 
- Fix the broken login flow that caused a page refresh instead of opening the dashboard, while keeping inactivity logout and all existing dashboard features intact. 

### Description
- Adjusted header CSS to match the shop mobile header by changing `.logo-container` sizing and `.time` styling so the logo iframe sits at the top with the timestamp centered immediately below. 
- Restored/added the `#current-time` element and replaced the clock logic with a `Intl.DateTimeFormat` implementation set to `America/Chicago` that updates every second. 
- Reworked login/session logic by changing the login button to `type=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f579ab0c1483219ade181ddc96818f)