### PR TITLE
Fix dashboard login flow and restore Chicago timestamp header

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -60,9 +60,27 @@ footer{position:static;width:100%;text-align:center;background-color:#f7f7f7;pad
 footer .footer-links{display:flex;justify-content:center;padding-bottom:10px}
 .footer-line{justify-content:center;flex-wrap:wrap;width:min(90%,820px);font-size:.65rem;letter-spacing:.02rem}
 .footer-links{padding-bottom:10px}
-</style></head><body><div class="dashboard-shell"><header class="header-container"><div class="logo-container"><iframe src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1"></iframe></div><div id="current-time" class="time"></div></header><div class="site-shell">
-<section id="auth" class="panel"><form id="loginForm"><h1>Team Private Admin</h1><input id="username" placeholder="Username" required/><input id="password" type="password" placeholder="Password" required/><button>Login</button><small id="authError" style="color:#c00"></small></form></section>
-<main id="dashboard" hidden>
+
+#dashboard-site-header {
+  display: block !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  width: 100%;
+  text-align: center;
+}
+
+#chicago-time {
+  display: block !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  text-align: center;
+  font-size: 11px;
+  margin-top: 2px;
+  margin-bottom: 12px;
+}
+</style></head><body><header id="dashboard-site-header"><div class="logo-container"><iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe><div class="logo-overlay"></div></div><div id="chicago-time" class="chicago-time"></div></header><div class="dashboard-shell"><div class="site-shell">
+<section id="dashboard-login-screen" class="panel"><form id="dashboard-login-form"><h1>Team Private Admin</h1><input id="dashboard-username" name="username" autocomplete="username" placeholder="Username" required/><input id="dashboard-password" name="password" type="password" autocomplete="current-password" placeholder="Password" required/><button type="submit">Sign In</button><p id="dashboard-login-error" style="display:none;"></p></form></section>
+<main id="dashboard-app" hidden style="display:none;">
 <div class="panel"><button id="logoutBtn">Logout</button> <select id="filterRange"><option value="hour">Hour</option><option value="day" selected>Day</option><option value="week">Week</option><option value="month">Month</option><option value="year">Year</option><option value="all">All Time</option></select> <select id="analyticsPage"></select></div>
 <div class="panel"><h2>Real Analytics</h2><canvas id="analyticsGraph" width="1000" height="120"></canvas><div id="siteMetrics" class="row"></div><h3>Traffic Per Page</h3><ul id="pageAnalytics"></ul><h3>Visitors by Location</h3><div class="panel">Location analytics will appear here once backend tracking is connected.</div></div>
 <div class="panel"><h2>Product Manager</h2><h3>Create New Product</h3><form id="createProductForm" class="row"><input id="newName" placeholder="Product name" required><textarea id="newDescription" placeholder="Description"></textarea><input id="newPrice" type="number" step="0.01" placeholder="Price" required><select id="newCategory"></select><input id="newMainImage" placeholder="Main image path"><input id="newMainImageUpload" type="file" accept="image/*"><input id="newImages" placeholder="Additional images (comma separated)"><input id="newImagesUpload" type="file" accept="image/*" multiple><input id="newQty" type="number" placeholder="Quantity" value="0"><input id="newVariants" placeholder="Variants (comma separated)"><label><input type="checkbox" id="newManualSold"> Sold out manually</label><label><input type="checkbox" id="newActive" checked> Active/visible</label><div><strong>Placement</strong><div id="placementPills" class="pill-wrap"></div></div><button id="createProductBtn" type="submit">Create Product</button><small id="createProductError" style="color:#c00"></small></form><div id="productGrid" class="product-manager-list"></div></div>
@@ -70,7 +88,6 @@ footer .footer-links{display:flex;justify-content:center;padding-bottom:10px}
 </main></div><div class="view-full-site-wrap"><a class="view-full-site" href="index.html">View Full Site</a></div><footer class="footer"><div class="footer-links"><div class="footer-line extra-padding"><a href="shop.html">shop</a><a href="all.html">view all</a><a href="soon.html">preview</a><a href="soon.html">lookbook</a><a href="news.html">news</a></div><div class="footer-line"><a href="random.html">random</a><a href="about.html">about</a><a href="stores.html">stores</a><a href="soon.html">sizing</a><a href="faq.html">f.a.q.</a><a href="contact.html">contact</a></div><div class="footer-line less-padding"><a href="terms.html">terms</a><a href="privacy.html">privacy</a><a href="accessibility.html">accessibility</a><a href="mailinglist.html">mailing list</a></div></div></footer></div>
 <script>
 const DASH_SESSION_KEY='mbnt_dashboard_auth',productsKey='mbnt_admin_products',pagesKey='mbnt_admin_pages',analyticsKey='mbnt_analytics_events';
-const ACCESS={username:'maybenot',passwordHash:'461a77919bf434e323be3c1d06796673a925a273dd02f5cb06b7f3a2c19c059f'};
 const SITE_PAGES=['index.html','shop.html','all.html','new.html','t-shirts.html','babynot.html','vintage.html','hoodie.html','hats.html','accessories.html','shirts.html','sweatshirts.html','pants.html','bags.html','skate.html','cart.html','checkout.html','about.html','contact.html'];
 const PAGE_TYPES=['Collection Page','Product Page','Blank Page','Redirect Page'];
 const COLLECTION_SLUGS=['babynot.html','new.html','jackets.html','shirts.html','tops-sweaters.html','sweatshirts.html','pants.html','t-shirts.html','hats.html','bags.html','accessories.html','shoes.html','gym.html','skate.html','all.html'];
@@ -86,9 +103,9 @@ function buildEvent(type,payload={}){return{type,timestamp:new Date().toISOStrin
 async function trackEvent(type,payload={}){const event=buildEvent(type,payload);const events=read(analyticsKey,[]);events.push({...event,timestampMs:Date.now()});save(analyticsKey,events);try{await fetch('/api/analytics/track',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(event)});}catch(_){}}
 trackEvent('page_visit',{page:'dashboard.html'});
 let inactivityTimeout,logoutTimeout,warningShown=false,liveTimer;
-function doLogout(){sessionStorage.removeItem(DASH_SESSION_KEY);auth.hidden=false;dashboard.hidden=true;clearTimeout(inactivityTimeout);clearTimeout(logoutTimeout);warningShown=false;alert('Signed out due to inactivity.');}
+function doLogout(){const loginScreen=document.getElementById('dashboard-login-screen');const app=document.getElementById('dashboard-app');sessionStorage.removeItem(DASH_SESSION_KEY);sessionStorage.removeItem('maybenotDashboardAuth');if(loginScreen){loginScreen.hidden=false;loginScreen.style.display='block';}if(app){app.hidden=true;app.style.display='none';}clearTimeout(inactivityTimeout);clearTimeout(logoutTimeout);warningShown=false;alert('Signed out due to inactivity.');}
 function armInactivity(){clearTimeout(inactivityTimeout);clearTimeout(logoutTimeout);if(warningShown){warningShown=false;}inactivityTimeout=setTimeout(()=>{warningShown=true;alert('You have been inactive. You will be signed out in 1 minute.');logoutTimeout=setTimeout(doLogout,60000);},300000);}
-['mousemove','click','keydown','scroll','touchstart'].forEach(evt=>document.addEventListener(evt,()=>{if(!dashboard.hidden)armInactivity()},{passive:true}));
+['mousemove','click','keydown','scroll','touchstart'].forEach(evt=>document.addEventListener(evt,()=>{if(!dashboardApp.hidden)armInactivity()},{passive:true}));
 async function fetchAnalyticsSummary(){try{const res=await fetch('/api/analytics/summary');if(!res.ok)throw new Error('summary');const summary=await res.json();return summary.events||[]}catch(_){return read(analyticsKey,[])}}
 
 function filterEvents(events,scope,page){const spans={hour:36e5,day:864e5,week:6048e5,month:26298e5,year:315576e5,all:1e16};const now=Date.now();return events.filter(e=>now-(e.timestampMs||Date.parse(e.timestamp)||0)<=spans[scope]).filter(e=>!page||e.pagePath===page||e.page===page)}
@@ -117,6 +134,111 @@ function guardedRender(fn){return ()=>{if(dirty&&!confirm('Please confirm change
 function initPageSelect(){const products=read(productsKey,[]);const pages=[...new Set(['index.html',...SITE_PAGES,...COLLECTION_SLUGS,...products.map(p=>slugifyProductPage(p.name||p.id||'product')),...read(pagesKey,[]).map(p=>p.slug)])];analyticsPage.innerHTML=pages.map(p=>`<option ${p==='index.html'?'selected':''}>${p}</option>`).join('')}
 async function renderAll(){const productsFix=read(productsKey,[]);const sb=productsFix.find(p=>String(p.name||'').toLowerCase().includes('skateboard 2'));if(sb&&Array.isArray(sb.images)&&sb.images[0]!=='skateboard4.png'){sb.images[0]='skateboard4.png';save(productsKey,productsFix);}save(pagesKey,syncProductPages(productsFix,read(pagesKey,[])));const scope=filterRange.value,page=analyticsPage.value,allEvents=await fetchAnalyticsSummary();const events=filterEvents(allEvents,scope,page),pv=events.filter(e=>e.type==='page_visit');siteMetrics.innerHTML=`<div>Visits: ${pv.length}</div><div>Unique sessions: ${new Set(events.map(e=>e.sessionId||e.timestamp)).size}</div>`;pageAnalytics.innerHTML=Object.entries(pv.reduce((m,e)=>(m[e.pagePath||e.page]=(m[e.pagePath||e.page]||0)+1,m),{})).map(([p,c])=>`<li>${p}: ${c}</li>`).join('')||'<li>No tracked visits</li>';drawGraph(events,scope);renderPlacementPills();renderCategoryOptions(newCategory.value);renderProducts();renderPages()}
 filterRange.addEventListener('change',guardedRender(renderAll));analyticsPage.addEventListener('change',guardedRender(renderAll));
-loginForm.addEventListener('submit',async e=>{e.preventDefault();const hash=await crypto.subtle.digest('SHA-256',new TextEncoder().encode(password.value));const h=[...new Uint8Array(hash)].map(b=>b.toString(16).padStart(2,'0')).join('');if(username.value.trim()===ACCESS.username&&h===ACCESS.passwordHash){sessionStorage.setItem(DASH_SESSION_KEY,'1');sessionStorage.setItem('mbnt_admin_auth',h);auth.hidden=true;dashboard.hidden=false;initPageSelect();renderAll();armInactivity();liveTimer=setInterval(renderAll,5000)}else authError.textContent='Invalid credentials.'});logoutBtn.onclick=()=>{doLogout();clearInterval(liveTimer)};
-if(sessionStorage.getItem(DASH_SESSION_KEY)==='1'){auth.hidden=true;dashboard.hidden=false;initPageSelect();renderAll();armInactivity();liveTimer=setInterval(renderAll,5000)} setInterval(()=>document.getElementById('current-time').textContent=`${new Date().toLocaleTimeString('en-US',{timeZone:'America/Chicago'})} CHICAGO`,1000);
+
+</script><script>
+(function () {
+  function ready(fn) {
+    if (document.readyState !== "loading") fn();
+    else document.addEventListener("DOMContentLoaded", fn);
+  }
+
+  ready(function () {
+    const form = document.getElementById("dashboard-login-form");
+    const usernameInput = document.getElementById("dashboard-username");
+    const passwordInput = document.getElementById("dashboard-password");
+    const loginScreen = document.getElementById("dashboard-login-screen");
+    const dashboardApp = document.getElementById("dashboard-app");
+    const loginError = document.getElementById("dashboard-login-error");
+
+    console.log("Dashboard login elements:", {
+      form: !!form,
+      usernameInput: !!usernameInput,
+      passwordInput: !!passwordInput,
+      loginScreen: !!loginScreen,
+      dashboardApp: !!dashboardApp,
+      loginError: !!loginError
+    });
+
+    if (!form || !usernameInput || !passwordInput || !loginScreen || !dashboardApp || !loginError) {
+      console.error("Dashboard login is broken because required IDs are missing.");
+      return;
+    }
+
+    function showDashboard() {
+      sessionStorage.setItem("maybenotDashboardAuth", "true");
+      sessionStorage.setItem(DASH_SESSION_KEY,'1');
+      loginScreen.hidden = true;
+      loginScreen.style.display = "none";
+      dashboardApp.hidden = false;
+      dashboardApp.style.display = "block";
+      loginError.textContent = "";
+      loginError.style.display = "none";
+      initPageSelect();renderAll();armInactivity();liveTimer=setInterval(renderAll,5000);
+    }
+
+    function showLogin() {
+      sessionStorage.removeItem("maybenotDashboardAuth");
+      sessionStorage.removeItem(DASH_SESSION_KEY);
+      clearInterval(liveTimer);
+      loginScreen.hidden = false;
+      loginScreen.style.display = "block";
+      dashboardApp.hidden = true;
+      dashboardApp.style.display = "none";
+    }
+
+    if (sessionStorage.getItem("maybenotDashboardAuth") === "true") {
+      showDashboard();
+    } else {
+      showLogin();
+    }
+
+    form.addEventListener("submit", function (event) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const username = usernameInput.value.trim();
+      const password = passwordInput.value.trim();
+
+      if (username === "maybenot" && password === "Sacred6767") {
+        showDashboard();
+      } else {
+        loginError.textContent = "Invalid credentials.";
+        loginError.style.display = "block";
+      }
+    });
+  });
+})();
+</script>
+<script>
+(function () {
+  function ready(fn) {
+    if (document.readyState !== "loading") fn();
+    else document.addEventListener("DOMContentLoaded", fn);
+  }
+
+  ready(function () {
+    const timeEl = document.getElementById("chicago-time");
+
+    if (!timeEl) {
+      console.error("Missing #chicago-time timestamp element.");
+      return;
+    }
+
+    function updateChicagoTime() {
+      timeEl.textContent = new Intl.DateTimeFormat("en-US", {
+        timeZone: "America/Chicago",
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: true
+      }).format(new Date());
+    }
+
+    updateChicagoTime();
+    setInterval(updateChicagoTime, 1000);
+  });
+})();
 </script></body></html>


### PR DESCRIPTION
### Motivation
- Restore a simple, reliable dashboard login flow (direct credentials, no hashing, no page refresh) that was broken by a revert.
- Reintroduce the Chicago timestamp in the dashboard header so the site shows current local time again.
- Make targeted changes limited to login/timestamp behavior in `dashboard.html` without touching products/pages/analytics/footer/hydration/styling beyond what's necessary.

### Description
- Replaced the old hashed-login flow with a simple form using the required IDs and direct credential check for `maybenot` / `Sacred6767`, and removed the obsolete `ACCESS.passwordHash` usage. 
- Added the required login HTML IDs and structure: `#dashboard-login-screen`, `#dashboard-login-form`, `#dashboard-username`, `#dashboard-password`, `#dashboard-login-error`, and `#dashboard-app` so the new script can target them directly.
- Inserted a header outside the login/dashboard containers using the same logo iframe markup pattern from `shop.html`, and added a `#chicago-time` element and CSS rules for `#dashboard-site-header` and `#chicago-time` to ensure visibility.
- Appended a standalone bottom-of-page login bootstrap script (runs on DOMContentLoaded) that prevents form refresh, logs element presence to the console, validates credentials, shows the dashboard immediately on success, and shows `Invalid credentials.` on failure.
- Appended a standalone Chicago time updater script (runs on DOMContentLoaded) that updates `#chicago-time` every second using `Intl.DateTimeFormat` with `timeZone: "America/Chicago"`.
- Updated logout/inactivity logic to use the new login/dashboard element IDs and to clear the session key used by the simple login flow.

### Testing
- Verified presence of required IDs and new strings using ripgrep: `rg -n "dashboard-login-form|dashboard-username|dashboard-password|dashboard-login-screen|dashboard-app|dashboard-login-error|maybenot|Sacred6767|Invalid credentials.|event.preventDefault\(|chicago-time|dashboard-site-header" dashboard.html`, and all expected matches were found. (passed)
- Inspected `dashboard.html` content sections with `sed` to confirm the header, login form markup, CSS, and appended scripts are present. (passed)
- Committed the modified `dashboard.html` file after edits to ensure changes are saved. (commit recorded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f586f62b8883219ef364900d83130c)