### PR TITLE
Route checkout and cart Log in buttons to `/account` sign-in

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -624,7 +624,7 @@
             <div class="or">OR</div>
             <div class="contact-header">
                 <h3>Contact</h3>
-                <button type="button" id="login-btn" onclick="window.location.href='/account/login';">Log in</button>
+                <button type="button" id="login-btn" onclick="window.location.href='/account';">Log in</button>
             </div>
             <input type="email" name="contact_email" placeholder="Enter an email">
             <p class="email-warning empty-cart-message" style="display:none;">Please provide your contact email for this order.</p>

--- a/cart.js
+++ b/cart.js
@@ -1265,7 +1265,7 @@ function createCartModal() {
                     <div class="or">OR</div>
                     <div class="contact-header">
                         <h3>Contact</h3>
-                        <button type="button" id="login-btn" onclick="window.location.href='/account/login';">Log in</button>
+                        <button type="button" id="login-btn" onclick="window.location.href='/account';">Log in</button>
                     </div>
                     <input type="email" name="contact_email" placeholder="Enter an email">
                     <p class="email-warning empty-cart-message" style="display:none;">Please provide your contact email for this order.</p>

--- a/checkout.html
+++ b/checkout.html
@@ -600,7 +600,7 @@
             <div class="or">OR</div>
             <div class="contact-header">
                 <h3>Contact</h3>
-                <button type="button" id="login-btn" onclick="window.location.href='/account/login';">Log in</button>
+                <button type="button" id="login-btn" onclick="window.location.href='/account';">Log in</button>
             </div>
             <input type="email" name="contact_email" placeholder="Enter an email">
             <p class="email-warning empty-cart-message" style="display:none;">Please provide your contact email for this order.</p>


### PR DESCRIPTION
### Motivation
- Users could not sign in from the checkout/cart UI because login links pointed to an incorrect route. 
- The project needs consistent entry points for account sign-in across checkout, cart, and cart modal templates.

### Description
- Changed the login button target from `/account/login` to `/account` in `checkout.html`. 
- Changed the login button target from `/account/login` to `/account` in `cart.html`. 
- Changed the login button target from `/account/login` to `/account` in the cart modal template inside `cart.js`. 

### Testing
- Verified occurrences and replacements using `rg` searches for the login target and inspected updated lines with `nl -ba`, which showed the buttons now use `/account`. 
- Ran a full-file search with `rg --files` to confirm only the intended files were modified, which succeeded. 
- Opened the updated files to visually confirm the `onclick` handlers now point to `/account`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58db40be48321ba4d62501af89483)