### PR TITLE
Update vintage navigation links to new Whatnot profile URL

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -415,7 +415,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -437,7 +437,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/all-page2.html
+++ b/all-page2.html
@@ -445,7 +445,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -467,7 +467,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/all.html
+++ b/all.html
@@ -636,7 +636,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -658,7 +658,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/americandenim.html
+++ b/americandenim.html
@@ -257,7 +257,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -279,7 +279,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/babynot-hoodie-set.html
+++ b/babynot-hoodie-set.html
@@ -252,7 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -274,7 +274,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/babynot-onesie.html
+++ b/babynot-onesie.html
@@ -247,7 +247,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -269,7 +269,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/babynot-toddler-tee.html
+++ b/babynot-toddler-tee.html
@@ -246,7 +246,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -268,7 +268,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/babynot.html
+++ b/babynot.html
@@ -445,7 +445,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -467,7 +467,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/backpack.html
+++ b/backpack.html
@@ -226,7 +226,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -248,7 +248,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/bags.html
+++ b/bags.html
@@ -425,7 +425,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -447,7 +447,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/blankhoodie.html
+++ b/blankhoodie.html
@@ -153,7 +153,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -175,7 +175,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/blankshirt.html
+++ b/blankshirt.html
@@ -260,7 +260,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -282,7 +282,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/camohat.html
+++ b/camohat.html
@@ -227,7 +227,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -249,7 +249,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/category_template.html
+++ b/category_template.html
@@ -406,7 +406,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -428,7 +428,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/dufflebag.html
+++ b/dufflebag.html
@@ -211,7 +211,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -233,7 +233,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/gym.html
+++ b/gym.html
@@ -406,7 +406,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -428,7 +428,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/hat.html
+++ b/hat.html
@@ -226,7 +226,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -248,7 +248,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/hats.html
+++ b/hats.html
@@ -445,7 +445,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -467,7 +467,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/hoodie.html
+++ b/hoodie.html
@@ -153,7 +153,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -175,7 +175,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/jackets.html
+++ b/jackets.html
@@ -406,7 +406,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -428,7 +428,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/joggers.html
+++ b/joggers.html
@@ -160,7 +160,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -182,7 +182,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-cancer-shirt.html
+++ b/mbnt-cancer-shirt.html
@@ -252,7 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -274,7 +274,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-coke-shirt.html
+++ b/mbnt-coke-shirt.html
@@ -252,7 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -274,7 +274,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-mickey-deez-shirt.html
+++ b/mbnt-mickey-deez-shirt.html
@@ -252,7 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -274,7 +274,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-moon-landing-shirt.html
+++ b/mbnt-moon-landing-shirt.html
@@ -252,7 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -274,7 +274,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-patagucci-shirt.html
+++ b/mbnt-patagucci-shirt.html
@@ -252,7 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -274,7 +274,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-pro-shops-shirt.html
+++ b/mbnt-pro-shops-shirt.html
@@ -252,7 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -274,7 +274,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-superior-shirt.html
+++ b/mbnt-superior-shirt.html
@@ -254,7 +254,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -276,7 +276,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/new-page2.html
+++ b/new-page2.html
@@ -445,7 +445,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-            <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+            <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -467,7 +467,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/new.html
+++ b/new.html
@@ -635,7 +635,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -657,7 +657,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/pants.html
+++ b/pants.html
@@ -435,7 +435,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -457,7 +457,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/shirt.html
+++ b/shirt.html
@@ -255,7 +255,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -277,7 +277,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/shirts.html
+++ b/shirts.html
@@ -485,7 +485,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -507,7 +507,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/shoes.html
+++ b/shoes.html
@@ -406,7 +406,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -428,7 +428,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/shop.html
+++ b/shop.html
@@ -476,7 +476,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -498,7 +498,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/shorts.html
+++ b/shorts.html
@@ -159,7 +159,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -181,7 +181,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/skate.html
+++ b/skate.html
@@ -435,7 +435,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -457,7 +457,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/skateboard1.html
+++ b/skateboard1.html
@@ -213,7 +213,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -235,7 +235,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/skateboard2.html
+++ b/skateboard2.html
@@ -213,7 +213,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -235,7 +235,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/skateboard3.html
+++ b/skateboard3.html
@@ -213,7 +213,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -235,7 +235,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/socks.html
+++ b/socks.html
@@ -213,7 +213,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -235,7 +235,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -425,7 +425,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -447,7 +447,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -495,7 +495,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -517,7 +517,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -406,7 +406,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -428,7 +428,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/truckerhat.html
+++ b/truckerhat.html
@@ -226,7 +226,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>
@@ -248,7 +248,7 @@
 <nav class="mobile-nav">
     <ul>
         
-        <li><a href="babynot.html">babynot</a></li><li><a href="https://whatnot.com/user/maybenot" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="babynot.html">babynot</a></li><li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>


### PR DESCRIPTION
### Motivation
- Replace an outdated Whatnot profile link so the site’s "vintage" nav item points to the correct profile URL across the site.
- Ensure both desktop and mobile navigation rows use the updated link to avoid broken or incorrect external links.

### Description
- Replaced `https://whatnot.com/user/maybenot` with `https://www.whatnot.com/s/lod4xCg5` across site HTML pages where the vintage nav item appears. 
- Changes touch 45 HTML files with two nav occurrences per file (desktop and mobile), totaling 90 link replacements. 
- The updates were performed via a small automated replacement script to reliably find-and-replace the URL. 
- No other markup, styling, or JavaScript behavior was modified.

### Testing
- Ran the replacement script (inline Python) which reported `replacements 90` and `files 45`. 
- Verified the new URL is present and the old URL is no longer referenced using `rg -n "https://whatnot.com/user/maybenot|https://www.whatnot.com/s/lod4xCg5" *.html`. 
- Spot-checked rendered nav snippets in `shop.html` and `all.html` to confirm both desktop and mobile nav entries now point to the new URL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04fd8a11008321aa158637d55d418a)