### PR TITLE
Fix dashboard admin auth wiring for products, pages, and orders sync

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -154,7 +154,8 @@ const syncedPages=syncProductPages(mergedProducts,mergedPages);
 save(pagesKey,syncedPages);
 }
 
-const adminAuth=()=>sessionStorage.getItem('mbnt_admin_auth')||'';
+const ADMIN_AUTH_KEY='mbnt_admin_auth';
+const adminAuth=()=>sessionStorage.getItem(ADMIN_AUTH_KEY)||sessionStorage.getItem(DASH_SESSION_KEY)||'';
 const read=(k,d)=>{try{const raw=localStorage.getItem(k);if(raw===null||raw===undefined||raw==='')return structuredClone(d);const parsed=JSON.parse(raw);return parsed===null||parsed===undefined?structuredClone(d):parsed;}catch(_){return structuredClone(d);}},save=(k,v)=>localStorage.setItem(k,JSON.stringify(v)); let dirty=false;
 function slugifyProductPage(name){return String(name||'').toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'')+'.html'}
 function syncProductPages(products,pages){const nonProduct=(pages||[]).filter(pg=>pg.type!=='Product Page');const productPages=products.map(prod=>{const slug=slugifyProductPage(prod.name||prod.id||'product');const existing=(pages||[]).find(pg=>pg.slug===slug)||{};return {...existing,slug,label:prod.name||slug,type:'Product Page',visible:prod.status!=='inactive',productId:prod.id||null};});return [...nonProduct,...productPages]}
@@ -350,10 +351,12 @@ document.addEventListener("DOMContentLoaded", function () {
 
     if (username === "maybenot" && password === "Sacred6767") {
       sessionStorage.setItem(DASH_SESSION_KEY, "1");
+      sessionStorage.setItem("mbnt_admin_auth", "maybenot:Sacred6767");
       authError.textContent = "";
       showDashboard();
     } else {
       sessionStorage.removeItem(DASH_SESSION_KEY);
+      sessionStorage.removeItem("mbnt_admin_auth");
       authError.textContent = "Invalid credentials.";
       showLogin();
     }
@@ -363,6 +366,7 @@ document.addEventListener("DOMContentLoaded", function () {
   if (logoutBtn) {
     logoutBtn.onclick = function () {
       sessionStorage.removeItem(DASH_SESSION_KEY);
+      sessionStorage.removeItem("mbnt_admin_auth");
       if (window.analyticsTimer) clearInterval(window.analyticsTimer);
       if (window.ordersTimer) clearInterval(window.ordersTimer);
       showLogin();
@@ -370,6 +374,7 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   if (sessionStorage.getItem(DASH_SESSION_KEY) === "1") {
+    if (!sessionStorage.getItem("mbnt_admin_auth")) sessionStorage.setItem("mbnt_admin_auth", "maybenot:Sacred6767");
     showDashboard();
   } else {
     showLogin();


### PR DESCRIPTION
### Motivation
- Dashboard API calls to `/api/admin/*` were failing because the admin auth token (`mbnt_admin_auth`) was not being set or read consistently, causing products, pages and orders to appear empty. 

### Description
- Added an `ADMIN_AUTH_KEY` constant and updated `adminAuth()` to fall back to the dashboard session token when `mbnt_admin_auth` is missing, in `dashboard.html`.
- Persist `mbnt_admin_auth` into `sessionStorage` immediately on successful dashboard login so admin API calls can authenticate right away.
- Clear `mbnt_admin_auth` on failed login attempts and on logout to avoid stale tokens.
- Rehydrate `mbnt_admin_auth` for already-authenticated sessions on load so refreshes don’t leave the dashboard without product/page/order data.

### Testing
- Ran repository checks and validation commands including `rg` searches to locate affected code paths and confirm changes applied; these completed successfully.
- Verified the working tree diff with `git diff` and created a commit with `git commit`, which succeeded.
- Inspected the modified file with `nl`/`sed` to confirm inserted lines and token changes; inspection showed the expected updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65482a1688321843de8539177b4f5)