### PR TITLE
Revert dashboard.html to pre-hydration standalone rendering

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Team Private Admin</title><style>
 *{box-sizing:border-box}
 html,body{min-height:100%;width:100%;overflow-x:hidden}
-body{margin:0;font-family:Arial,sans-serif;background:#fff;color:#000;min-height:100vh;display:flex;flex-direction:column}
+body{margin:0;font-family:Arial,sans-serif;background:#fff;color:#000}
 .dashboard-shell{min-height:100vh;display:flex;flex-direction:column;width:100%}
-.site-mobile-header,.header-container{width:100%;padding:0 10px 10px;background-color:#f7f7f7;display:flex;flex-direction:column;align-items:center}
-.logo-frame-wrap,.logo-container{position:relative;width:20vw;height:15vh;margin-top:0}
-.logo-frame-wrap iframe,.logo-container iframe{width:100%;height:100%;border:0;display:block}
-.chicago-time,.time{font-size:.7rem;text-align:center;margin-top:-15px;font-weight:600;display:block;min-height:1.2em;color:#000}
+.header-container{width:100%;padding:0 10px 10px;background-color:#f7f7f7;display:flex;flex-direction:column;align-items:center}
+.logo-container{position:relative;width:100%;max-width:260px;height:120px;margin-top:0}
+.logo-container iframe{width:100%;height:100%;border:0;display:block}
+.time{font-size:.7rem;text-align:center;margin-top:-15px;font-weight:600}
 .site-shell{width:100%;max-width:1280px;margin:0 auto;padding:14px 16px;flex:1;display:flex;flex-direction:column;align-items:center}
-#dashboard-root{flex:1;display:flex;width:100%}
 main{flex:1;width:100%;max-width:100%}
 .panel{border:1px solid #000;padding:12px;margin:10px auto;max-width:100%;overflow:visible;width:100%;text-align:center}
 .row{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;max-width:100%;width:100%;margin:0 auto}
@@ -30,7 +29,7 @@ label{text-align:left;display:block}
 .pill input{display:none}
 .pill.active{background:#000;color:#fff}
 .page-card{border:1px solid #ddd;padding:10px;margin-bottom:8px;width:100%;max-width:100%;box-sizing:border-box;text-align:center}
-.product-manager-list,#pageManager{width:100%;max-width:100%;overflow-y:visible;overflow-x:hidden;padding-right:2px;-webkit-overflow-scrolling:touch}
+.product-manager-list,#pageManager{width:100%;max-width:100%;max-height:55vh;overflow-y:auto;overflow-x:hidden;padding-right:2px;-webkit-overflow-scrolling:touch}
 .view-full-site-wrap{text-align:center;padding:8px 0}
 .view-full-site{color:#c00;text-decoration:none;font-size:.75rem}
 .view-full-site:hover{color:#900}
@@ -46,14 +45,14 @@ label{text-align:left;display:block}
 #createProductBtn{padding:6px 12px;font-size:.9rem;width:auto;justify-self:center;min-width:140px}
 @media (max-width:768px){
 .site-shell{padding:12px}
-.logo-frame-wrap{width:220px;height:120px}
+.logo-container{max-width:220px;height:110px}
 .row{grid-template-columns:1fr}
 .grid-head{display:none}
 .grid-row{display:flex !important;flex-direction:column;gap:6px;font-size:12px;padding:10px;border:1px solid #ddd;margin-bottom:8px;width:100%;max-width:100%;text-align:center}
 .grid-row>div{padding:2px 0;display:block;max-width:100%}
 .grid-row div:last-child{display:flex;flex-wrap:wrap;gap:6px;justify-content:center}
 .product-img{width:72px;height:72px}
-.product-manager-list,#pageManager{width:100%;max-width:100%;display:flex;flex-direction:column;overflow-y:visible;overflow-x:hidden;padding-right:0;-webkit-overflow-scrolling:touch}
+.product-manager-list,#pageManager{width:100%;max-width:100%;display:flex;flex-direction:column;max-height:60vh;min-height:280px;overflow-y:auto;overflow-x:hidden;padding-right:0;-webkit-overflow-scrolling:touch}
 .product-manager-list>div,.product-row-card,.page-card{display:flex;flex-direction:column;width:100%;max-width:100%;box-sizing:border-box}
 footer .footer-links{justify-content:center;padding-bottom:25px;margin-top:40px}
 }
@@ -61,38 +60,17 @@ footer{position:static;width:100%;text-align:center;background-color:#f7f7f7;pad
 footer .footer-links{display:flex;justify-content:center;padding-bottom:10px}
 .footer-line{justify-content:center;flex-wrap:wrap;width:min(90%,820px);font-size:.65rem;letter-spacing:.02rem}
 .footer-links{padding-bottom:10px}
-
-#dashboard-site-header {
-  display: block !important;
-  visibility: visible !important;
-  opacity: 1 !important;
-  text-align: center;
-  width: 100%;
-}
-
-#chicago-time {
-  display: block !important;
-  visibility: visible !important;
-  opacity: 1 !important;
-  color: inherit;
-  text-align: center;
-}
-
-@media (max-width:768px){
-.logo-frame-wrap,.logo-container{width:220px;height:120px}
-}
-</style></head><body data-page="dashboard"><header id="dashboard-site-header" class="site-mobile-header dashboard-site-header header-container"><div class="logo-frame-wrap logo-container"><iframe src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1"></iframe></div><div id="chicago-time" class="chicago-time time"></div></header><main id="dashboard-root"><div class="dashboard-shell"><div class="site-shell">
-<section id="dashboard-login-screen" class="panel"><form id="dashboard-login-form"><h1>Team Private Admin</h1><input id="dashboard-username" name="username" autocomplete="username" placeholder="Username" required/><input id="dashboard-password" name="password" type="password" autocomplete="current-password" placeholder="Password" required/><button type="submit">Sign In</button><p id="dashboard-login-error" style="color:#c00;display:none"></p></form></section>
-<main id="dashboard-app" hidden style="display:none;">
+</style></head><body><div class="dashboard-shell"><header class="header-container"><div class="logo-container"><iframe src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1"></iframe></div><div id="current-time" class="time"></div></header><div class="site-shell">
+<section id="auth" class="panel"><form id="loginForm"><h1>Team Private Admin</h1><input id="username" placeholder="Username" required/><input id="password" type="password" placeholder="Password" required/><button>Login</button><small id="authError" style="color:#c00"></small></form></section>
+<main id="dashboard" hidden>
 <div class="panel"><button id="logoutBtn">Logout</button> <select id="filterRange"><option value="hour">Hour</option><option value="day" selected>Day</option><option value="week">Week</option><option value="month">Month</option><option value="year">Year</option><option value="all">All Time</option></select> <select id="analyticsPage"></select></div>
 <div class="panel"><h2>Real Analytics</h2><canvas id="analyticsGraph" width="1000" height="120"></canvas><div id="siteMetrics" class="row"></div><h3>Traffic Per Page</h3><ul id="pageAnalytics"></ul><h3>Visitors by Location</h3><div class="panel">Location analytics will appear here once backend tracking is connected.</div></div>
 <div class="panel"><h2>Product Manager</h2><h3>Create New Product</h3><form id="createProductForm" class="row"><input id="newName" placeholder="Product name" required><textarea id="newDescription" placeholder="Description"></textarea><input id="newPrice" type="number" step="0.01" placeholder="Price" required><select id="newCategory"></select><input id="newMainImage" placeholder="Main image path"><input id="newMainImageUpload" type="file" accept="image/*"><input id="newImages" placeholder="Additional images (comma separated)"><input id="newImagesUpload" type="file" accept="image/*" multiple><input id="newQty" type="number" placeholder="Quantity" value="0"><input id="newVariants" placeholder="Variants (comma separated)"><label><input type="checkbox" id="newManualSold"> Sold out manually</label><label><input type="checkbox" id="newActive" checked> Active/visible</label><div><strong>Placement</strong><div id="placementPills" class="pill-wrap"></div></div><button id="createProductBtn" type="submit">Create Product</button><small id="createProductError" style="color:#c00"></small></form><div id="productGrid" class="product-manager-list"></div></div>
 <div class="panel"><h2>Page Manager</h2><h3>Create New Page</h3><form id="pageForm" class="row"><input id="pageName" placeholder="Page filename (example: vintage.html)" required><input id="pageLabel" placeholder="Nav label" required><select id="pageType"><option>Collection Page</option><option>Redirect Page</option><option>Product Page</option><option>Blank Page</option></select><input id="redirectUrl" placeholder="Redirect URL (for Redirect Page)"><button>Create/Update Page</button></form><div id="pageManager"></div></div>
-</main></div><div class="view-full-site-wrap"><a class="view-full-site" href="index.html">View Full Site</a></div><footer class="footer"><div class="footer-links"><div class="footer-line extra-padding"><a href="shop.html">shop</a><a href="all.html">view all</a><a href="soon.html">preview</a><a href="soon.html">lookbook</a><a href="news.html">news</a></div><div class="footer-line"><a href="random.html">random</a><a href="about.html">about</a><a href="stores.html">stores</a><a href="soon.html">sizing</a><a href="faq.html">f.a.q.</a><a href="contact.html">contact</a></div><div class="footer-line less-padding"><a href="terms.html">terms</a><a href="privacy.html">privacy</a><a href="accessibility.html">accessibility</a><a href="mailinglist.html">mailing list</a></div></div></footer></div></main>
+</main></div><div class="view-full-site-wrap"><a class="view-full-site" href="index.html">View Full Site</a></div><footer class="footer"><div class="footer-links"><div class="footer-line extra-padding"><a href="shop.html">shop</a><a href="all.html">view all</a><a href="soon.html">preview</a><a href="soon.html">lookbook</a><a href="news.html">news</a></div><div class="footer-line"><a href="random.html">random</a><a href="about.html">about</a><a href="stores.html">stores</a><a href="soon.html">sizing</a><a href="faq.html">f.a.q.</a><a href="contact.html">contact</a></div><div class="footer-line less-padding"><a href="terms.html">terms</a><a href="privacy.html">privacy</a><a href="accessibility.html">accessibility</a><a href="mailinglist.html">mailing list</a></div></div></footer></div>
 <script>
-const DASH_SESSION_KEY='maybenotDashboardAuth',productsKey='mbnt_admin_products',pagesKey='mbnt_admin_pages',analyticsKey='mbnt_analytics_events';
-const VALID_USERNAME="maybenot";
-const VALID_PASSWORD="Sacred6767";
+const DASH_SESSION_KEY='mbnt_dashboard_auth',productsKey='mbnt_admin_products',pagesKey='mbnt_admin_pages',analyticsKey='mbnt_analytics_events';
+const ACCESS={username:'maybenot',passwordHash:'461a77919bf434e323be3c1d06796673a925a273dd02f5cb06b7f3a2c19c059f'};
 const SITE_PAGES=['index.html','shop.html','all.html','new.html','t-shirts.html','babynot.html','vintage.html','hoodie.html','hats.html','accessories.html','shirts.html','sweatshirts.html','pants.html','bags.html','skate.html','cart.html','checkout.html','about.html','contact.html'];
 const PAGE_TYPES=['Collection Page','Product Page','Blank Page','Redirect Page'];
 const COLLECTION_SLUGS=['babynot.html','new.html','jackets.html','shirts.html','tops-sweaters.html','sweatshirts.html','pants.html','t-shirts.html','hats.html','bags.html','accessories.html','shoes.html','gym.html','skate.html','all.html'];
@@ -100,8 +78,6 @@ const DEFAULT_PAGE_TYPE_MAP={
   'index.html':'Blank Page','vintage.html':'Redirect Page',...Object.fromEntries(COLLECTION_SLUGS.map(s=>[s,'Collection Page']))
 };
 const adminAuth=()=>sessionStorage.getItem('mbnt_admin_auth')||'';
-if(document.body && document.body.dataset.page==='dashboard'){window.__MBNT_SKIP_PUBLIC_HYDRATION__=true;}
-
 const read=(k,d)=>JSON.parse(localStorage.getItem(k)||JSON.stringify(d)),save=(k,v)=>localStorage.setItem(k,JSON.stringify(v)); let dirty=false;
 function slugifyProductPage(name){return String(name||'').toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'')+'.html'}
 function syncProductPages(products,pages){const nonProduct=(pages||[]).filter(pg=>pg.type!=='Product Page');const productPages=products.map(prod=>{const slug=slugifyProductPage(prod.name||prod.id||'product');const existing=(pages||[]).find(pg=>pg.slug===slug)||{};return {...existing,slug,label:prod.name||slug,type:'Product Page',visible:prod.status!=='inactive',productId:prod.id||null};});return [...nonProduct,...productPages]}
@@ -109,18 +85,14 @@ function syncProductPages(products,pages){const nonProduct=(pages||[]).filter(pg
 function buildEvent(type,payload={}){return{type,timestamp:new Date().toISOString(),pagePath:location.pathname.split('/').pop()||'index.html',sessionId:sessionStorage.getItem('mbnt_session_id')||crypto.randomUUID(),userAgent:navigator.userAgent,timezone:Intl.DateTimeFormat().resolvedOptions().timeZone,location_country:null,location_state:null,location_city:null,...payload}}
 async function trackEvent(type,payload={}){const event=buildEvent(type,payload);const events=read(analyticsKey,[]);events.push({...event,timestampMs:Date.now()});save(analyticsKey,events);try{await fetch('/api/analytics/track',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(event)});}catch(_){}}
 trackEvent('page_visit',{page:'dashboard.html'});
-
-function startDashboardSystems(){initPageSelect();renderAll();armInactivity();clearInterval(liveTimer);liveTimer=setInterval(renderAll,5000)}
-
 let inactivityTimeout,logoutTimeout,warningShown=false,liveTimer;
-function doLogout(isInactivity=true){sessionStorage.removeItem(DASH_SESSION_KEY);sessionStorage.removeItem('mbnt_admin_auth');if(typeof window.showLogin==='function'){window.showLogin();}if(isInactivity)alert('Signed out due to inactivity.');}
+function doLogout(){sessionStorage.removeItem(DASH_SESSION_KEY);auth.hidden=false;dashboard.hidden=true;clearTimeout(inactivityTimeout);clearTimeout(logoutTimeout);warningShown=false;alert('Signed out due to inactivity.');}
 function armInactivity(){clearTimeout(inactivityTimeout);clearTimeout(logoutTimeout);if(warningShown){warningShown=false;}inactivityTimeout=setTimeout(()=>{warningShown=true;alert('You have been inactive. You will be signed out in 1 minute.');logoutTimeout=setTimeout(doLogout,60000);},300000);}
-['mousemove','click','keydown','scroll','touchstart'].forEach(evt=>document.addEventListener(evt,()=>{const app=document.getElementById('dashboard-app');if(app && !app.hidden)armInactivity()},{passive:true}));
+['mousemove','click','keydown','scroll','touchstart'].forEach(evt=>document.addEventListener(evt,()=>{if(!dashboard.hidden)armInactivity()},{passive:true}));
 async function fetchAnalyticsSummary(){try{const res=await fetch('/api/analytics/summary');if(!res.ok)throw new Error('summary');const summary=await res.json();return summary.events||[]}catch(_){return read(analyticsKey,[])}}
 
 function filterEvents(events,scope,page){const spans={hour:36e5,day:864e5,week:6048e5,month:26298e5,year:315576e5,all:1e16};const now=Date.now();return events.filter(e=>now-(e.timestampMs||Date.parse(e.timestamp)||0)<=spans[scope]).filter(e=>!page||e.pagePath===page||e.page===page)}
-function fitAnalyticsCanvas(){const c=analyticsGraph,ratio=Math.max(1,Math.floor(window.devicePixelRatio||1));const cssWidth=Math.max(280,Math.floor(c.parentElement?.clientWidth||c.clientWidth||1000)-20);const cssHeight=140;c.style.width=cssWidth+'px';c.style.height=cssHeight+'px';c.width=cssWidth*ratio;c.height=cssHeight*ratio;const ctx=c.getContext('2d');ctx.setTransform(ratio,0,0,ratio,0,0);}
-function drawGraph(events,scope){const c=analyticsGraph,x=c.getContext('2d'),bins=24,w=parseFloat(c.style.width)||c.width,h=parseFloat(c.style.height)||c.height,span={hour:36e5,day:864e5,week:6048e5,month:26298e5,year:315576e5,all:315576e5}[scope]||864e5,start=Date.now()-span,counts=Array(bins).fill(0);events.forEach(e=>{const t=e.timestampMs||Date.parse(e.timestamp)||0;if(t<start)return;counts[Math.min(bins-1,Math.floor((t-start)/span*bins))]++});x.clearRect(0,0,w,h);const max=Math.max(...counts,1);x.strokeStyle='#000';x.lineWidth=2;x.beginPath();counts.forEach((v,i)=>{const px=i*(w/(bins-1)),py=h-10-((v/max)*(h-20));i?x.lineTo(px,py):x.moveTo(px,py)});x.stroke();x.fillStyle='rgba(0,0,0,0.08)';x.lineTo(w,h-10);x.lineTo(0,h-10);x.closePath();x.fill();}
+function drawGraph(events,scope){const c=analyticsGraph,x=c.getContext('2d'),bins=24,w=c.width,h=c.height,span={hour:36e5,day:864e5,week:6048e5,month:26298e5,year:315576e5,all:315576e5}[scope]||864e5,start=Date.now()-span,counts=Array(bins).fill(0);events.forEach(e=>{const t=e.timestampMs||Date.parse(e.timestamp)||0;if(t<start)return;counts[Math.min(bins-1,Math.floor((t-start)/span*bins))]++});x.clearRect(0,0,w,h);const max=Math.max(...counts,1);x.beginPath();counts.forEach((v,i)=>{const px=i*(w/(bins-1)),py=h-10-((v/max)*(h-20));i?x.lineTo(px,py):x.moveTo(px,py)});x.stroke()}
 function placementOptions(){const pages=read(pagesKey,[]);const fromPages=pages.filter(p=>p&&p.slug&&p.type==='Collection Page').map(p=>p.slug);return [...new Set([...COLLECTION_SLUGS,...fromPages])];}
 function renderPlacementPills(){placementPills.innerHTML=placementOptions().map(n=>`<label class='pill'><input type='checkbox' value='${n}'>${n}</label>`).join('');placementPills.querySelectorAll('.pill').forEach(p=>p.addEventListener('click',()=>p.classList.toggle('active')))}
 function categoryOptions(){return placementOptions();}
@@ -141,89 +113,10 @@ window.togglePageVis=slug=>{const pages=read(pagesKey,[]);const p=pages.find(x=>
 window.deletePage=slug=>{const core=['index.html','shop.html'];const msg=core.includes(slug)?'Core page. Confirm delete again?':'Delete page?';if(!confirm(msg))return;const pages=read(pagesKey,[]).filter(p=>p.slug!==slug);save(pagesKey,pages);renderAll()};
 window.savePage=async (slug,i)=>{if(!confirm('Confirm changes before saving?'))return;const pages=read(pagesKey,[]);let p=pages.find(x=>x.slug===slug);if(!p){p={slug};pages.push(p)};document.querySelectorAll(`#page-edit-${i} [data-page]`).forEach(el=>{const k=el.dataset.page;p[k]=el.type==='checkbox'?el.checked:(k==='assignments'?el.value.split(',').map(s=>s.trim()).filter(Boolean):el.value)});persistAdmin('/api/admin/update-page',{page:p}).then(()=>{save(pagesKey,pages);dirty=false;renderAll()}).catch(err=>alert(err.message));};
 pageForm.addEventListener('submit',async e=>{e.preventDefault();if(!confirm('Confirm changes before saving?'))return;const pages=read(pagesKey,[]),slug=pageName.value.trim();const data={slug,label:pageLabel.value.trim(),type:pageType.value,redirectUrl:redirectUrl.value.trim(),visible:true};const ex=pages.find(p=>p.slug===slug);if(ex)Object.assign(ex,data);else pages.push(data);try{await persistAdmin('/api/admin/create-page',{page:data});}catch(err){alert(err.message);return;}save(pagesKey,pages);renderAll()});
-
 function guardedRender(fn){return ()=>{if(dirty&&!confirm('Please confirm changes before changing pages if not done so already.'))return;fn();}}
 function initPageSelect(){const products=read(productsKey,[]);const pages=[...new Set(['index.html',...SITE_PAGES,...COLLECTION_SLUGS,...products.map(p=>slugifyProductPage(p.name||p.id||'product')),...read(pagesKey,[]).map(p=>p.slug)])];analyticsPage.innerHTML=pages.map(p=>`<option ${p==='index.html'?'selected':''}>${p}</option>`).join('')}
 async function renderAll(){const productsFix=read(productsKey,[]);const sb=productsFix.find(p=>String(p.name||'').toLowerCase().includes('skateboard 2'));if(sb&&Array.isArray(sb.images)&&sb.images[0]!=='skateboard4.png'){sb.images[0]='skateboard4.png';save(productsKey,productsFix);}save(pagesKey,syncProductPages(productsFix,read(pagesKey,[])));const scope=filterRange.value,page=analyticsPage.value,allEvents=await fetchAnalyticsSummary();const events=filterEvents(allEvents,scope,page),pv=events.filter(e=>e.type==='page_visit');siteMetrics.innerHTML=`<div>Visits: ${pv.length}</div><div>Unique sessions: ${new Set(events.map(e=>e.sessionId||e.timestamp)).size}</div>`;pageAnalytics.innerHTML=Object.entries(pv.reduce((m,e)=>(m[e.pagePath||e.page]=(m[e.pagePath||e.page]||0)+1,m),{})).map(([p,c])=>`<li>${p}: ${c}</li>`).join('')||'<li>No tracked visits</li>';drawGraph(events,scope);renderPlacementPills();renderCategoryOptions(newCategory.value);renderProducts();renderPages()}
-
-
-
-
-function initDashboardSystemsSafe(){
-  try { initPageSelect(); } catch (e) { console.error('initPageSelect failed', e); }
-  try { renderAll(); } catch (e) { console.error('renderAll failed', e); }
-  try { armInactivity(); } catch (e) { console.error('armInactivity failed', e); }
-  try { clearInterval(liveTimer); liveTimer=setInterval(()=>{ try { renderAll(); } catch (err) { console.error('live renderAll failed', err); } },5000); } catch (e) { console.error('liveTimer failed', e); }
-}
-</script>
-<script>
-(function () {
-  document.addEventListener("DOMContentLoaded", function () {
-    const timeEl = document.getElementById("chicago-time");
-    function updateChicagoTime() {
-      if (!timeEl) return;
-      timeEl.textContent = new Intl.DateTimeFormat("en-US", {
-        timeZone: "America/Chicago", weekday: "short", month: "short", day: "numeric",
-        hour: "numeric", minute: "2-digit", second: "2-digit", hour12: true
-      }).format(new Date());
-    }
-    updateChicagoTime();
-    setInterval(updateChicagoTime, 1000);
-    const form = document.getElementById("dashboard-login-form");
-    const usernameInput = document.getElementById("dashboard-username");
-    const passwordInput = document.getElementById("dashboard-password");
-    const loginScreen = document.getElementById("dashboard-login-screen");
-    const dashboardApp = document.getElementById("dashboard-app");
-    const loginError = document.getElementById("dashboard-login-error");
-
-    console.log("Dashboard login check:", { form: !!form, usernameInput: !!usernameInput, passwordInput: !!passwordInput, loginScreen: !!loginScreen, dashboardApp: !!dashboardApp, loginError: !!loginError, timeEl: !!timeEl });
-    if (!form || !usernameInput || !passwordInput || !loginScreen || !dashboardApp || !loginError) { console.error("Dashboard login elements are missing. Fix IDs in HTML."); return; }
-
-    function openDashboard() {
-      sessionStorage.setItem("maybenotDashboardAuth", "true");
-      sessionStorage.setItem("mbnt_admin_auth", "Sacred6767");
-      loginScreen.style.display = "none";
-      dashboardApp.style.display = "block";
-      dashboardApp.hidden = false;
-      loginError.textContent = "";
-      loginError.style.display = "none";
-      try {
-        fitAnalyticsCanvas();
-        filterRange?.addEventListener("change", guardedRender(renderAll));
-        analyticsPage?.addEventListener("change", guardedRender(renderAll));
-        if (typeof logoutBtn !== "undefined" && logoutBtn) logoutBtn.onclick = () => { doLogout(false); };
-        window.addEventListener("resize", () => {
-          try { fitAnalyticsCanvas(); if (!dashboardApp.hidden) renderAll(); }
-          catch (e) { console.error("resize handler failed", e); }
-        });
-      } catch (e) { console.error("dashboard UI init failed", e); }
-      initDashboardSystemsSafe();
-    }
-
-    function showLogin() {
-      sessionStorage.removeItem("maybenotDashboardAuth");
-      sessionStorage.removeItem("mbnt_admin_auth");
-      loginScreen.style.display = "block";
-      dashboardApp.style.display = "none";
-      dashboardApp.hidden = true;
-    }
-
-    window.showLogin = showLogin;
-    if (sessionStorage.getItem("maybenotDashboardAuth") === "true") { openDashboard(); } else { showLogin(); }
-
-    form.addEventListener("submit", function (event) {
-      event.preventDefault();
-      event.stopPropagation();
-      const username = usernameInput.value.trim();
-      const password = passwordInput.value.trim();
-      if (username === "maybenot" && password === "Sacred6767") {
-        openDashboard();
-      } else {
-        loginError.textContent = "Invalid credentials.";
-        loginError.style.display = "block";
-      }
-    });
-  });
-})();
-</script>
-</body></html>
+filterRange.addEventListener('change',guardedRender(renderAll));analyticsPage.addEventListener('change',guardedRender(renderAll));
+loginForm.addEventListener('submit',async e=>{e.preventDefault();const hash=await crypto.subtle.digest('SHA-256',new TextEncoder().encode(password.value));const h=[...new Uint8Array(hash)].map(b=>b.toString(16).padStart(2,'0')).join('');if(username.value.trim()===ACCESS.username&&h===ACCESS.passwordHash){sessionStorage.setItem(DASH_SESSION_KEY,'1');sessionStorage.setItem('mbnt_admin_auth',h);auth.hidden=true;dashboard.hidden=false;initPageSelect();renderAll();armInactivity();liveTimer=setInterval(renderAll,5000)}else authError.textContent='Invalid credentials.'});logoutBtn.onclick=()=>{doLogout();clearInterval(liveTimer)};
+if(sessionStorage.getItem(DASH_SESSION_KEY)==='1'){auth.hidden=true;dashboard.hidden=false;initPageSelect();renderAll();armInactivity();liveTimer=setInterval(renderAll,5000)} setInterval(()=>document.getElementById('current-time').textContent=`${new Date().toLocaleTimeString('en-US',{timeZone:'America/Chicago'})} CHICAGO`,1000);
+</script></body></html>


### PR DESCRIPTION
### Motivation
- The dashboard became broken after introducing hydration and cross-browser rendering changes, causing logos, products, pages, and analytics selectors to disappear.  
- Restore the last known-working dashboard-local rendering so Product Manager, Page Manager, and Analytics behave without hydration dependencies.  
- Keep small, non-breaking fixes for login, timestamp, and inactivity handling that do not interfere with dashboard rendering.

### Description
- Restored `dashboard.html` to the pre-hydration implementation: reinstated the standalone render functions (`renderProducts`, `renderPages`, `initPageSelect`, `renderAll`) and removed the dashboard hydration override logic so dashboard does not rely on shop hydration.  
- Repaired header/footer markup/CSS to match the working baseline: centered logo iframe, Chicago timestamp under logo, and footer link groups/spacing consistent with `shop.html`.  
- Preserved secure login flow and session behavior by keeping the hashed `ACCESS` check, timestamp updater, and inactivity logout while wiring the login UI to the restored dashboard flow.  
- Adjusted product/page manager styles to restore scrollable lists and mobile sizing so all products/pages appear across browsers.

### Testing
- Located the pre-hydration dashboard version and restored `dashboard.html`, then verified the repository status and file diff show only `dashboard.html` changed; the verification succeeded.  
- Scanned the restored file for hydration-related markers and confirmed the dashboard no longer depends on hydration logic; the scan passed.  
- Inspected the restored file to confirm header/logo/timestamp, product/page render functions, analytics page selector initialization, and login hashing are present; those automated inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5854056708321b70b2c99f78eca5f)