### PR TITLE
Sync dashboard admin data from repo and Stripe (products/pages/orders)

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -243,9 +243,16 @@ window.deletePage=async slug=>{const core=['index.html','shop.html'];const msg=c
 window.savePage=async (slug,i)=>{const products=read(productsKey,[]);const isProductPage=products.map(p=>slugifyProductPage(p.name||p.id||'product')).includes(slug);if(isProductPage){alert('Product pages are edited through Product Manager.');return;}if(!confirm('Confirm changes before saving?'))return;const pages=read(pagesKey,[]);let p=pages.find(x=>x.slug===slug);if(!p){p={slug};pages.push(p)};document.querySelectorAll(`#page-edit-${i} [data-page]`).forEach(el=>{const k=el.dataset.page;p[k]=el.type==='checkbox'?el.checked:(k==='assignments'?el.value.split(',').map(s=>s.trim()).filter(Boolean):el.value)});persistAdmin('/api/admin/update-page',{page:p}).then(()=>{save(pagesKey,pages);dirty=false;renderAll()}).catch(err=>alert(err.message));};
 if(pageForm)pageForm.addEventListener('submit',async e=>{e.preventDefault();if(!confirm('Confirm changes before saving?'))return;const pages=read(pagesKey,[]),slug=pageName.value.trim();const data={slug,label:pageLabel.value.trim(),type:pageType.value,redirectUrl:redirectUrl.value.trim(),visible:true};const ex=pages.find(p=>p.slug===slug);if(ex)Object.assign(ex,data);else pages.push(data);try{await persistAdmin('/api/admin/create-page',{page:data});}catch(err){alert(err.message);return;}save(pagesKey,pages);renderAll()});
 function guardedRender(fn){return ()=>{if(dirty&&!confirm('Please confirm changes before changing pages if not done so already.'))return;fn();}}
-function initPageSelect(){seedDefaultData();const products=read(productsKey,[]);const pages=[...new Set(['index.html',...STATIC_PAGE_SLUGS,...SITE_PAGES,...COLLECTION_SLUGS,...DEFAULT_PAGES.map(p=>p.slug),...products.map(p=>slugifyProductPage(p.name||p.id||'product')),...read(pagesKey,[]).map(p=>p.slug)])];analyticsPage.innerHTML=pages.map(p=>`<option ${p==='index.html'?'selected':''}>${p}</option>`).join('')}
-async function renderAll(){seedDefaultData();const productsFix=read(productsKey,[]);const sb=productsFix.find(p=>String(p.name||'').toLowerCase().includes('skateboard 2'));if(sb&&Array.isArray(sb.images)&&sb.images[0]!=='skateboard4.png'){sb.images[0]='skateboard4.png';save(productsKey,productsFix);}save(pagesKey,syncProductPages(productsFix,read(pagesKey,[])));const scope=filterRange.value,page=analyticsPage.value,allEvents=await fetchAnalyticsSummary();const events=filterEvents(allEvents,scope,page),pv=events.filter(e=>e.type==='page_visit');siteMetrics.innerHTML=`<div>Visits: ${pv.length}</div><div>Unique sessions: ${new Set(events.map(e=>e.sessionId||e.timestamp)).size}</div>`;pageAnalytics.innerHTML=Object.entries(pv.reduce((m,e)=>(m[e.pagePath||e.page]=(m[e.pagePath||e.page]||0)+1,m),{})).map(([p,c])=>`<li>${p}: ${c}</li>`).join('')||'<li>No tracked visits</li>';drawGraph(events,scope);await renderOrders();renderPlacementPills();renderCategoryOptions(newCategory.value);renderProducts();renderPages()}
-window.initPageSelect=initPageSelect;window.renderAll=renderAll;window.renderOrders=renderOrders;window.armInactivity=armInactivity;seedDefaultData();if(filterRange)filterRange.addEventListener('change',guardedRender(renderAll));if(analyticsPage)analyticsPage.addEventListener('change',guardedRender(renderAll));if(refreshOrdersBtn)refreshOrdersBtn.addEventListener('click',renderOrders);
+async function syncDashboardData(){
+  const headers={'x-admin-auth':adminAuth()};
+  const errors=[];
+  try{const r=await fetch('/api/admin/products',{headers});const d=await r.json();if(!r.ok)throw new Error(d.error||'Failed to load products');if(Array.isArray(d.products)&&d.products.length){save(productsKey,d.products);}else{errors.push('Product Manager: no products returned from backend.');}}catch(e){errors.push(`Product Manager: ${e.message}`)}
+  try{const r=await fetch('/api/admin/pages',{headers});const d=await r.json();if(!r.ok)throw new Error(d.error||'Failed to load pages');if(Array.isArray(d.pages)&&d.pages.length){save(pagesKey,d.pages);}else{errors.push('Page Manager: no pages returned from backend.');}}catch(e){errors.push(`Page Manager: ${e.message}`)}
+  window.__adminSyncErrors=errors;
+}
+function initPageSelect(){const products=read(productsKey,[]);const pages=[...new Set(['index.html',...STATIC_PAGE_SLUGS,...SITE_PAGES,...COLLECTION_SLUGS,...DEFAULT_PAGES.map(p=>p.slug),...products.map(p=>slugifyProductPage(p.name||p.id||'product')),...read(pagesKey,[]).map(p=>p.slug)])];analyticsPage.innerHTML=pages.map(p=>`<option ${p==='index.html'?'selected':''}>${p}</option>`).join('')}
+async function renderAll(){const productsFix=read(productsKey,[]);const sb=productsFix.find(p=>String(p.name||'').toLowerCase().includes('skateboard 2'));if(sb&&Array.isArray(sb.images)&&sb.images[0]!=='skateboard4.png'){sb.images[0]='skateboard4.png';save(productsKey,productsFix);}save(pagesKey,syncProductPages(productsFix,read(pagesKey,[])));const scope=filterRange.value,page=analyticsPage.value,allEvents=await fetchAnalyticsSummary();const events=filterEvents(allEvents,scope,page),pv=events.filter(e=>e.type==='page_visit');siteMetrics.innerHTML=`<div>Visits: ${pv.length}</div><div>Unique sessions: ${new Set(events.map(e=>e.sessionId||e.timestamp)).size}</div>` + (((window.__adminSyncErrors||[]).length)?`<div style='color:#c00'>${window.__adminSyncErrors.join(' | ')}</div>`:'');pageAnalytics.innerHTML=Object.entries(pv.reduce((m,e)=>(m[e.pagePath||e.page]=(m[e.pagePath||e.page]||0)+1,m),{})).map(([p,c])=>`<li>${p}: ${c}</li>`).join('')||'<li>No tracked visits</li>';drawGraph(events,scope);await renderOrders();renderPlacementPills();renderCategoryOptions(newCategory.value);renderProducts();renderPages()}
+window.initPageSelect=initPageSelect;window.renderAll=renderAll;window.renderOrders=renderOrders;window.armInactivity=armInactivity;window.syncDashboardData=syncDashboardData;seedDefaultData();if(filterRange)filterRange.addEventListener('change',guardedRender(renderAll));if(analyticsPage)analyticsPage.addEventListener('change',guardedRender(renderAll));if(refreshOrdersBtn)refreshOrdersBtn.addEventListener('click',renderOrders);
 });
 
 </script>
@@ -290,11 +297,12 @@ document.addEventListener("DOMContentLoaded", function () {
   const dashboard = document.getElementById("dashboard");
   const authError = document.getElementById("authError");
 
-  function showDashboard() {
+  async function showDashboard() {
     auth.style.display = "none";
     dashboard.hidden = false;
     dashboard.style.display = "block";
 
+    if (typeof syncDashboardData === "function") await syncDashboardData();
     if (typeof initPageSelect === "function") initPageSelect();
     if (typeof renderAll === "function") renderAll();
     if (typeof armInactivity === "function") armInactivity();

--- a/stripe-checkout-server.mjs
+++ b/stripe-checkout-server.mjs
@@ -445,6 +445,72 @@ async function handleCreateProduct(req, res) {
     return jsonResponse(res, 500, { error: error.message || 'Unable to create product in Stripe.' }, requestOrigin);
   }
 }
+
+
+async function readJsonFile(fileName, fallback = []) {
+  try {
+    const raw = await fs.readFile(path.join(repoRoot, fileName), 'utf8');
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+async function readDashboardDefaults() {
+  const html = await fs.readFile(path.join(repoRoot, 'dashboard.html'), 'utf8');
+  const productsMatch = html.match(/const DEFAULT_PRODUCTS=\[(.*?)\];\s*const DEFAULT_PAGES=/s);
+  const pagesMatch = html.match(/const DEFAULT_PAGES=\[(.*?)\];\s*function seedDefaultData/s);
+  const evalArray = (body) => Function(`"use strict"; return [${body}];`)();
+  return {
+    products: productsMatch ? evalArray(productsMatch[1]) : [],
+    pages: pagesMatch ? evalArray(pagesMatch[1]) : []
+  };
+}
+
+function slugifyProductPage(name){return String(name||'').toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'')+'.html'}
+
+async function handleAdminProducts(req,res){
+  const requestOrigin=req.headers.origin||'';
+  const defaults=await readDashboardDefaults();
+  const adminProducts=await readJsonFile('admin-products.json',[]);
+  const map=new Map();
+  [...defaults.products,...adminProducts].forEach((p)=>{if(p&&p.id) map.set(p.id,{...map.get(p.id),...p});});
+  const products=[...map.values()].map((p)=>({
+    id:p.id,name:p.name||'',slug:p.slug||slugifyProductPage(p.name||p.id),images:Array.isArray(p.images)?p.images:[],description:p.description||'',price:Number(p.price||0),inventoryQuantity:Number(p.inventoryQuantity||0),category:p.category||'',placement:Array.isArray(p.placement)?p.placement:[],status:p.status||'active',manualSold:Boolean(p.manualSold),soldOut:Boolean(p.manualSold)||Number(p.inventoryQuantity||0)<1,stripe_product_id:p.stripe_product_id||'',stripe_price_id:p.stripe_price_id||'',variants:Array.isArray(p.variants)?p.variants:[]
+  }));
+  return jsonResponse(res,200,{products,source:'repo+registry'},requestOrigin);
+}
+
+async function handleAdminPages(req,res){
+  const requestOrigin=req.headers.origin||'';
+  const htmlFiles=(await fs.readdir(repoRoot)).filter((f)=>f.endsWith('.html'));
+  const defaults=await readDashboardDefaults();
+  const adminPages=await readJsonFile('admin-pages.json',[]);
+  const products=(await handleProductsData());
+  const productSlugs=products.map((p)=>slugifyProductPage(p.name||p.id));
+  const names=new Set([...htmlFiles,...productSlugs,...defaults.pages.map((p)=>p.slug),...adminPages.map((p)=>p.slug)]);
+  const collectionHints=['shop.html','all.html','new.html','jackets.html','shirts.html','tops-sweaters.html','sweatshirts.html','pants.html','t-shirts.html','hats.html','bags.html','accessories.html','shoes.html','gym.html','skate.html','babynot.html'];
+  const infoHints=['about.html','privacy.html','terms.html','faq.html','contact.html','accessibility.html','mailinglist.html','news.html','stores.html'];
+  const pages=[...names].map((slug)=>{
+    let type='Blank Page';
+    if(slug==='vintage.html') type='Redirect Page';
+    else if(productSlugs.includes(slug)) type='Product Page';
+    else if(collectionHints.includes(slug)) type='Collection Page';
+    else if(slug==='index.html'||infoHints.includes(slug)) type='Blank Page';
+    const existing=adminPages.find((p)=>p.slug===slug)||defaults.pages.find((p)=>p.slug===slug)||{};
+    return {slug,label:existing.label||slug,type,visible:existing.visible!==false,redirectUrl:existing.redirectUrl||'',content:existing.content||''};
+  });
+  return jsonResponse(res,200,{pages},requestOrigin);
+}
+
+async function handleProductsData(){
+  const defaults=await readDashboardDefaults();
+  const adminProducts=await readJsonFile('admin-products.json',[]);
+  const map=new Map();
+  [...defaults.products,...adminProducts].forEach((p)=>{if(p&&p.id) map.set(p.id,{...map.get(p.id),...p});});
+  return [...map.values()];
+}
 const analyticsEvents = [];
 
 const repoRoot=process.cwd();
@@ -555,6 +621,33 @@ const server = createServer(async (req, res) => {
 
     if (req.method === 'GET' && pathname === '/api/admin/orders') {
       return await handleAdminOrders(req, res);
+    }
+    if (req.method === 'GET' && pathname === '/api/admin/products') {
+      return await handleAdminProducts(req, res);
+    }
+    if (req.method === 'GET' && pathname === '/api/admin/pages') {
+      return await handleAdminPages(req, res);
+    }
+
+    if (req.method === 'POST' && pathname === '/api/admin/delete-product') {
+      const body=JSON.parse((await readBody(req))||'{}');
+      const arr=await readJsonFile('admin-products.json',[]);
+      const next=arr.filter(p=>p.id!==(body.product?.id||body.id));
+      const fp=path.join(repoRoot,'admin-products.json');
+      await fs.writeFile(fp,JSON.stringify(next,null,2));
+      if(!ensureGitHubConfigured()) return jsonResponse(res,503,{error:'GitHub save is not configured yet. Changes were not published permanently.'},requestOrigin);
+      await gitCommit(path.relative(repoRoot,fp),'admin: delete product');
+      return jsonResponse(res,200,{ok:true},requestOrigin);
+    }
+    if (req.method === 'POST' && pathname === '/api/admin/delete-page') {
+      const body=JSON.parse((await readBody(req))||'{}');
+      const arr=await readJsonFile('admin-pages.json',[]);
+      const next=arr.filter(p=>p.slug!==(body.slug||body.page?.slug));
+      const fp=path.join(repoRoot,'admin-pages.json');
+      await fs.writeFile(fp,JSON.stringify(next,null,2));
+      if(!ensureGitHubConfigured()) return jsonResponse(res,503,{error:'GitHub save is not configured yet. Changes were not published permanently.'},requestOrigin);
+      await gitCommit(path.relative(repoRoot,fp),'admin: delete page');
+      return jsonResponse(res,200,{ok:true},requestOrigin);
     }
 
     if (req.method === 'POST' && pathname === '/api/admin/create-page') {


### PR DESCRIPTION
### Motivation
- Stop relying on empty browser localStorage as the primary source for admin data and make the dashboard authoritative against repo files and Stripe. 
- Ensure Product Manager, Page Manager and Order Manager show real repo pages, the full 25-product registry, and real Stripe orders immediately after login. 

### Description
- Added backend read endpoints `GET /api/admin/products` and `GET /api/admin/pages` that read repo files and merge any admin overrides with the embedded 25-product default registry, returning normalized product fields (name, slug, images, description, price, quantity, category, placements, status, sold-out flag, Stripe Product/Price IDs, variants). 
- Re-used the existing `GET /api/admin/orders` (Stripe-backed) and kept server-side Stripe logic that lists checkout sessions with expanded `line_items` so Order Manager shows real Stripe orders or a clear "not configured" message when Stripe keys are missing. 
- Implemented server-side helpers to read `admin-*.json` and to parse defaults embedded in `dashboard.html`, and added `POST /api/admin/delete-product` and `POST /api/admin/delete-page` to complement existing create/update endpoints so dashboard save/delete flows persist to repo files (server validates admin header and will return clear errors when repo/GitHub save is not configured). 
- Updated frontend load flow in `dashboard.html` to call a new `syncDashboardData()` during `showDashboard()` so after login the dashboard fetches `/api/admin/products` and `/api/admin/pages` (and then `/api/admin/orders` via existing flow), and treats localStorage only as a fallback cache; sync errors are surfaced visibly instead of silently showing empty managers. 

### Testing
- Syntax/validity check of the server module passed with `node --check stripe-checkout-server.mjs`. 
- Verified new server routes and handlers are present in `stripe-checkout-server.mjs` and that `dashboard.html` now calls `syncDashboardData()` before rendering managers. 
- Performed automated file edits and run-time checks to confirm the backend returns merged product lists and scanned page lists for the dashboard to consume.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f624596a288321b86e41958f559bd5)