### PR TITLE
Fix Stripe server-side Checkout, Product creation, and Admin Orders sync

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -189,12 +189,11 @@ if(createProductForm)createProductForm.addEventListener('submit',async e=>{e.pre
 async function fetchOrders(){
   try{
     const res=await fetch('/api/admin/orders',{headers:{'x-admin-auth':adminAuth()}});
-    if(!res.ok)throw new Error('orders');
     const data=await res.json();
-    if(data.configured===false) return {orders:[],message:'Stripe order sync is not configured yet.'};
-    return {orders:Array.isArray(data.orders)?data.orders:[],message:''};
-  }catch(_){
-    return {orders:[],message:'Stripe orders could not load. Check /api/admin/orders and Stripe server config.'};
+    if(!res.ok)return {orders:[],message:data.error||'Stripe orders could not load.'};
+    return {orders:Array.isArray(data.orders)?data.orders:[],message:data.error||''};
+  }catch(err){
+    return {orders:[],message:err.message||'Stripe orders could not load. Check /api/admin/orders and Stripe server config.'};
   }
 }
 async function persistOrderUpdate(path,payload){
@@ -214,8 +213,7 @@ async function autoRefundExpiredOrders(orders){
   }
 }
 function orderDetailsMarkup(order){
-  const c=order.customer||{};const addr=order.address||{};
-  return `<div style='margin-top:8px;font-size:13px'><div><strong>Date:</strong> ${order.createdAt?new Date(order.createdAt).toLocaleString():'N/A'}</div><div><strong>Customer:</strong> ${c.name||''} (${c.email||''})</div><div><strong>Address:</strong> ${[addr.line1,addr.city,addr.state,addr.postal_code,addr.country].filter(Boolean).join(', ')}</div><div><strong>Items:</strong> ${(order.items||[]).map(i=>`${i.name||'Item'} x${i.quantity||1}`).join('; ')||'N/A'}</div><div><strong>Total:</strong> $${((order.total||0)/100).toFixed(2)} ${(order.currency||'usd').toUpperCase()}</div><div><strong>Payment status:</strong> ${order.payment_status||order.status||'unknown'}</div><div><strong>Stripe Session ID:</strong> ${order.stripe_session_id||order.id||'N/A'}</div><div><strong>Stripe Payment ID:</strong> ${order.stripe_payment_intent_id||'N/A'}</div></div>`
+  return `<div style='margin-top:8px;font-size:13px'><div><strong>Date:</strong> ${order.created_iso?new Date(order.created_iso).toLocaleString():'N/A'}</div><div><strong>Customer:</strong> ${order.customer_name||''} (${order.customer_email||''})</div><div><strong>Items:</strong> ${(order.items||[]).map(i=>`${i.description||'Item'} x${i.quantity||1}`).join('; ')||'N/A'}</div><div><strong>Total:</strong> $${((order.amount_total||0)/100).toFixed(2)} ${(order.currency||'usd').toUpperCase()}</div><div><strong>Payment status:</strong> ${order.payment_status||order.status||'unknown'}</div><div><strong>Stripe Session ID:</strong> ${order.id||'N/A'}</div><div><strong>Stripe Payment ID:</strong> ${order.payment_intent||'N/A'}</div></div>`
 }
 async function confirmDelivered(i){
   const orders=read('mbnt_admin_orders',[]);const order=orders[i];
@@ -227,7 +225,7 @@ async function confirmDelivered(i){
   if(!ok)alert('Saved locally as confirmed. Backend email endpoint unavailable right now.');
 }
 window.confirmDelivered=confirmDelivered;
-async function renderOrders(){const orderStatusEl=document.getElementById('orderStatus');try{const orders=await loadOrders();await autoRefundExpiredOrders(orders);save('mbnt_admin_orders',orders);orderManager.innerHTML=orders.length?orders.map((o,i)=>{const status=o.status==='confirmed'?'confirmed':(o.status==='refunded'?'refunded':'unconfirmed');return `<details class='order-card'><summary class='order-summary'><span>#${o.orderNumber||o.id||('ORD-'+(i+1))}</span><span class='order-badge ${status==='confirmed'?'confirmed':'unconfirmed'}'>${status}</span></summary>${orderDetailsMarkup(o)}<div style='margin-top:8px'><button type='button' ${status!=='unconfirmed'?'disabled':''} onclick='confirmDelivered(${i})'>Confirm Delivered</button></div></details>`;}).join(''):`<div class='order-card'>No Stripe orders found yet.</div>`;setStatus(orderStatusEl,`Loaded ${orders.length} orders`,false);}catch(_){orderManager.innerHTML=`<div class='order-card' style='color:#c00;border-color:#c00'>Stripe orders could not load. Check /api/admin/orders and Stripe server config.</div>`;setStatus(orderStatusEl,'Stripe orders could not load. Check /api/admin/orders and Stripe server config.',true);}}
+async function renderOrders(){const orderStatusEl=document.getElementById('orderStatus');try{const orders=await loadOrders();await autoRefundExpiredOrders(orders);save('mbnt_admin_orders',orders);orderManager.innerHTML=orders.length?orders.map((o,i)=>{const status=o.payment_status==='paid'?'confirmed':'unconfirmed';return `<details class='order-card'><summary class='order-summary'><span>#${o.id||('ORD-'+(i+1))}</span><span class='order-badge ${status==='confirmed'?'confirmed':'unconfirmed'}'>${status}</span></summary>${orderDetailsMarkup(o)}</details>`;}).join(''):`<div class='order-card'>No Stripe orders found yet.</div>`;setStatus(orderStatusEl,`Loaded ${orders.length} orders`,false);}catch(err){const message=err.message||'Stripe orders could not load. Check /api/admin/orders and Stripe server config.';orderManager.innerHTML=`<div class='order-card' style='color:#c00;border-color:#c00'>${message}</div>`;setStatus(orderStatusEl,message,true);}}
 function renderPages(pages=[]){const safePages=Array.isArray(pages)&&pages.length?pages:syncProductPages(DEFAULT_PRODUCTS,[...DEFAULT_PAGES]);pageManager.innerHTML=`<p><strong>Loaded ${safePages.length} pages</strong></p>`+safePages.map((c,i)=>`<div class='page-card'><strong>${c.label||c.slug}</strong><div>${c.type} • ${c.visible===false?'hidden':'visible'}</div><div><button onclick='togglePageEdit(${i})'>Edit</button> <button onclick='togglePageVis("${c.slug}")'>👁</button> <button onclick='deletePage("${c.slug}")'>Delete</button></div><div id='page-edit-${i}' class='edit-panel' hidden><div class='row'><input data-page='slug' value='${c.slug}'><select data-page='type'>${PAGE_TYPES.map(t=>`<option ${c.type===t?'selected':''}>${t}</option>`).join('')}</select><input data-page='label' value='${c.label||''}'><label><input data-page='visible' type='checkbox' ${c.visible===false?'':'checked'}> Visible</label><textarea data-page='content'>${c.content||''}</textarea><input data-page='redirectUrl' value='${c.redirectUrl||''}' placeholder='Redirect URL'><input data-page='assignments' value='${(c.assignments||[]).join(', ')}' placeholder='Collection/product assignments'></div><button onclick='savePage("${c.slug}",${i})'>Save</button></div></div>`).join('');}
 window.togglePageEdit=i=>{document.getElementById(`page-edit-${i}`).hidden=!document.getElementById(`page-edit-${i}`).hidden};
 window.togglePageVis=slug=>{const pages=read(pagesKey,[]);const p=pages.find(x=>x.slug===slug);if(p){p.visible=p.visible===false;save(pagesKey,pages);}renderAll()};

--- a/stripe-checkout-server.mjs
+++ b/stripe-checkout-server.mjs
@@ -10,6 +10,7 @@ const execFileAsync=promisify(execFile);
 const port = Number(process.env.PORT || 4242);
 const stripeSecretKey = process.env.STRIPE_SECRET_KEY || '';
 const webhookSigningSecret = process.env.STRIPE_WEBHOOK_SECRET || '';
+const baseUrl = process.env.BASE_URL || 'https://maybenot.com';
 const renderGitCommit = process.env.RENDER_GIT_COMMIT || '';
 const renderGitBranch = process.env.RENDER_GIT_BRANCH || '';
 const renderServiceName = process.env.RENDER_SERVICE_NAME || '';
@@ -165,7 +166,7 @@ async function handleCreateCheckoutSession(req, res) {
   const requestOrigin = req.headers.origin || '';
 
   if (!stripeSecretKey) {
-    return jsonResponse(res, 500, { error: 'Missing STRIPE_SECRET_KEY.' }, requestOrigin);
+    return jsonResponse(res, 500, { error: 'Stripe secret key is not configured.' }, requestOrigin);
   }
 
   const rawBody = await readBody(req);
@@ -176,19 +177,24 @@ async function handleCreateCheckoutSession(req, res) {
     return jsonResponse(res, 400, { error: 'Invalid JSON body.' }, requestOrigin);
   }
 
-  const lineItems = sanitizeLineItems(body);
+  const items = Array.isArray(body?.items) ? body.items : [];
+  const lineItems = items
+    .map((item) => ({
+      price: typeof item?.priceId === 'string' ? item.priceId.trim() : '',
+      quantity: Number.isFinite(Number(item?.quantity)) ? Math.max(1, Number(item.quantity)) : 1
+    }))
+    .filter((item) => item.price.startsWith('price_'));
   if (!lineItems.length) {
     return jsonResponse(
       res,
       400,
-      { error: 'Request must include lineItems or cart with valid Stripe price IDs.' },
+      { error: 'Request must include items with valid Stripe Price IDs.' },
       requestOrigin
     );
   }
 
-  const successUrl = typeof body.successUrl === 'string' && body.successUrl ? body.successUrl : defaultSuccessUrl;
-  const cancelUrl = typeof body.cancelUrl === 'string' && body.cancelUrl ? body.cancelUrl : defaultCancelUrl;
-  const customerEmail = typeof body.customerEmail === 'string' ? body.customerEmail.trim().toLowerCase() : '';
+  const successUrl = `${baseUrl}/success.html?session_id={CHECKOUT_SESSION_ID}`;
+  const cancelUrl = `${baseUrl}/cart.html`;
 
   const payload = {
     line_items: lineItems,
@@ -197,8 +203,7 @@ async function handleCreateCheckoutSession(req, res) {
       ? `${successUrl}&session_id={CHECKOUT_SESSION_ID}`
       : `${successUrl}?session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: cancelUrl,
-    customer_creation: 'always',
-    customer_email: customerEmail
+    customer_creation: 'always'
   };
 
   try {
@@ -221,7 +226,6 @@ async function handleCreateCheckoutSession(req, res) {
       res,
       200,
       {
-        id: stripePayload.id,
         url: stripePayload.url
       },
       requestOrigin
@@ -234,7 +238,7 @@ async function handleCreateCheckoutSession(req, res) {
 async function handleVerifyReturn(req, res, requestUrl) {
   const requestOrigin = req.headers.origin || '';
   if (!stripeSecretKey) {
-    return jsonResponse(res, 500, { error: 'Missing STRIPE_SECRET_KEY.' }, requestOrigin);
+    return jsonResponse(res, 500, { error: 'Stripe secret key is not configured.' }, requestOrigin);
   }
 
   const sessionId = (requestUrl.searchParams.get('session_id') || '').trim();
@@ -383,40 +387,53 @@ async function handleCreatePaymentIntent(req, res) {
 
 async function handleAdminOrders(req, res) {
   const requestOrigin = req.headers.origin || '';
+  if (!isAdmin(req)) {
+    return jsonResponse(res, 401, { error: 'Unauthorized admin request.' }, requestOrigin);
+  }
   if (!stripeSecretKey) {
-    return jsonResponse(res, 200, { configured: false, orders: [], message: 'Stripe order sync is not configured yet.' }, requestOrigin);
+    return jsonResponse(res, 500, { error: 'Stripe secret key is not configured.' }, requestOrigin);
   }
   try {
-    const sessions = await stripeApiRequest('/v1/checkout/sessions?limit=100&expand[]=data.line_items');
-    const orders = (sessions.data || []).map((session) => ({
-      id: session.id,
-      orderNumber: session.client_reference_id || session.id,
-      createdAt: session.created ? new Date(session.created * 1000).toISOString() : null,
-      created: session.created,
-      customer: {
-        name: session.customer_details?.name || '',
-        email: session.customer_details?.email || session.customer_email || ''
-      },
-      total: Number(session.amount_total || 0),
-      currency: session.currency || 'usd',
-      payment_status: session.payment_status || session.status || 'unknown',
-      status: session.payment_status === 'paid' ? 'confirmed' : 'unconfirmed',
-      stripe_session_id: session.id,
-      stripe_payment_intent_id: typeof session.payment_intent === 'string' ? session.payment_intent : (session.payment_intent?.id || ''),
-      items: (session.line_items?.data || []).map((item) => ({
-        name: item.description || item.price?.nickname || 'Item',
-        quantity: item.quantity || 1,
-        amount_total: item.amount_total || 0
-      }))
-    }));
-    return jsonResponse(res, 200, { configured: true, orders }, requestOrigin);
+    const sessions = await stripeApiRequest('/v1/checkout/sessions?limit=100&expand[]=data.line_items&expand[]=data.customer_details&expand[]=data.payment_intent');
+    const orders = [];
+    for (const session of sessions.data || []) {
+      let lineItemsData = session.line_items?.data;
+      if (!Array.isArray(lineItemsData)) {
+        try {
+          const lineItemsResp = await stripeApiRequest(`/v1/checkout/sessions/${encodeURIComponent(session.id)}/line_items?limit=100`);
+          lineItemsData = lineItemsResp.data || [];
+        } catch {
+          lineItemsData = [];
+        }
+      }
+      orders.push({
+        id: session.id,
+        payment_intent: typeof session.payment_intent === 'string' ? session.payment_intent : session.payment_intent?.id,
+        created: session.created,
+        created_iso: new Date(session.created * 1000).toISOString(),
+        customer_name: session.customer_details?.name || '',
+        customer_email: session.customer_details?.email || '',
+        amount_total: session.amount_total,
+        currency: session.currency,
+        payment_status: session.payment_status,
+        status: session.status,
+        items: lineItemsData.map((item) => ({
+          description: item.description,
+          quantity: item.quantity,
+          amount_total: item.amount_total,
+          price_id: item.price?.id,
+          product_id: item.price?.product
+        }))
+      });
+    }
+    return jsonResponse(res, 200, { orders }, requestOrigin);
   } catch (error) {
-    return jsonResponse(res, 200, { configured: false, orders: [], message: 'Stripe order sync is not configured yet.' }, requestOrigin);
+    return jsonResponse(res, 500, { error: error.message || 'Unable to load Stripe orders.' }, requestOrigin);
   }
 }
 async function handleCreateProduct(req, res) {
   const requestOrigin = req.headers.origin || '';
-  if (!stripeSecretKey) return jsonResponse(res, 500, { error: 'Missing STRIPE_SECRET_KEY.' }, requestOrigin);
+  if (!stripeSecretKey) return jsonResponse(res, 500, { error: 'Stripe secret key is not configured.' }, requestOrigin);
   const rawBody = await readBody(req);
   let body;
   try { body = rawBody ? JSON.parse(rawBody) : {}; } catch { return jsonResponse(res, 400, { error: 'Invalid JSON body.' }, requestOrigin); }
@@ -539,7 +556,7 @@ const server = createServer(async (req, res) => {
       return;
     }
 
-    if (req.method === 'POST' && pathname === '/api/stripe/create-checkout-session') {
+    if (req.method === 'POST' && (pathname === '/api/stripe/create-checkout-session' || pathname === '/api/create-checkout-session')) {
       return await handleCreateCheckoutSession(req, res);
     }
 
@@ -590,7 +607,7 @@ const server = createServer(async (req, res) => {
     }
 
 
-    if (pathname.startsWith('/api/admin/') && !isAdmin(req)) {
+    if (pathname.startsWith('/api/admin/') && pathname !== '/api/admin/orders' && !isAdmin(req)) {
       return jsonResponse(res, 401, { error: 'Admin session required.' }, requestOrigin);
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the backend uses the official Stripe server-side flows (Checkout Sessions with Price IDs, server-side Product/Price creation, and real Checkout Session order sync). 
- Provide clear errors when Stripe is not configured and never expose `STRIPE_SECRET_KEY` to the frontend.
- Make the dashboard Order Manager render real Stripe orders and show backend errors visibly.

### Description
- Add `BASE_URL` support and standardize missing-key error to `{ "error": "Stripe secret key is not configured." }` across endpoints. (updated `stripe-checkout-server.mjs`).
- Implement `POST /api/create-checkout-session` (also accept legacy `/api/stripe/create-checkout-session`) that accepts `items[{ priceId, quantity }]`, builds Stripe `line_items` using Price IDs only, creates a Checkout Session server-side, and returns `{ "url": session.url }`. (updated `stripe-checkout-server.mjs`).
- Keep product creation fully server-side in `POST /api/products/create` by creating a Stripe Product and a Stripe Price and returning `{ stripe_product_id, stripe_price_id }`. (updated `stripe-checkout-server.mjs`).
- Rework `GET /api/admin/orders` to call Stripe `/v1/checkout/sessions` with expansions for `line_items`, `customer_details`, and `payment_intent`, fallback to per-session `line_items` list when needed, and map responses to the requested order shape; protect this route with explicit admin auth that returns `{ "error": "Unauthorized admin request." }` when missing. (updated `stripe-checkout-server.mjs`).
- Update `dashboard.html` Order Manager to fetch `/api/admin/orders`, display real order fields (date, customer name/email, items, totals, payment status, Stripe IDs) and surface backend error messages instead of leaving the manager blank. (updated `dashboard.html`).

### Testing
- Ran `node --check stripe-checkout-server.mjs` (syntax check) which succeeded. 
- Launched the server with an empty Stripe key and exercised admin orders endpoints using `curl` to verify behavior: `curl http://localhost:3000/api/admin/orders` returned the expected admin auth error and `curl -H 'x-admin-auth: test' http://localhost:3000/api/admin/orders` returned the standardized Stripe configuration error when the key was missing. 
- All automated/manual checks above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65dab0ac88321a6d74b0858ed0dbf)