### PR TITLE
Update site logo iframe embed to p3d.in across pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -61,7 +61,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="logo-frame" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/accessibility.html
+++ b/accessibility.html
@@ -62,7 +62,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="logo-frame" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/accessories.html
+++ b/accessories.html
@@ -384,7 +384,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/all-page2.html
+++ b/all-page2.html
@@ -384,7 +384,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/all.html
+++ b/all.html
@@ -394,7 +394,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/americandenim.html
+++ b/americandenim.html
@@ -211,7 +211,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/babynot-hoodie-set.html
+++ b/babynot-hoodie-set.html
@@ -212,7 +212,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/babynot-onesie.html
+++ b/babynot-onesie.html
@@ -208,7 +208,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/babynot-toddler-tee.html
+++ b/babynot-toddler-tee.html
@@ -208,7 +208,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/babynot.html
+++ b/babynot.html
@@ -394,7 +394,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/backpack.html
+++ b/backpack.html
@@ -185,7 +185,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/bags.html
+++ b/bags.html
@@ -384,7 +384,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/blankhoodie.html
+++ b/blankhoodie.html
@@ -106,7 +106,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/blankshirt.html
+++ b/blankshirt.html
@@ -208,7 +208,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/camohat.html
+++ b/camohat.html
@@ -185,7 +185,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/cart.html
+++ b/cart.html
@@ -563,7 +563,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/cart.js
+++ b/cart.js
@@ -1188,7 +1188,7 @@ function createCartModal() {
         <div class="cart-content">
             <button id="cart-close" class="close-btn">&times;</button>
             <div class="logo-container">
-                <iframe id="cart-logo" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+                <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
             </div>
             <div class="cart-time" id="cart-current-time"></div>
             <h2>Cart</h2>

--- a/category_template.html
+++ b/category_template.html
@@ -384,7 +384,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/checkout.html
+++ b/checkout.html
@@ -562,7 +562,7 @@
 <body>
     <header class="header-container">
         <div class="logo-container">
-            <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+            <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
             <div class="logo-overlay"></div>
         </div>
         <div class="time" id="current-time"></div>

--- a/contact.html
+++ b/contact.html
@@ -66,7 +66,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="logo-frame" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/dashboard.html
+++ b/dashboard.html
@@ -75,7 +75,7 @@ footer .footer-links{display:flex;justify-content:center;padding-bottom:10px}
 .footer-line{justify-content:center;flex-wrap:wrap;width:min(90%,820px);font-size:.65rem;letter-spacing:.02rem}
 .footer-links{padding-bottom:10px}
 
-</style></head><body><header id="dashboard-site-header" class="header-container"><div class="logo-container"><iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe><div class="logo-overlay"></div></div><div id="chicago-time" class="chicago-time"></div></header><div class="dashboard-shell"><div class="site-shell">
+</style></head><body><header id="dashboard-site-header" class="header-container"><div class="logo-container"><iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe><div class="logo-overlay"></div></div><div id="chicago-time" class="chicago-time"></div></header><div class="dashboard-shell"><div class="site-shell">
 <div id="auth">
   <form id="loginForm">
     <input id="username" type="text" placeholder="Username" required />

--- a/dufflebag.html
+++ b/dufflebag.html
@@ -174,7 +174,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/faq.html
+++ b/faq.html
@@ -63,7 +63,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="logo-frame" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/gym.html
+++ b/gym.html
@@ -384,7 +384,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/hat.html
+++ b/hat.html
@@ -185,7 +185,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/hats.html
+++ b/hats.html
@@ -394,7 +394,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/hoodie.html
+++ b/hoodie.html
@@ -106,7 +106,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/index.html
+++ b/index.html
@@ -381,7 +381,7 @@
 <div class="container">
     <div class="logo-time-container">
         <div class="logo-container">
-            <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+            <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
             <div class="logo-overlay"></div>
         </div>
         <div class="time" id="current-time"></div>

--- a/jackets.html
+++ b/jackets.html
@@ -384,7 +384,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/joggers.html
+++ b/joggers.html
@@ -113,7 +113,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/mailinglist.html
+++ b/mailinglist.html
@@ -72,7 +72,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="logo-frame" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/mbnt-cancer-shirt.html
+++ b/mbnt-cancer-shirt.html
@@ -208,7 +208,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/mbnt-coke-shirt.html
+++ b/mbnt-coke-shirt.html
@@ -208,7 +208,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/mbnt-mickey-deez-shirt.html
+++ b/mbnt-mickey-deez-shirt.html
@@ -208,7 +208,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/mbnt-moon-landing-shirt.html
+++ b/mbnt-moon-landing-shirt.html
@@ -208,7 +208,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/mbnt-patagucci-shirt.html
+++ b/mbnt-patagucci-shirt.html
@@ -208,7 +208,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/mbnt-pro-shops-shirt.html
+++ b/mbnt-pro-shops-shirt.html
@@ -208,7 +208,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/mbnt-superior-shirt.html
+++ b/mbnt-superior-shirt.html
@@ -208,7 +208,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/new-page2.html
+++ b/new-page2.html
@@ -384,7 +384,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/new.html
+++ b/new.html
@@ -394,7 +394,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/news.html
+++ b/news.html
@@ -64,7 +64,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="logo-frame" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/pants.html
+++ b/pants.html
@@ -384,7 +384,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/privacy.html
+++ b/privacy.html
@@ -66,7 +66,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="logo-frame" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/random.html
+++ b/random.html
@@ -62,7 +62,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="logo-frame" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/shirt.html
+++ b/shirt.html
@@ -208,7 +208,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/shirts.html
+++ b/shirts.html
@@ -384,7 +384,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/shoes.html
+++ b/shoes.html
@@ -384,7 +384,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/shop.html
+++ b/shop.html
@@ -461,7 +461,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/shorts.html
+++ b/shorts.html
@@ -113,7 +113,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/skate.html
+++ b/skate.html
@@ -384,7 +384,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/skateboard1.html
+++ b/skateboard1.html
@@ -174,7 +174,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/skateboard2.html
+++ b/skateboard2.html
@@ -174,7 +174,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/skateboard3.html
+++ b/skateboard3.html
@@ -174,7 +174,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/socks.html
+++ b/socks.html
@@ -174,7 +174,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/soon.html
+++ b/soon.html
@@ -345,7 +345,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/stores.html
+++ b/stores.html
@@ -62,7 +62,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="logo-frame" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/success.html
+++ b/success.html
@@ -100,12 +100,7 @@
 <body>
     <header class="header-container">
         <div class="logo-container">
-            <iframe
-                id="logo-frame"
-                src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1"
-                frameborder="0"
-                aria-label="Maybe Not logo"
-            ></iframe>
+            <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
             <div class="logo-overlay" aria-hidden="true"></div>
         </div>
         <div class="header-line"></div>

--- a/sweatshirts.html
+++ b/sweatshirts.html
@@ -384,7 +384,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/t-shirts.html
+++ b/t-shirts.html
@@ -384,7 +384,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/terms.html
+++ b/terms.html
@@ -62,7 +62,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="logo-frame" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/tops-sweaters.html
+++ b/tops-sweaters.html
@@ -384,7 +384,7 @@
 
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>

--- a/truckerhat.html
+++ b/truckerhat.html
@@ -185,7 +185,7 @@
 <body>
 <header class="header-container">
     <div class="logo-container">
-        <iframe id="8b9281ad-097b-4408-88e2-ef824efa63eb" src="https://www.vectary.com/viewer/v1/?model=8b9281ad-097b-4408-88e2-ef824efa63eb&env=studio3&turntable=1" frameborder="0"></iframe>
+        <iframe allowfullscreen width="640" height="480" loading="lazy" frameborder="0" src="https://p3d.in/e/307lu+clean+spin+load"></iframe>
         <div class="logo-overlay"></div>
     </div>
     <div class="time" id="current-time"></div>


### PR DESCRIPTION
### Motivation
- Replace the existing Vectary logo iframe with the new p3d.in embed for a consistent logo experience across desktop and mobile headers and modals. 
- Ensure the logo iframe includes `allowfullscreen`, explicit `width="640"`/`height="480"`, `loading="lazy"`, and `frameborder="0"` attributes as requested.

### Description
- Replaced the previous Vectary iframe markup (`https://www.vectary.com/viewer/v1/...`) with the provided p3d.in embed (`https://p3d.in/e/307lu+clean+spin+load`) and the requested attributes in all header logo locations and templates. 
- Applied the change to 62 files spanning site pages and the cart modal/template, including the dynamic modal HTML generated in `cart.js`. 
- Preserved the surrounding `.logo-container` and `.logo-overlay` markup and existing header layout/JS behavior. 

### Testing
- Ran a Python scan to confirm there are zero occurrences of the old Vectary URL and `62` occurrences of the new `p3d.in` embed, and the scan passed. 
- Verified with `rg`/search that the new iframe string is present in the updated files and the old viewer URL is absent. 
- Ran `git diff --check` to ensure no whitespace or diff errors were introduced and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a604483bb248321b188696c93652f2b)