### PR TITLE
Fix dashboard login/auth flow and session handling

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -5,7 +5,7 @@ body{min-height:100dvh;font-family:Arial,sans-serif;background:#fff;color:#000}
 .dashboard-shell{min-height:100dvh;display:flex;flex-direction:column;width:100%}
 
 #dashboard-site-header{flex:0 0 auto}
-#dashboard-login-screen{flex:1 1 auto;display:flex;align-items:center;justify-content:center;padding:16px}
+#auth{flex:1 1 auto;display:flex;align-items:center;justify-content:center;padding:16px}
 .dashboard-footer-wrap{flex:0 0 auto}
 .header-container{width:100%;padding:0 10px 10px;background-color:#f7f7f7;display:flex;flex-direction:column;align-items:center}
 .logo-container{position:relative;width:20vw;max-width:260px;min-width:170px;height:15vh;max-height:120px;margin-top:0}
@@ -66,15 +66,16 @@ footer .footer-links{display:flex;justify-content:center;padding-bottom:10px}
 .footer-links{padding-bottom:10px}
 
 </style></head><body><header id="dashboard-site-header" class="header-container"><div class="logo-container"><iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe><div class="logo-overlay"></div></div><div id="chicago-time" class="chicago-time"></div></header><div class="dashboard-shell"><div class="site-shell">
-<section id="dashboard-login-screen" class="panel"><form id="dashboard-login-form"><h1>Team Private Admin</h1><input id="dashboard-username" name="username" autocomplete="username" placeholder="Username" required/><input id="dashboard-password" name="password" type="password" autocomplete="current-password" placeholder="Password" required/><button type="submit">Login</button><p id="dashboard-login-error" style="display:none;"></p></form></section>
-<main id="dashboard-app" hidden style="display:none;">
+<section id="auth" class="panel"><form id="loginForm"><h1>Team Private Admin</h1><input id="username" name="username" autocomplete="username" placeholder="Username" required/><input id="password" name="password" type="password" autocomplete="current-password" placeholder="Password" required/><button type="submit">Login</button><p id="authError"></p></form></section>
+<main id="dashboard" hidden style="display:none;">
 <div class="panel"><button id="logoutBtn">Logout</button> <select id="filterRange"><option value="hour">Hour</option><option value="day" selected>Day</option><option value="week">Week</option><option value="month">Month</option><option value="year">Year</option><option value="all">All Time</option></select> <select id="analyticsPage"></select></div>
 <div class="panel"><h2>Real Analytics</h2><canvas id="analyticsGraph" width="1000" height="120"></canvas><div id="siteMetrics" class="row"></div><h3>Traffic Per Page</h3><ul id="pageAnalytics"></ul><h3>Visitors by Location</h3><div class="panel">Location analytics will appear here once backend tracking is connected.</div></div>
 <div class="panel"><h2>Product Manager</h2><h3>Create New Product</h3><form id="createProductForm" class="row"><input id="newName" placeholder="Product name" required><textarea id="newDescription" placeholder="Description"></textarea><input id="newPrice" type="number" step="0.01" placeholder="Price" required><select id="newCategory"></select><input id="newMainImage" placeholder="Main image path"><input id="newMainImageUpload" type="file" accept="image/*"><input id="newImages" placeholder="Additional images (comma separated)"><input id="newImagesUpload" type="file" accept="image/*" multiple><input id="newQty" type="number" placeholder="Quantity" value="0"><input id="newVariants" placeholder="Variants (comma separated)"><label><input type="checkbox" id="newManualSold"> Sold out manually</label><label><input type="checkbox" id="newActive" checked> Active/visible</label><div><strong>Placement</strong><div id="placementPills" class="pill-wrap"></div></div><button id="createProductBtn" type="submit">Create Product</button><small id="createProductError" style="color:#c00"></small></form><div id="productGrid" class="product-manager-list"></div></div>
 <div class="panel"><h2>Page Manager</h2><h3>Create New Page</h3><form id="pageForm" class="row"><input id="pageName" placeholder="Page filename (example: vintage.html)" required><input id="pageLabel" placeholder="Nav label" required><select id="pageType"><option>Collection Page</option><option>Redirect Page</option><option>Product Page</option><option>Blank Page</option></select><input id="redirectUrl" placeholder="Redirect URL (for Redirect Page)"><button>Create/Update Page</button></form><div id="pageManager"></div></div>
 </main></div><div class="view-full-site-wrap"><a class="view-full-site" href="index.html">View Full Site</a></div><footer class="footer dashboard-footer-wrap"><div class="footer-links"><div class="footer-line extra-padding"><a href="shop.html">shop</a><a href="all.html">view all</a><a href="soon.html">preview</a><a href="soon.html">lookbook</a><a href="news.html">news</a></div><div class="footer-line"><a href="random.html">random</a><a href="about.html">about</a><a href="stores.html">stores</a><a href="soon.html">sizing</a><a href="faq.html">f.a.q.</a><a href="contact.html">contact</a></div><div class="footer-line less-padding"><a href="terms.html">terms</a><a href="privacy.html">privacy</a><a href="accessibility.html">accessibility</a><a href="mailinglist.html">mailing list</a></div></div></footer></div>
 <script>
-const DASH_SESSION_KEY='mbnt_dashboard_auth',productsKey='mbnt_admin_products',pagesKey='mbnt_admin_pages',analyticsKey='mbnt_analytics_events';
+document.addEventListener("DOMContentLoaded", () => {
+const DASH_SESSION_KEY = "mbnt_dashboard_auth",productsKey='mbnt_admin_products',pagesKey='mbnt_admin_pages',analyticsKey='mbnt_analytics_events';
 const SITE_PAGES=['index.html','shop.html','all.html','new.html','t-shirts.html','babynot.html','vintage.html','hoodie.html','hats.html','accessories.html','shirts.html','sweatshirts.html','pants.html','bags.html','skate.html','cart.html','checkout.html','about.html','contact.html'];
 const PAGE_TYPES=['Collection Page','Product Page','Blank Page','Redirect Page'];
 const COLLECTION_SLUGS=['babynot.html','new.html','jackets.html','shirts.html','tops-sweaters.html','sweatshirts.html','pants.html','t-shirts.html','hats.html','bags.html','accessories.html','shoes.html','gym.html','skate.html','all.html'];
@@ -90,9 +91,9 @@ function buildEvent(type,payload={}){return{type,timestamp:new Date().toISOStrin
 async function trackEvent(type,payload={}){const event=buildEvent(type,payload);const events=read(analyticsKey,[]);events.push({...event,timestampMs:Date.now()});save(analyticsKey,events);try{await fetch('/api/analytics/track',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(event)});}catch(_){}}
 trackEvent('page_visit',{page:'dashboard.html'});
 let inactivityTimeout,logoutTimeout,warningShown=false,liveTimer;
-function doLogout(){const loginScreen=document.getElementById('dashboard-login-screen');const app=document.getElementById('dashboard-app');sessionStorage.removeItem(DASH_SESSION_KEY);if(loginScreen){loginScreen.hidden=false;loginScreen.style.display='flex';}if(app){app.hidden=true;app.style.display='none';}clearTimeout(inactivityTimeout);clearTimeout(logoutTimeout);warningShown=false;alert('Signed out due to inactivity.');}
+function doLogout(){const loginScreen=document.getElementById('auth');const app=document.getElementById('dashboard');sessionStorage.removeItem(DASH_SESSION_KEY);if(loginScreen){loginScreen.hidden=false;loginScreen.style.display='flex';}if(app){app.hidden=true;app.style.display='none';}clearTimeout(inactivityTimeout);clearTimeout(logoutTimeout);warningShown=false;alert('Signed out due to inactivity.');}
 function armInactivity(){clearTimeout(inactivityTimeout);clearTimeout(logoutTimeout);if(warningShown){warningShown=false;}inactivityTimeout=setTimeout(()=>{warningShown=true;alert('You have been inactive. You will be signed out in 1 minute.');logoutTimeout=setTimeout(doLogout,60000);},300000);}
-['mousemove','click','keydown','scroll','touchstart'].forEach(evt=>document.addEventListener(evt,()=>{const app=document.getElementById('dashboard-app');if(app && !app.hidden)armInactivity()},{passive:true}));
+['mousemove','click','keydown','scroll','touchstart'].forEach(evt=>document.addEventListener(evt,()=>{const app=document.getElementById('dashboard');if(app && !app.hidden)armInactivity()},{passive:true}));
 async function fetchAnalyticsSummary(){try{const res=await fetch('/api/analytics/summary');if(!res.ok)throw new Error('summary');const summary=await res.json();return summary.events||[]}catch(_){return read(analyticsKey,[])}}
 
 function filterEvents(events,scope,page){const spans={hour:36e5,day:864e5,week:6048e5,month:26298e5,year:315576e5,all:1e16};const now=Date.now();return events.filter(e=>now-(e.timestampMs||Date.parse(e.timestamp)||0)<=spans[scope]).filter(e=>!page||e.pagePath===page||e.page===page)}
@@ -122,88 +123,62 @@ function guardedRender(fn){return ()=>{if(dirty&&!confirm('Please confirm change
 function initPageSelect(){const products=read(productsKey,[]);const pages=[...new Set(['index.html',...SITE_PAGES,...COLLECTION_SLUGS,...products.map(p=>slugifyProductPage(p.name||p.id||'product')),...read(pagesKey,[]).map(p=>p.slug)])];analyticsPage.innerHTML=pages.map(p=>`<option ${p==='index.html'?'selected':''}>${p}</option>`).join('')}
 async function renderAll(){const productsFix=read(productsKey,[]);const sb=productsFix.find(p=>String(p.name||'').toLowerCase().includes('skateboard 2'));if(sb&&Array.isArray(sb.images)&&sb.images[0]!=='skateboard4.png'){sb.images[0]='skateboard4.png';save(productsKey,productsFix);}save(pagesKey,syncProductPages(productsFix,read(pagesKey,[])));const scope=filterRange.value,page=analyticsPage.value,allEvents=await fetchAnalyticsSummary();const events=filterEvents(allEvents,scope,page),pv=events.filter(e=>e.type==='page_visit');siteMetrics.innerHTML=`<div>Visits: ${pv.length}</div><div>Unique sessions: ${new Set(events.map(e=>e.sessionId||e.timestamp)).size}</div>`;pageAnalytics.innerHTML=Object.entries(pv.reduce((m,e)=>(m[e.pagePath||e.page]=(m[e.pagePath||e.page]||0)+1,m),{})).map(([p,c])=>`<li>${p}: ${c}</li>`).join('')||'<li>No tracked visits</li>';drawGraph(events,scope);renderPlacementPills();renderCategoryOptions(newCategory.value);renderProducts();renderPages()}
 filterRange.addEventListener('change',guardedRender(renderAll));analyticsPage.addEventListener('change',guardedRender(renderAll));
+const loginForm = document.getElementById("loginForm");
+const auth = document.getElementById("auth");
+const dashboard = document.getElementById("dashboard");
+const authError = document.getElementById("authError");
 
-</script><script>
-(function () {
-  function ready(fn) {
-    if (document.readyState !== "loading") fn();
-    else document.addEventListener("DOMContentLoaded", fn);
+function showDashboard() {
+  auth.hidden = true;
+  dashboard.hidden = false;
+
+  if (typeof initPageSelect === "function") initPageSelect();
+  if (typeof renderAll === "function") renderAll();
+  if (typeof armInactivity === "function") armInactivity();
+
+  if (window.liveTimer) clearInterval(window.liveTimer);
+  if (typeof renderAll === "function") {
+    window.liveTimer = setInterval(renderAll, 5000);
   }
+}
 
-  ready(function () {
-    const form = document.getElementById("dashboard-login-form");
-    const usernameInput = document.getElementById("dashboard-username");
-    const passwordInput = document.getElementById("dashboard-password");
-    const loginError = document.getElementById("dashboard-login-error");
-    const loginScreen = document.getElementById("dashboard-login-screen");
-    const dashboardApp = document.getElementById("dashboard-app");
+function showLogin() {
+  auth.hidden = false;
+  dashboard.hidden = true;
+}
 
-    console.log("Dashboard login elements:", {
-      form: !!form,
-      usernameInput: !!usernameInput,
-      passwordInput: !!passwordInput,
-      loginError: !!loginError,
-      loginScreen: !!loginScreen,
-      dashboardApp: !!dashboardApp
-    });
+loginForm.addEventListener("submit", function (event) {
+  event.preventDefault();
+  event.stopPropagation();
 
-    if (!form || !usernameInput || !passwordInput || !loginError || !loginScreen || !dashboardApp) {
-      console.error("Dashboard login is broken because required IDs are missing.");
-      return;
-    }
+  const username = document.getElementById("username").value.trim();
+  const password = document.getElementById("password").value.trim();
 
-    function showDashboard() {
-      sessionStorage.setItem(DASH_SESSION_KEY, "1");
-      loginScreen.hidden = true;
-      loginScreen.style.display = "none";
-      dashboardApp.hidden = false;
-      dashboardApp.style.display = "block";
-      loginError.textContent = "";
-      loginError.style.display = "none";
-      initPageSelect();
-      renderAll();
-      if (typeof armInactivity === "function") armInactivity();
-      if (typeof clearInterval === "function") clearInterval(liveTimer);
-      if (typeof renderAll === "function") liveTimer = setInterval(renderAll, 5000);
-    }
+  if (username === "maybenot" && password === "Sacred6767") {
+    sessionStorage.setItem(DASH_SESSION_KEY, "1");
+    authError.textContent = "";
+    showDashboard();
+  } else {
+    sessionStorage.removeItem(DASH_SESSION_KEY);
+    authError.textContent = "Invalid credentials.";
+    showLogin();
+  }
+});
 
-    function showLogin() {
-      sessionStorage.removeItem(DASH_SESSION_KEY);
-      clearInterval(liveTimer);
-      loginScreen.hidden = false;
-      loginScreen.style.display = "flex";
-      dashboardApp.hidden = true;
-      dashboardApp.style.display = "none";
-    }
+if (sessionStorage.getItem(DASH_SESSION_KEY) === "1") {
+  showDashboard();
+} else {
+  showLogin();
+}
 
-    if (sessionStorage.getItem(DASH_SESSION_KEY) === "1") {
-      showDashboard();
-    } else {
-      showLogin();
-    }
+logoutBtn.onclick = () => {
+  sessionStorage.removeItem(DASH_SESSION_KEY);
+  if (window.liveTimer) clearInterval(window.liveTimer);
+  showLogin();
+};
 
-    form.addEventListener("submit", function (event) {
-      event.preventDefault();
+});
 
-      const username = usernameInput.value.trim();
-      const password = passwordInput.value;
-      const matched = username === "maybenot" && password === "Sacred6767";
-
-      console.log("Dashboard login attempt:", {
-        username,
-        passwordLength: password.length,
-        matched
-      });
-
-      if (matched) {
-        showDashboard();
-      } else {
-        loginError.textContent = "Invalid credentials.";
-        loginError.style.display = "block";
-      }
-    });
-  });
-})();
 </script>
 <script>
 (function () {


### PR DESCRIPTION
### Motivation
- The dashboard login form was unreliable and allowed the page to refresh or not open the dashboard after submit, so a deterministic client-side auth flow was required.  
- Initialization handlers could run before DOM elements existed which caused race conditions for login and dashboard setup.  
- A simple, local session mechanism and a proper logout flow were requested to avoid depending on backend auth and to persist the dashboard across refreshes when logged in.

### Description
- Replaced the login markup with the required `auth`/`dashboard` containers and `loginForm`, `username`, `password`, and `authError` element IDs in `dashboard.html`.  
- Wrapped the dashboard initialization and related functions inside `document.addEventListener("DOMContentLoaded", () => { ... })` to ensure elements exist before binding handlers.  
- Implemented the exact client-side auth behavior using `sessionStorage` key `mbnt_dashboard_auth` with `preventDefault` + `stopPropagation`, direct credential check for `maybenot` / `Sacred6767`, and `showDashboard` / `showLogin` functions; added the requested `logoutBtn.onclick` handler to clear the session and live timer.  
- Adjusted internal element references (e.g. login/dashboard IDs and inactivity/interval handling) while preserving analytics, product/page manager, footer, and styling logic.

### Testing
- Verified presence of new IDs and containers with `rg` which reported `#auth`, `id="loginForm"`, and `id="dashboard"` as present in `dashboard.html`, indicating markup updates succeeded.  
- Checked DOM-ready wrapping occurrences with `node -e` which counted `document.addEventListener("DOMContentLoaded")` entries as expected, confirming init code was wrapped.  
- Inspected the updated file sections with `sed`/`nl` to confirm the `sessionStorage` key, `showDashboard`/`showLogin` behavior, and `logoutBtn.onclick` handler were inserted, and those checks succeeded.  
- Generated PR metadata (title/body) to capture the change; automated checks above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5fb212c6883219259846625ef931d)