### PR TITLE
Connect MBNT Coke Shirt page to new Stripe price ID

### DIFF
--- a/mbnt-coke-shirt.html
+++ b/mbnt-coke-shirt.html
@@ -218,16 +218,16 @@
     
 </div>
 </header>
-<div class="product-item" data-product="mbnt-coke-shirt" data-price="33" data-price-id="mbnt-coke-shirt" data-selected-color="white" data-size="" data-style="single">
+<div class="product-item" data-product="mbnt-coke-shirt" data-price="33" data-price-id="price_1TVKt86vAbsTB4QVLa6jodsN" data-selected-color="white" data-size="" data-style="single">
     <div class="image-slider" data-images="mbntcoke.png">
         <button class="prev">&#10094;</button>
         <img id="product-image" src="mbntcoke.png" alt="MBNT Coke Shirt">
         <button class="next">&#10095;</button>
     </div>
     <h1>MBNT Coke Shirt</h1>
-    <p class="dynamic-price">$33</p>
+    <p class="dynamic-price">$33.00</p>
     <div class="color-options">
-        <span class="color-option" data-color="white" data-style="single" data-price="33" data-price-id="mbnt-coke-shirt" data-image="mbntcoke.png" data-images="mbntcoke.png" style="background:#fff;border:1px solid #000;" title="White"></span></div>
+        <span class="color-option" data-color="white" data-style="single" data-price="33" data-price-id="price_1TVKt86vAbsTB4QVLa6jodsN" data-image="mbntcoke.png" data-images="mbntcoke.png" style="background:#fff;border:1px solid #000;" title="White"></span></div>
     <div class="size-select">
         <select>
             <option value="">Select Size</option>


### PR DESCRIPTION
### Motivation
- Wire the MBNT Coke Shirt product page to the new Stripe Price so checkout and add-to-cart submit the correct Stripe price ID while keeping the product display and design unchanged.
- Ensure the product name and visible price match the Stripe product metadata exactly.

### Description
- Updated `mbnt-coke-shirt.html` to replace the product-level `data-price-id` with `price_1TVKt86vAbsTB4QVLa6jodsN`.
- Updated the color-option `data-price-id` on the same page to `price_1TVKt86vAbsTB4QVLa6jodsN` so variant selection uses the same Stripe price.
- Normalized the displayed product price from `$33` to `$33.00` and left the product title as `MBNT Coke Shirt`.
- No changes were made to layout, images, styling, tags, or navigation.

### Testing
- Verified the updated HTML contains `data-price-id="price_1TVKt86vAbsTB4QVLa6jodsN"`, `<h1>MBNT Coke Shirt</h1>`, and `<p class="dynamic-price">$33.00</p>` using `rg` and `sed`, and those checks passed.
- Applied the replacements with a small `python` script and confirmed the modified lines with `nl`/`sed`, which showed the new `data-price-id` and updated price.
- Inspected the `buildStripeLineItems` logic in `cart.js` to confirm the checkout flow prioritizes an `item.stripePriceId` that starts with `price_`, so the page now sends the correct Stripe price into checkout; inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffcc81d57c832198f74c383591e35e)