### PR TITLE
Restore dashboard data visibility, add Order Manager sync and idle timers

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -143,8 +143,8 @@ const normalizedDefaults=DEFAULT_PRODUCTS.map(p=>({...p,placement:Array.isArray(
 const validExisting=Array.isArray(existingProducts)?existingProducts.filter(p=>p&&typeof p==='object'&&(p.id||p.name)):[];
 const productsById=new Map(validExisting.map(p=>[p.id||p.name,p]));
 for(const dp of normalizedDefaults){const key=dp.id||dp.name;if(!productsById.has(key))productsById.set(key,dp);}
-const mergedProducts=[...productsById.values()];
-if(!isValidProductsData(existingProducts)||mergedProducts.length<DEFAULT_PRODUCTS.length)save(productsKey,mergedProducts);
+const mergedProducts=[...productsById.values()].map(p=>({...p,placement:Array.isArray(p.placement)?p.placement:[p.category].filter(Boolean),variants:Array.isArray(p.variants)?p.variants:[],price:Number(p.price||0),description:p.description||''}));
+save(productsKey,mergedProducts);
 const existingPages=read(pagesKey,[]);
 const validPages=Array.isArray(existingPages)?existingPages.filter(p=>p&&typeof p==='object'&&p.slug):[];
 const pageMap=new Map(validPages.map(p=>[p.slug,p]));
@@ -155,7 +155,7 @@ save(pagesKey,syncedPages);
 }
 
 const adminAuth=()=>sessionStorage.getItem('mbnt_admin_auth')||'';
-const read=(k,d)=>JSON.parse(localStorage.getItem(k)||JSON.stringify(d)),save=(k,v)=>localStorage.setItem(k,JSON.stringify(v)); let dirty=false;
+const read=(k,d)=>{try{const raw=localStorage.getItem(k);if(raw===null||raw===undefined||raw==='')return structuredClone(d);const parsed=JSON.parse(raw);return parsed===null||parsed===undefined?structuredClone(d):parsed;}catch(_){return structuredClone(d);}},save=(k,v)=>localStorage.setItem(k,JSON.stringify(v)); let dirty=false;
 function slugifyProductPage(name){return String(name||'').toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'')+'.html'}
 function syncProductPages(products,pages){const nonProduct=(pages||[]).filter(pg=>pg.type!=='Product Page');const productPages=products.map(prod=>{const slug=slugifyProductPage(prod.name||prod.id||'product');const existing=(pages||[]).find(pg=>pg.slug===slug)||{};return {...existing,slug,label:prod.name||slug,type:'Product Page',visible:prod.status!=='inactive',productId:prod.id||null};});return [...nonProduct,...productPages]}
 
@@ -164,7 +164,7 @@ async function trackEvent(type,payload={}){const event=buildEvent(type,payload);
 trackEvent('page_visit',{page:'dashboard.html'});
 let inactivityTimeout,logoutTimeout,warningShown=false,liveTimer;
 function doLogout(){const loginScreen=document.getElementById('auth');const app=document.getElementById('dashboard');sessionStorage.removeItem(DASH_SESSION_KEY);if(loginScreen){loginScreen.hidden=false;loginScreen.style.display='flex';}if(app){app.hidden=true;app.style.display='none';}clearTimeout(inactivityTimeout);clearTimeout(logoutTimeout);warningShown=false;alert('Signed out due to inactivity.');}
-function armInactivity(){clearTimeout(inactivityTimeout);clearTimeout(logoutTimeout);if(warningShown){warningShown=false;}inactivityTimeout=setTimeout(()=>{warningShown=true;alert('You have been inactive. You will be signed out in 1 minute.');logoutTimeout=setTimeout(doLogout,60000);},300000);}
+function armInactivity(){clearTimeout(inactivityTimeout);clearTimeout(logoutTimeout);if(warningShown){warningShown=false;}inactivityTimeout=setTimeout(()=>{warningShown=true;alert('You have been inactive. You will be signed out in 1 minute.');logoutTimeout=setTimeout(doLogout,60000);},120000);}
 ['mousemove','click','keydown','scroll','touchstart'].forEach(evt=>document.addEventListener(evt,()=>{const app=document.getElementById('dashboard');if(app && !app.hidden)armInactivity()},{passive:true}));
 async function fetchAnalyticsSummary(){try{const res=await fetch('/api/analytics/summary');if(!res.ok)throw new Error('summary');const summary=await res.json();return summary.events||[]}catch(_){return read(analyticsKey,[])}}
 
@@ -214,7 +214,7 @@ async function autoRefundExpiredOrders(orders){
 }
 function orderDetailsMarkup(order){
   const c=order.customer||{};const addr=order.address||{};
-  return `<div style='margin-top:8px;font-size:13px'><div><strong>Date:</strong> ${order.createdAt?new Date(order.createdAt).toLocaleString():'N/A'}</div><div><strong>Customer:</strong> ${c.name||''} (${c.email||''})</div><div><strong>Address:</strong> ${[addr.line1,addr.city,addr.state,addr.postal_code,addr.country].filter(Boolean).join(', ')}</div><div><strong>Items:</strong> ${(order.items||[]).map(i=>`${i.name||'Item'} x${i.quantity||1}`).join('; ')||'N/A'}</div><div><strong>Total:</strong> $${((order.total||0)/100).toFixed(2)} ${(order.currency||'usd').toUpperCase()}</div><div><strong>Payment status:</strong> ${order.payment_status||order.status||'unknown'}</div><div><strong>Stripe ID:</strong> ${order.stripe_session_id||order.id||'N/A'}</div></div>`
+  return `<div style='margin-top:8px;font-size:13px'><div><strong>Date:</strong> ${order.createdAt?new Date(order.createdAt).toLocaleString():'N/A'}</div><div><strong>Customer:</strong> ${c.name||''} (${c.email||''})</div><div><strong>Address:</strong> ${[addr.line1,addr.city,addr.state,addr.postal_code,addr.country].filter(Boolean).join(', ')}</div><div><strong>Items:</strong> ${(order.items||[]).map(i=>`${i.name||'Item'} x${i.quantity||1}`).join('; ')||'N/A'}</div><div><strong>Total:</strong> $${((order.total||0)/100).toFixed(2)} ${(order.currency||'usd').toUpperCase()}</div><div><strong>Payment status:</strong> ${order.payment_status||order.status||'unknown'}</div><div><strong>Stripe Session ID:</strong> ${order.stripe_session_id||order.id||'N/A'}</div><div><strong>Stripe Payment ID:</strong> ${order.stripe_payment_intent_id||'N/A'}</div></div>`
 }
 async function confirmDelivered(i){
   const orders=read('mbnt_admin_orders',[]);const order=orders[i];
@@ -245,7 +245,7 @@ if(pageForm)pageForm.addEventListener('submit',async e=>{e.preventDefault();if(!
 function guardedRender(fn){return ()=>{if(dirty&&!confirm('Please confirm changes before changing pages if not done so already.'))return;fn();}}
 function initPageSelect(){seedDefaultData();const products=read(productsKey,[]);const pages=[...new Set(['index.html',...STATIC_PAGE_SLUGS,...SITE_PAGES,...COLLECTION_SLUGS,...DEFAULT_PAGES.map(p=>p.slug),...products.map(p=>slugifyProductPage(p.name||p.id||'product')),...read(pagesKey,[]).map(p=>p.slug)])];analyticsPage.innerHTML=pages.map(p=>`<option ${p==='index.html'?'selected':''}>${p}</option>`).join('')}
 async function renderAll(){seedDefaultData();const productsFix=read(productsKey,[]);const sb=productsFix.find(p=>String(p.name||'').toLowerCase().includes('skateboard 2'));if(sb&&Array.isArray(sb.images)&&sb.images[0]!=='skateboard4.png'){sb.images[0]='skateboard4.png';save(productsKey,productsFix);}save(pagesKey,syncProductPages(productsFix,read(pagesKey,[])));const scope=filterRange.value,page=analyticsPage.value,allEvents=await fetchAnalyticsSummary();const events=filterEvents(allEvents,scope,page),pv=events.filter(e=>e.type==='page_visit');siteMetrics.innerHTML=`<div>Visits: ${pv.length}</div><div>Unique sessions: ${new Set(events.map(e=>e.sessionId||e.timestamp)).size}</div>`;pageAnalytics.innerHTML=Object.entries(pv.reduce((m,e)=>(m[e.pagePath||e.page]=(m[e.pagePath||e.page]||0)+1,m),{})).map(([p,c])=>`<li>${p}: ${c}</li>`).join('')||'<li>No tracked visits</li>';drawGraph(events,scope);await renderOrders();renderPlacementPills();renderCategoryOptions(newCategory.value);renderProducts();renderPages()}
-window.initPageSelect=initPageSelect;window.renderAll=renderAll;window.armInactivity=armInactivity;seedDefaultData();if(filterRange)filterRange.addEventListener('change',guardedRender(renderAll));if(analyticsPage)analyticsPage.addEventListener('change',guardedRender(renderAll));if(refreshOrdersBtn)refreshOrdersBtn.addEventListener('click',renderOrders);
+window.initPageSelect=initPageSelect;window.renderAll=renderAll;window.renderOrders=renderOrders;window.armInactivity=armInactivity;seedDefaultData();if(filterRange)filterRange.addEventListener('change',guardedRender(renderAll));if(analyticsPage)analyticsPage.addEventListener('change',guardedRender(renderAll));if(refreshOrdersBtn)refreshOrdersBtn.addEventListener('click',renderOrders);
 });
 
 </script>
@@ -299,9 +299,13 @@ document.addEventListener("DOMContentLoaded", function () {
     if (typeof renderAll === "function") renderAll();
     if (typeof armInactivity === "function") armInactivity();
 
-    if (window.liveTimer) clearInterval(window.liveTimer);
+      if (window.analyticsTimer) clearInterval(window.analyticsTimer);
+    if (window.ordersTimer) clearInterval(window.ordersTimer);
     if (typeof renderAll === "function") {
-      window.liveTimer = setInterval(renderAll, 5000);
+      window.analyticsTimer = setInterval(renderAll, 5000);
+    }
+    if (typeof renderOrders === "function") {
+      window.ordersTimer = setInterval(renderOrders, 30000);
     }
   }
 
@@ -309,6 +313,8 @@ document.addEventListener("DOMContentLoaded", function () {
     auth.style.display = "block";
     dashboard.hidden = true;
     dashboard.style.display = "none";
+    if (window.analyticsTimer) clearInterval(window.analyticsTimer);
+    if (window.ordersTimer) clearInterval(window.ordersTimer);
   }
 
   loginForm.addEventListener("submit", function (e) {
@@ -333,7 +339,8 @@ document.addEventListener("DOMContentLoaded", function () {
   if (logoutBtn) {
     logoutBtn.onclick = function () {
       sessionStorage.removeItem(DASH_SESSION_KEY);
-      if (window.liveTimer) clearInterval(window.liveTimer);
+      if (window.analyticsTimer) clearInterval(window.analyticsTimer);
+      if (window.ordersTimer) clearInterval(window.ordersTimer);
       showLogin();
     };
   }

--- a/stripe-checkout-server.mjs
+++ b/stripe-checkout-server.mjs
@@ -402,6 +402,7 @@ async function handleAdminOrders(req, res) {
       payment_status: session.payment_status || session.status || 'unknown',
       status: session.payment_status === 'paid' ? 'confirmed' : 'unconfirmed',
       stripe_session_id: session.id,
+      stripe_payment_intent_id: typeof session.payment_intent === 'string' ? session.payment_intent : (session.payment_intent?.id || ''),
       items: (session.line_items?.data || []).map((item) => ({
         name: item.description || item.price?.nickname || 'Item',
         quantity: item.quantity || 1,


### PR DESCRIPTION
### Motivation
- Prevent empty/invalid `localStorage` from hiding the shop by ensuring default catalog/pages are always available and merged on load. 
- Restore immediate visibility of all 25 products and all pages in the Product/Page Managers so the admin sees a full catalog after login. 
- Surface real Stripe orders in the Order Manager and make the dashboard refresh and idle-signout behavior conform to the new requirements.

### Description
- Hardened localStorage reads by replacing the simple `JSON.parse(localStorage.getItem(...))` wrapper with a safe `read` that falls back to defaults on `null`, empty string, parse errors, or invalid data, and uses `structuredClone` of defaults to avoid mutation. 
- Always merge `DEFAULT_PRODUCTS` into admin products and persist the merged result back to `localStorage` on seed via `seedDefaultData`, guaranteeing the Product Manager is populated with all 25 items on load. 
- Synced `DEFAULT_PAGES` with product pages and saved merged pages back to `localStorage` immediately, and kept the existing product-page edit guard (`Product pages are edited through Product Manager.`). 
- Exposed `renderOrders` globally and added a dedicated orders refresh timer that runs every 30s while logged in, retained analytics refresh at 5s, and ensured timers are cleared on login/logout; updated inactivity logic to warn at 2 minutes and auto sign out after 3 minutes total. 
- Extended Order Manager UI to show both Stripe Checkout Session ID and Stripe Payment Intent ID, and updated the backend `/api/admin/orders` mapping to include `stripe_payment_intent_id` from Checkout Sessions. 

### Testing
- Static validation and searches were executed with `rg -n` to confirm updated tokens and fields (e.g. `structuredClone`, `stripe_payment_intent_id`, `renderOrders`), and these searches succeeded. 
- File inspections were performed (viewing relevant `dashboard.html` and `stripe-checkout-server.mjs` regions) to verify the merged-products save, hardened `read`, timer changes, and added Stripe field were present and correctly formatted. 
- Confirmed that the Order Manager rendering now includes both session and payment intent IDs and that the orders refresh timer and inactivity timers are wired in the login/logout lifecycle (observed via the modified source).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6225adbe083219f6cf1322459188c)