### PR TITLE
Update desktop vintage link to new Whatnot profile URL

### DIFF
--- a/accessories.html
+++ b/accessories.html
@@ -415,7 +415,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/all-page2.html
+++ b/all-page2.html
@@ -445,7 +445,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/all.html
+++ b/all.html
@@ -636,7 +636,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/americandenim.html
+++ b/americandenim.html
@@ -257,7 +257,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/babynot-hoodie-set.html
+++ b/babynot-hoodie-set.html
@@ -252,7 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/babynot-onesie.html
+++ b/babynot-onesie.html
@@ -247,7 +247,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/babynot-toddler-tee.html
+++ b/babynot-toddler-tee.html
@@ -246,7 +246,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/babynot.html
+++ b/babynot.html
@@ -445,7 +445,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/backpack.html
+++ b/backpack.html
@@ -226,7 +226,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/bags.html
+++ b/bags.html
@@ -425,7 +425,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/blankhoodie.html
+++ b/blankhoodie.html
@@ -153,7 +153,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/blankshirt.html
+++ b/blankshirt.html
@@ -260,7 +260,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/camohat.html
+++ b/camohat.html
@@ -227,7 +227,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/category_template.html
+++ b/category_template.html
@@ -406,7 +406,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/dufflebag.html
+++ b/dufflebag.html
@@ -211,7 +211,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/gym.html
+++ b/gym.html
@@ -406,7 +406,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/hat.html
+++ b/hat.html
@@ -226,7 +226,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/hats.html
+++ b/hats.html
@@ -445,7 +445,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/hoodie.html
+++ b/hoodie.html
@@ -153,7 +153,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/jackets.html
+++ b/jackets.html
@@ -406,7 +406,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/joggers.html
+++ b/joggers.html
@@ -160,7 +160,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-cancer-shirt.html
+++ b/mbnt-cancer-shirt.html
@@ -252,7 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-coke-shirt.html
+++ b/mbnt-coke-shirt.html
@@ -252,7 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-mickey-deez-shirt.html
+++ b/mbnt-mickey-deez-shirt.html
@@ -252,7 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-moon-landing-shirt.html
+++ b/mbnt-moon-landing-shirt.html
@@ -252,7 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-patagucci-shirt.html
+++ b/mbnt-patagucci-shirt.html
@@ -252,7 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-pro-shops-shirt.html
+++ b/mbnt-pro-shops-shirt.html
@@ -252,7 +252,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/mbnt-superior-shirt.html
+++ b/mbnt-superior-shirt.html
@@ -254,7 +254,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/new-page2.html
+++ b/new-page2.html
@@ -445,7 +445,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-            <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+            <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/new.html
+++ b/new.html
@@ -635,7 +635,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/pants.html
+++ b/pants.html
@@ -435,7 +435,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/shirt.html
+++ b/shirt.html
@@ -255,7 +255,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/shirts.html
+++ b/shirts.html
@@ -485,7 +485,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/shoes.html
+++ b/shoes.html
@@ -406,7 +406,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/shop.html
+++ b/shop.html
@@ -476,7 +476,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/shorts.html
+++ b/shorts.html
@@ -159,7 +159,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/skate.html
+++ b/skate.html
@@ -435,7 +435,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/skateboard1.html
+++ b/skateboard1.html
@@ -213,7 +213,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/skateboard2.html
+++ b/skateboard2.html
@@ -213,7 +213,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/skateboard3.html
+++ b/skateboard3.html
@@ -213,7 +213,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/socks.html
+++ b/socks.html
@@ -213,7 +213,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -425,7 +425,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -495,7 +495,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -406,7 +406,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>

--- a/truckerhat.html
+++ b/truckerhat.html
@@ -226,7 +226,7 @@
 <nav class="desktop-nav">
     <ul>
         <li><a href="babynot.html">babynot</a></li>
-        <li><a href="https://www.whatnot.com/s/lod4xCg5" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
+        <li><a href="https://www.whatnot.com/s/n5GvUugn" target="_blank" rel="noopener noreferrer" class="vintage-link">vintage</a></li>
         <li><a href="new.html">new</a></li>
         <li><a href="jackets.html">jackets</a></li>
         <li><a href="shirts.html">shirts</a></li>


### PR DESCRIPTION
### Motivation
- The desktop navigation `vintage` link needed to point to a new Whatnot profile URL (`https://www.whatnot.com/s/n5GvUugn`) while mobile nav links should remain unchanged.
- Keep the site templates and per-page desktop nav consistent so users on desktop hit the correct external profile.

### Description
- Replaced the old URL `https://www.whatnot.com/s/lod4xCg5` with `https://www.whatnot.com/s/n5GvUugn` in the desktop nav block across site `*.html` pages (45 files affected). 
- The change was applied programmatically with a small replacement script to update the first (desktop) `vintage` link occurrence in each page. 
- Left the mobile nav `vintage` links unchanged (they remain pointing at the previous URL). 
- Updated the shared `category_template.html` so newly generated collection pages will contain the new desktop link.

### Testing
- Ran a search to verify occurrences with `rg -n "whatnot.com/s/(lod4xCg5|n5GvUugn)" *.html` and confirmed the new URL appears in the desktop link locations. 
- Inspected representative pages with `nl -ba shop.html | sed -n '472,506p'` and `nl -ba category_template.html | sed -n '404,436p'` to confirm the desktop nav uses the new URL and the mobile nav still uses the old URL. 
- Verified the set of modified files with `git status --short`, which showed the expected HTML files were updated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06462a733083218a4bc365a795003d)